### PR TITLE
fix: rework bottom sheet detent heights and anchor logic

### DIFF
--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/LogBottomSheet.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/LogBottomSheet.kt
@@ -55,6 +55,7 @@ fun LogBottomSheet(
     sheetState: BottomSheetState,
     viewModel: MainViewModel,
     screenHeight: Dp,
+    navBarHeight: Dp,
     isWindowExpanded: Boolean,
     bottomPadding: Dp,
     onSendPrompt: (String) -> Unit,
@@ -177,7 +178,7 @@ fun LogBottomSheet(
         // Bottom Sheet
         BottomSheetLayout(
             state = sheetState,
-            peekHeight = PeekHeight.dp((screenHeight * 0.25f).value),
+            peekHeight = PeekHeight.dp((screenHeight * 0.25f + navBarHeight).value),
             modifier = Modifier
                 .fillMaxSize()
                 .padding(bottom = bottomPadding),

--- a/docs/UI_UX.md
+++ b/docs/UI_UX.md
@@ -9,10 +9,10 @@ LogKitty is a developer tool designed to be unobtrusive yet instantly accessible
 - **Accents:** Minimal use of color; system colors used for specific log levels (Error=Red, Warn=Yellow) if implemented.
 
 ## Components
-- **Bottom Sheet:** The primary interaction point. It supports three states:
-    - **Peek:** Small strip at the bottom, showing the last log line or status.
-    - **Half-Expanded:** Covers 50% of the screen, allows scrolling.
-    - **Fully-Expanded:** Covers 80% of the screen for deep debugging.
+- **Bottom Sheet:** The primary interaction point. It supports three states (heights include the system navigation bar area):
+    - **Peek:** Small strip at the bottom, showing the last log line or status (25% of screen height + Nav Bar).
+    - **Half-Expanded:** Covers 50% of the screen + Nav Bar, allows scrolling.
+    - **Fully-Expanded:** Covers 80% of the screen + Nav Bar for deep debugging.
 - **Overlay:** A transparent touch-through layer that allows interaction with the app below when the sheet is collapsed.
 
 ## Interaction


### PR DESCRIPTION
- Anchor the bottom sheet to the absolute bottom of the screen (y=0).
- Update detent calculations to include the system navigation bar height.
- Ensure the overlay sits behind the navigation bar visually.
- Clean up duplicate code in `LogKittyOverlayService`.
- Update documentation to reflect new UI states.

## Summary by Sourcery

Adjust bottom sheet positioning and sizing to account for system navigation bars and anchor it to the absolute bottom of the screen.

Bug Fixes:
- Anchor the overlay bottom sheet to the screen bottom instead of an offset from the bottom.
- Include system navigation bar height in bottom sheet expansion and detent height calculations to prevent visual overlap issues.

Enhancements:
- Pass navigation bar height into the bottom sheet component for consistent height handling.
- Simplify and deduplicate overlay service height and anchor logic.

Documentation:
- Update UI/UX documentation to describe bottom sheet states as including the system navigation bar area.