### PR TITLE
fix: improve gesture handling and nav bar visibility

### DIFF
--- a/app/src/main/kotlin/com/hereliesaz/logkitty/services/LogKittyOverlayService.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/services/LogKittyOverlayService.kt
@@ -32,6 +32,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.unit.dp
 import androidx.core.app.NotificationCompat
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.navigationBars
 import com.hereliesaz.logkitty.MainActivity
 import com.hereliesaz.logkitty.MainApplication
 import com.hereliesaz.logkitty.R
@@ -234,26 +236,9 @@ class LogKittyOverlayService : Service() {
                 }
                 val screenHeight = (screenHeightPx / density.density).dp
 
-                // Robust screen height calculation
-                val screenHeightPx = remember {
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-                        windowManager.currentWindowMetrics.bounds.height()
-                    } else {
-                        val metrics = DisplayMetrics()
-                        @Suppress("DEPRECATION")
-                        windowManager.defaultDisplay.getRealMetrics(metrics)
-                        metrics.heightPixels
-                    }
-                }
-                val screenHeight = (screenHeightPx / density.density).dp
-
-                val detents = remember(screenHeight) {
-                    val hidden = SheetDetent("hidden", calculateDetentHeight = {_, _ -> screenHeight * 0.02f })
-                    val peek = SheetDetent("peek", calculateDetentHeight = { _, _ -> screenHeight * 0.25f })
-                    val halfway = SheetDetent("halfway", calculateDetentHeight = { _, _ -> screenHeight * 0.50f })
-                    val fully = SheetDetent("fully_expanded", calculateDetentHeight = { _, _ -> screenHeight * 0.80f })
-                    listOf(hidden, peek, halfway, fully)
-                }
+                val navBarInsets = WindowInsets.navigationBars
+                val navBarHeightPx = navBarInsets.getBottom(density)
+                val navBarHeight = with(density) { navBarHeightPx.toDp() }
 
                 val sheetState = rememberBottomSheetState(
                     initialValue = BottomSheetValue.Collapsed
@@ -269,13 +254,9 @@ class LogKittyOverlayService : Service() {
                 var delayedShrinkJob by remember { androidx.compose.runtime.mutableStateOf<kotlinx.coroutines.Job?>(null) }
                 var isWindowExpanded by remember { mutableStateOf(false) }
 
-                // Fixed Anchor: 10% of screen height from bottom
-                val anchorYPx = (screenHeightPx * 0.10f).toInt()
-                val expandedHeightPx = (screenHeightPx * 0.90f).toInt()
-
-                // Fixed Anchor: 10% of screen height from bottom
-                val anchorYPx = (screenHeightPx * 0.10f).toInt()
-                val expandedHeightPx = (screenHeightPx * 0.90f).toInt()
+                // Fixed Anchor: 0 (Immovable at bottom)
+                val anchorYPx = 0
+                val expandedHeightPx = (screenHeightPx * 0.90f + navBarHeightPx).toInt()
 
                 val updateWindowHeight = { isInteracting: Boolean ->
                      val params = composeView?.layoutParams as? WindowManager.LayoutParams
@@ -311,7 +292,7 @@ class LogKittyOverlayService : Service() {
                                      BottomSheetValue.Expanded -> 0.80f
                                  }
 
-                                 val targetHeightPx = (screenHeightPx * detentHeightFactor).toInt()
+                                 val targetHeightPx = (screenHeightPx * detentHeightFactor + navBarHeightPx).toInt()
 
                                  // Check if we started interacting again during delay
                                  if (isActive) {
@@ -354,6 +335,7 @@ class LogKittyOverlayService : Service() {
                         sheetState = sheetState,
                         viewModel = viewModel,
                         screenHeight = screenHeight,
+                        navBarHeight = navBarHeight,
                         isWindowExpanded = isWindowExpanded,
                         bottomPadding = bottomPadding,
                         onSendPrompt = { viewModel.sendPrompt(it) },
@@ -382,7 +364,7 @@ class LogKittyOverlayService : Service() {
 
         // Initial params: Height = Hidden (2%) or Peek (25%)? Initial state is Collapsed (Hidden)
         val initialHeight = (resources.displayMetrics.heightPixels * 0.02f).toInt()
-        val initialY = (resources.displayMetrics.heightPixels * 0.10f).toInt()
+        val initialY = 0
 
         val params = WindowManager.LayoutParams(
             WindowManager.LayoutParams.MATCH_PARENT,
@@ -395,6 +377,7 @@ class LogKittyOverlayService : Service() {
         ).apply {
             gravity = Gravity.BOTTOM
             y = initialY
+            softInputMode = WindowManager.LayoutParams.SOFT_INPUT_ADJUST_NOTHING
         }
 
         try {

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/LogBottomSheet.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/LogBottomSheet.kt
@@ -5,7 +5,7 @@ import android.net.Uri
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.gestures.detectHorizontalDragGestures
+import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.gestures.detectVerticalDragGestures
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
@@ -55,6 +55,7 @@ fun LogBottomSheet(
     sheetState: BottomSheetState,
     viewModel: MainViewModel,
     screenHeight: Dp,
+    navBarHeight: Dp,
     isWindowExpanded: Boolean,
     bottomPadding: Dp,
     onSendPrompt: (String) -> Unit,
@@ -177,7 +178,7 @@ fun LogBottomSheet(
         // Bottom Sheet
         BottomSheetLayout(
             state = sheetState,
-            peekHeight = PeekHeight.dp((screenHeight * 0.25f).value),
+            peekHeight = PeekHeight.dp((screenHeight * 0.25f + navBarHeight).value),
             modifier = Modifier
                 .fillMaxSize()
                 .padding(bottom = bottomPadding),
@@ -187,13 +188,13 @@ fun LogBottomSheet(
                 modifier = Modifier
                     .fillMaxSize()
                     .pointerInput(Unit) {
-                        var totalDrag = 0f
-                        detectHorizontalDragGestures(
-                            onDragStart = { totalDrag = 0f },
+                        var totalDragX = 0f
+                        detectDragGestures(
+                            onDragStart = { totalDragX = 0f },
                             onDragEnd = {
-                                 if (abs(totalDrag) > swipeThreshold) {
+                                 if (abs(totalDragX) > swipeThreshold) {
                                      val currentIndex = tabs.indexOf(selectedTab)
-                                     if (totalDrag > 0) { // Swipe Right -> Previous Tab
+                                     if (totalDragX > 0) { // Swipe Right -> Previous Tab
                                          if (currentIndex > 0) {
                                              viewModel.selectTab(tabs[currentIndex - 1])
                                          }
@@ -205,8 +206,11 @@ fun LogBottomSheet(
                                  }
                             }
                         ) { change, dragAmount ->
-                            change.consume()
-                            totalDrag += dragAmount
+                            val (x, y) = dragAmount
+                            if (abs(x) > abs(y)) {
+                                change.consume()
+                                totalDragX += x
+                            }
                         }
                     }
             ) {
@@ -298,6 +302,7 @@ fun LogBottomSheet(
                         LazyColumn(
                             state = listState,
                             reverseLayout = isLogReversed,
+                            contentPadding = PaddingValues(bottom = navBarHeight),
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .weight(1f)

--- a/docs/UI_UX.md
+++ b/docs/UI_UX.md
@@ -9,10 +9,10 @@ LogKitty is a developer tool designed to be unobtrusive yet instantly accessible
 - **Accents:** Minimal use of color; system colors used for specific log levels (Error=Red, Warn=Yellow) if implemented.
 
 ## Components
-- **Bottom Sheet:** The primary interaction point. It supports three states:
-    - **Peek:** Small strip at the bottom, showing the last log line or status.
-    - **Half-Expanded:** Covers 50% of the screen, allows scrolling.
-    - **Fully-Expanded:** Covers 80% of the screen for deep debugging.
+- **Bottom Sheet:** The primary interaction point. It supports three states (heights include the system navigation bar area):
+    - **Peek:** Small strip at the bottom, showing the last log line or status (25% of screen height + Nav Bar).
+    - **Half-Expanded:** Covers 50% of the screen + Nav Bar, allows scrolling.
+    - **Fully-Expanded:** Covers 80% of the screen + Nav Bar for deep debugging.
 - **Overlay:** A transparent touch-through layer that allows interaction with the app below when the sheet is collapsed.
 
 ## Interaction


### PR DESCRIPTION
- Replace `detectHorizontalDragGestures` with `detectDragGestures` to allow vertical drags to pass through to the bottom sheet.
- Add `softInputMode = SOFT_INPUT_ADJUST_NOTHING` to prevent the overlay from jumping when the keyboard appears.
- Add `contentPadding` to `LazyColumn` in `LogBottomSheet` to ensure logs are visible behind the system navigation bar.
- Update documentation to reflect new layout logic.

## Summary by Sourcery

Improve gesture handling in the log bottom sheet overlay and adjust layout behavior around the system navigation bar and soft keyboard.

Bug Fixes:
- Allow vertical drag gestures to pass through to the bottom sheet while preserving horizontal swipe-based tab navigation.
- Prevent the overlay window from shifting position when the soft keyboard appears.
- Ensure log content in the bottom sheet remains visible behind the system navigation bar via bottom padding in the log list.