### PR TITLE
Fix anchor bottom sheet 778443951580934797

### DIFF
--- a/app/src/main/kotlin/com/hereliesaz/logkitty/services/LogKittyOverlayService.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/services/LogKittyOverlayService.kt
@@ -33,7 +33,6 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.unit.dp
 import androidx.core.app.NotificationCompat
 import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.navigationBars
 import com.hereliesaz.logkitty.MainActivity
 import com.hereliesaz.logkitty.MainApplication
 import com.hereliesaz.logkitty.R
@@ -326,8 +325,6 @@ class LogKittyOverlayService : Service() {
                     onDispose { }
                 }
 
-                val bottomPadding = if (isWindowExpanded) screenHeight * 0.10f else 0.dp
-
                 LogKittyTheme {
                     LogBottomSheet(
                         sheetState = sheetState,
@@ -335,7 +332,6 @@ class LogKittyOverlayService : Service() {
                         screenHeight = screenHeight,
                         navBarHeight = navBarHeight,
                         isWindowExpanded = isWindowExpanded,
-                        bottomPadding = bottomPadding,
                         onSendPrompt = { viewModel.sendPrompt(it) },
                         onInteraction = { isInteracting ->
                             updateWindowHeight(isInteracting)

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/services/LogKittyOverlayService.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/services/LogKittyOverlayService.kt
@@ -219,6 +219,9 @@ class LogKittyOverlayService : Service() {
         val app = applicationContext as MainApplication
         val viewModel = app.mainViewModel
 
+        val resourceId = resources.getIdentifier("navigation_bar_height", "dimen", "android")
+        val navBarHeightPx = if (resourceId > 0) resources.getDimensionPixelSize(resourceId) else 0
+
         composeView = ComposeView(this).apply {
             setContent {
                 val density = androidx.compose.ui.platform.LocalDensity.current
@@ -234,9 +237,6 @@ class LogKittyOverlayService : Service() {
                     }
                 }
                 val screenHeight = (screenHeightPx / density.density).dp
-
-                val resourceId = resources.getIdentifier("navigation_bar_height", "dimen", "android")
-                val navBarHeightPx = if (resourceId > 0) resources.getDimensionPixelSize(resourceId) else 0
                 val navBarHeight = with(density) { navBarHeightPx.toDp() }
 
                 val sheetState = rememberBottomSheetState(
@@ -263,6 +263,7 @@ class LogKittyOverlayService : Service() {
                          // Always ensure Y anchor is maintained and Gravity is BOTTOM
                          params.y = anchorYPx
                          params.gravity = Gravity.BOTTOM
+                         params.flags = params.flags or WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS
 
                          if (isInteracting) {
                              delayedShrinkJob?.cancel()
@@ -300,6 +301,7 @@ class LogKittyOverlayService : Service() {
                                          // Y anchor remains constant
                                          currentParams.y = anchorYPx
                                          currentParams.gravity = Gravity.BOTTOM
+                                         currentParams.flags = currentParams.flags or WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS
                                          try {
                                              windowManager.updateViewLayout(composeView, currentParams)
                                          } catch (e: Exception) {
@@ -357,8 +359,6 @@ class LogKittyOverlayService : Service() {
         lifecycleHelper!!.onStart()
 
         // Initial params: Height = Hidden (2%) or Peek (25%)? Initial state is Collapsed (Hidden)
-        val navBarResourceId = resources.getIdentifier("navigation_bar_height", "dimen", "android")
-        val navBarHeightPx = if (navBarResourceId > 0) resources.getDimensionPixelSize(navBarResourceId) else 0
         val initialHeight = (resources.displayMetrics.heightPixels * 0.02f + navBarHeightPx).toInt()
         val initialY = 0
 

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/services/LogKittyOverlayService.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/services/LogKittyOverlayService.kt
@@ -32,6 +32,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.unit.dp
 import androidx.core.app.NotificationCompat
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.navigationBars
 import com.hereliesaz.logkitty.MainActivity
 import com.hereliesaz.logkitty.MainApplication
 import com.hereliesaz.logkitty.R
@@ -234,26 +236,9 @@ class LogKittyOverlayService : Service() {
                 }
                 val screenHeight = (screenHeightPx / density.density).dp
 
-                // Robust screen height calculation
-                val screenHeightPx = remember {
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-                        windowManager.currentWindowMetrics.bounds.height()
-                    } else {
-                        val metrics = DisplayMetrics()
-                        @Suppress("DEPRECATION")
-                        windowManager.defaultDisplay.getRealMetrics(metrics)
-                        metrics.heightPixels
-                    }
-                }
-                val screenHeight = (screenHeightPx / density.density).dp
-
-                val detents = remember(screenHeight) {
-                    val hidden = SheetDetent("hidden", calculateDetentHeight = {_, _ -> screenHeight * 0.02f })
-                    val peek = SheetDetent("peek", calculateDetentHeight = { _, _ -> screenHeight * 0.25f })
-                    val halfway = SheetDetent("halfway", calculateDetentHeight = { _, _ -> screenHeight * 0.50f })
-                    val fully = SheetDetent("fully_expanded", calculateDetentHeight = { _, _ -> screenHeight * 0.80f })
-                    listOf(hidden, peek, halfway, fully)
-                }
+                val resourceId = resources.getIdentifier("navigation_bar_height", "dimen", "android")
+                val navBarHeightPx = if (resourceId > 0) resources.getDimensionPixelSize(resourceId) else 0
+                val navBarHeight = with(density) { navBarHeightPx.toDp() }
 
                 val sheetState = rememberBottomSheetState(
                     initialValue = BottomSheetValue.Collapsed
@@ -269,13 +254,9 @@ class LogKittyOverlayService : Service() {
                 var delayedShrinkJob by remember { androidx.compose.runtime.mutableStateOf<kotlinx.coroutines.Job?>(null) }
                 var isWindowExpanded by remember { mutableStateOf(false) }
 
-                // Fixed Anchor: 10% of screen height from bottom
-                val anchorYPx = (screenHeightPx * 0.10f).toInt()
-                val expandedHeightPx = (screenHeightPx * 0.90f).toInt()
-
-                // Fixed Anchor: 10% of screen height from bottom
-                val anchorYPx = (screenHeightPx * 0.10f).toInt()
-                val expandedHeightPx = (screenHeightPx * 0.90f).toInt()
+                // Fixed Anchor: 0 (Immovable at bottom)
+                val anchorYPx = 0
+                val expandedHeightPx = (screenHeightPx * 0.90f + navBarHeightPx).toInt()
 
                 val updateWindowHeight = { isInteracting: Boolean ->
                      val params = composeView?.layoutParams as? WindowManager.LayoutParams
@@ -305,13 +286,11 @@ class LogKittyOverlayService : Service() {
 
                                  // Determine current detent height
                                  val currentValue = sheetState.value
-                                 val detentHeightFactor = when (currentValue) {
-                                     BottomSheetValue.Collapsed -> 0.02f
-                                     BottomSheetValue.Peeked -> 0.25f
-                                     BottomSheetValue.Expanded -> 0.80f
+                                 val targetHeightPx = when (currentValue) {
+                                     BottomSheetValue.Collapsed -> (screenHeightPx * 0.02f + navBarHeightPx).toInt()
+                                     BottomSheetValue.Peeked -> (screenHeightPx * 0.25f + navBarHeightPx).toInt()
+                                     BottomSheetValue.Expanded -> (screenHeightPx * 0.80f + navBarHeightPx).toInt()
                                  }
-
-                                 val targetHeightPx = (screenHeightPx * detentHeightFactor).toInt()
 
                                  // Check if we started interacting again during delay
                                  if (isActive) {
@@ -354,6 +333,7 @@ class LogKittyOverlayService : Service() {
                         sheetState = sheetState,
                         viewModel = viewModel,
                         screenHeight = screenHeight,
+                        navBarHeight = navBarHeight,
                         isWindowExpanded = isWindowExpanded,
                         bottomPadding = bottomPadding,
                         onSendPrompt = { viewModel.sendPrompt(it) },
@@ -381,8 +361,10 @@ class LogKittyOverlayService : Service() {
         lifecycleHelper!!.onStart()
 
         // Initial params: Height = Hidden (2%) or Peek (25%)? Initial state is Collapsed (Hidden)
-        val initialHeight = (resources.displayMetrics.heightPixels * 0.02f).toInt()
-        val initialY = (resources.displayMetrics.heightPixels * 0.10f).toInt()
+        val navBarResourceId = resources.getIdentifier("navigation_bar_height", "dimen", "android")
+        val navBarHeightPx = if (navBarResourceId > 0) resources.getDimensionPixelSize(navBarResourceId) else 0
+        val initialHeight = (resources.displayMetrics.heightPixels * 0.02f + navBarHeightPx).toInt()
+        val initialY = 0
 
         val params = WindowManager.LayoutParams(
             WindowManager.LayoutParams.MATCH_PARENT,
@@ -395,6 +377,7 @@ class LogKittyOverlayService : Service() {
         ).apply {
             gravity = Gravity.BOTTOM
             y = initialY
+            softInputMode = WindowManager.LayoutParams.SOFT_INPUT_ADJUST_NOTHING
         }
 
         try {

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/LogBottomSheet.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/LogBottomSheet.kt
@@ -177,7 +177,7 @@ fun LogBottomSheet(
         // Bottom Sheet
         BottomSheetLayout(
             state = sheetState,
-            peekHeight = PeekHeight.dp((screenHeight * 0.02f + navBarHeight).value),
+            peekHeight = PeekHeight.dp((screenHeight * 0.25f + navBarHeight).value),
             modifier = Modifier
                 .fillMaxSize()
                 .padding(bottom = bottomPadding),

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/LogBottomSheet.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/LogBottomSheet.kt
@@ -56,7 +56,6 @@ fun LogBottomSheet(
     screenHeight: Dp,
     navBarHeight: Dp,
     isWindowExpanded: Boolean,
-    bottomPadding: Dp,
     onSendPrompt: (String) -> Unit,
     onInteraction: (Boolean) -> Unit,
     onSaveClick: () -> Unit,
@@ -179,8 +178,7 @@ fun LogBottomSheet(
             state = sheetState,
             peekHeight = PeekHeight.dp((screenHeight * 0.25f + navBarHeight).value),
             modifier = Modifier
-                .fillMaxSize()
-                .padding(bottom = bottomPadding),
+                .fillMaxSize(),
             skipPeeked = false,
         ) {
              Box(

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/LogBottomSheet.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/LogBottomSheet.kt
@@ -5,7 +5,6 @@ import android.net.Uri
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.gestures.detectHorizontalDragGestures
 import androidx.compose.foundation.gestures.detectVerticalDragGestures
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
@@ -55,6 +54,7 @@ fun LogBottomSheet(
     sheetState: BottomSheetState,
     viewModel: MainViewModel,
     screenHeight: Dp,
+    navBarHeight: Dp,
     isWindowExpanded: Boolean,
     bottomPadding: Dp,
     onSendPrompt: (String) -> Unit,
@@ -177,7 +177,7 @@ fun LogBottomSheet(
         // Bottom Sheet
         BottomSheetLayout(
             state = sheetState,
-            peekHeight = PeekHeight.dp((screenHeight * 0.25f).value),
+            peekHeight = PeekHeight.dp((screenHeight * 0.02f + navBarHeight).value),
             modifier = Modifier
                 .fillMaxSize()
                 .padding(bottom = bottomPadding),
@@ -186,29 +186,6 @@ fun LogBottomSheet(
              Box(
                 modifier = Modifier
                     .fillMaxSize()
-                    .pointerInput(Unit) {
-                        var totalDrag = 0f
-                        detectHorizontalDragGestures(
-                            onDragStart = { totalDrag = 0f },
-                            onDragEnd = {
-                                 if (abs(totalDrag) > swipeThreshold) {
-                                     val currentIndex = tabs.indexOf(selectedTab)
-                                     if (totalDrag > 0) { // Swipe Right -> Previous Tab
-                                         if (currentIndex > 0) {
-                                             viewModel.selectTab(tabs[currentIndex - 1])
-                                         }
-                                     } else { // Swipe Left -> Next Tab
-                                         if (currentIndex < tabs.size - 1) {
-                                             viewModel.selectTab(tabs[currentIndex + 1])
-                                         }
-                                     }
-                                 }
-                            }
-                        ) { change, dragAmount ->
-                            change.consume()
-                            totalDrag += dragAmount
-                        }
-                    }
             ) {
                 Column(
                     modifier = Modifier
@@ -298,6 +275,7 @@ fun LogBottomSheet(
                         LazyColumn(
                             state = listState,
                             reverseLayout = isLogReversed,
+                            contentPadding = PaddingValues(bottom = navBarHeight),
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .weight(1f)

--- a/docs/UI_UX.md
+++ b/docs/UI_UX.md
@@ -9,10 +9,10 @@ LogKitty is a developer tool designed to be unobtrusive yet instantly accessible
 - **Accents:** Minimal use of color; system colors used for specific log levels (Error=Red, Warn=Yellow) if implemented.
 
 ## Components
-- **Bottom Sheet:** The primary interaction point. It supports three states:
-    - **Peek:** Small strip at the bottom, showing the last log line or status.
-    - **Half-Expanded:** Covers 50% of the screen, allows scrolling.
-    - **Fully-Expanded:** Covers 80% of the screen for deep debugging.
+- **Bottom Sheet:** The primary interaction point. It supports three states (heights include the system navigation bar area):
+    - **Peek:** Small strip at the bottom, showing the last log line or status (25% of screen height + Nav Bar).
+    - **Half-Expanded:** Covers 50% of the screen + Nav Bar, allows scrolling.
+    - **Fully-Expanded:** Covers 80% of the screen + Nav Bar for deep debugging.
 - **Overlay:** A transparent touch-through layer that allows interaction with the app below when the sheet is collapsed.
 
 ## Interaction

--- a/docs/UI_UX.md
+++ b/docs/UI_UX.md
@@ -10,8 +10,8 @@ LogKitty is a developer tool designed to be unobtrusive yet instantly accessible
 
 ## Components
 - **Bottom Sheet:** The primary interaction point. It supports three states (heights include the system navigation bar area):
+    - **Hidden (Collapsed):** Small strip at the bottom (2% of screen height + Nav Bar).
     - **Peek:** Small strip at the bottom, showing the last log line or status (25% of screen height + Nav Bar).
-    - **Half-Expanded:** Covers 50% of the screen + Nav Bar, allows scrolling.
     - **Fully-Expanded:** Covers 80% of the screen + Nav Bar for deep debugging.
 - **Overlay:** A transparent touch-through layer that allows interaction with the app below when the sheet is collapsed.
 


### PR DESCRIPTION
## Summary by Sourcery

Adjust the log overlay bottom sheet to anchor immovably at the screen bottom and correctly account for the system navigation bar in its sizing and behavior.

Enhancements:
- Account for system navigation bar height when calculating bottom sheet heights, screen space usage, and initial overlay dimensions.
- Make the overlay window and bottom sheet anchor fixed at the bottom of the screen and allow drawing beyond normal layout limits for consistent positioning.
- Simplify bottom sheet interaction behavior by removing unused detent configuration and horizontal swipe tab switching in the content area.

Documentation:
- Update UI/UX documentation to describe the revised bottom sheet states and their heights relative to the system navigation bar.