### PR TITLE
fix: anchor bottom sheet to screen bottom and add dynamic peek

### DIFF
--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/LogBottomSheet.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/LogBottomSheet.kt
@@ -5,7 +5,6 @@ import android.net.Uri
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.gestures.detectHorizontalDragGestures
 import androidx.compose.foundation.gestures.detectVerticalDragGestures
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
@@ -55,8 +54,10 @@ fun LogBottomSheet(
     sheetState: BottomSheetState,
     viewModel: MainViewModel,
     screenHeight: Dp,
+    navBarHeight: Dp,
     isWindowExpanded: Boolean,
-    bottomPadding: Dp,
+    currentPeekFraction: Float,
+    onPeekFractionChange: (Float) -> Unit,
     onSendPrompt: (String) -> Unit,
     onInteraction: (Boolean) -> Unit,
     onSaveClick: () -> Unit,
@@ -95,6 +96,31 @@ fun LogBottomSheet(
     // --- OPTIMIZED AUTO-SCROLL ---
     var autoScrollEnabled by remember { mutableStateOf(true) }
     var selectedLogIndex by remember { mutableStateOf<Int?>(null) }
+
+    // Dynamic Peek Logic
+    LaunchedEffect(sheetState.dragProgress, sheetState.value) {
+        // approximate drag progress to height fraction
+        // This is heuristic because dragProgress is 0..1 (collapsed to expanded)
+        // Collapsed (2%) -> Peek (25% or 50%) -> Expanded (80%)
+        // If progress is significant, we can infer user intent.
+
+        // Threshold: 37.5% (Midpoint between 25% and 50%)
+        // Normalized range: Expanded(80) - Collapsed(2) = 78% range.
+        // 25% is approx 0.29 progress.
+        // 50% is approx 0.61 progress.
+        // 37.5% is approx 0.45 progress.
+
+        if (sheetState.dragProgress > 0.45f) {
+            if (currentPeekFraction != 0.50f) {
+                onPeekFractionChange(0.50f)
+            }
+        } else {
+             // If we are dragging down, or just below threshold
+             if (currentPeekFraction != 0.25f) {
+                 onPeekFractionChange(0.25f)
+             }
+        }
+    }
 
     LaunchedEffect(listState.isScrollInProgress) {
         if (listState.isScrollInProgress) {
@@ -177,38 +203,14 @@ fun LogBottomSheet(
         // Bottom Sheet
         BottomSheetLayout(
             state = sheetState,
-            peekHeight = PeekHeight.dp((screenHeight * 0.25f).value),
+            peekHeight = PeekHeight.dp((screenHeight * currentPeekFraction + navBarHeight).value),
             modifier = Modifier
-                .fillMaxSize()
-                .padding(bottom = bottomPadding),
+                .fillMaxSize(),
             skipPeeked = false,
         ) {
              Box(
                 modifier = Modifier
                     .fillMaxSize()
-                    .pointerInput(Unit) {
-                        var totalDrag = 0f
-                        detectHorizontalDragGestures(
-                            onDragStart = { totalDrag = 0f },
-                            onDragEnd = {
-                                 if (abs(totalDrag) > swipeThreshold) {
-                                     val currentIndex = tabs.indexOf(selectedTab)
-                                     if (totalDrag > 0) { // Swipe Right -> Previous Tab
-                                         if (currentIndex > 0) {
-                                             viewModel.selectTab(tabs[currentIndex - 1])
-                                         }
-                                     } else { // Swipe Left -> Next Tab
-                                         if (currentIndex < tabs.size - 1) {
-                                             viewModel.selectTab(tabs[currentIndex + 1])
-                                         }
-                                     }
-                                 }
-                            }
-                        ) { change, dragAmount ->
-                            change.consume()
-                            totalDrag += dragAmount
-                        }
-                    }
             ) {
                 Column(
                     modifier = Modifier
@@ -298,6 +300,7 @@ fun LogBottomSheet(
                         LazyColumn(
                             state = listState,
                             reverseLayout = isLogReversed,
+                            contentPadding = PaddingValues(bottom = navBarHeight),
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .weight(1f)

--- a/docs/UI_UX.md
+++ b/docs/UI_UX.md
@@ -9,10 +9,10 @@ LogKitty is a developer tool designed to be unobtrusive yet instantly accessible
 - **Accents:** Minimal use of color; system colors used for specific log levels (Error=Red, Warn=Yellow) if implemented.
 
 ## Components
-- **Bottom Sheet:** The primary interaction point. It supports three states:
-    - **Peek:** Small strip at the bottom, showing the last log line or status.
-    - **Half-Expanded:** Covers 50% of the screen, allows scrolling.
-    - **Fully-Expanded:** Covers 80% of the screen for deep debugging.
+- **Bottom Sheet:** The primary interaction point. It supports three states (heights include the system navigation bar area):
+    - **Hidden (Collapsed):** Small strip at the bottom (2% of screen height + Nav Bar).
+    - **Peek:** Small strip at the bottom, showing the last log line or status (25% of screen height + Nav Bar).
+    - **Fully-Expanded:** Covers 80% of the screen + Nav Bar for deep debugging.
 - **Overlay:** A transparent touch-through layer that allows interaction with the app below when the sheet is collapsed.
 
 ## Interaction


### PR DESCRIPTION
## Summary by Sourcery

Anchor the log overlay bottom sheet to the bottom of the screen, accounting for navigation bar height, and introduce a dynamic peek height based on user drag behavior.

New Features:
- Allow the bottom sheet peek height to dynamically toggle between two levels (25% and 50% of screen height) based on drag progress.

Bug Fixes:
- Ensure the overlay bottom sheet is consistently anchored to the bottom of the screen instead of floating above it.
- Adjust bottom sheet and list content heights to include the system navigation bar area, preventing logs from being obscured.
- Prevent the bottom sheet from resizing or shifting due to soft keyboard adjustments.

Enhancements:
- Simplify bottom sheet layout by removing custom bottom padding and horizontal swipe tab switching.
- Update UI/UX documentation to describe the revised bottom sheet states and their heights including the navigation bar.