### PR TITLE
Overhaul overlay: 4-detent sheet, gesture zones, tabs, selectable logs, color schemes

### DIFF
--- a/app/src/main/kotlin/com/hereliesaz/logkitty/services/LogKittyAccessibilityService.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/services/LogKittyAccessibilityService.kt
@@ -6,26 +6,25 @@ import android.util.Log
 import android.view.accessibility.AccessibilityEvent
 
 /**
- * [LogKittyAccessibilityService] is a lightweight Accessibility Service designed purely for
- * "Context Awareness".
- *
- * Its ONLY job is to detect which application is currently in the foreground (active on screen)
- * so that LogKitty can filter the log stream to show only relevant logs for that app.
+ * [LogKittyAccessibilityService] supplies *Context Awareness* (foreground-app detection) and
+ * also signals when the user reaches the launcher or the recents screen so the overlay can
+ * collapse out of the way.
  *
  * **Privacy Note:**
  * This service does NOT inspect UI content, read text, or track user inputs.
- * It only listens for [AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED] to get package names.
+ * It only consumes [AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED] to read package names.
  */
 class LogKittyAccessibilityService : AccessibilityService() {
 
     private val TAG = "LogKittyAccess"
 
     companion object {
-        // Broadcast action sent when the foreground app changes.
         const val ACTION_FOREGROUND_APP_CHANGED = "com.hereliesaz.logkitty.FOREGROUND_APP_CHANGED"
-
-        // Broadcast action sent when the user returns to the home screen (requesting the overlay to collapse).
         const val ACTION_COLLAPSE_OVERLAY = "com.hereliesaz.logkitty.COLLAPSE_OVERLAY"
+
+        const val EXTRA_REASON = "reason"
+        const val REASON_HOME = "home"
+        const val REASON_RECENTS = "recents"
     }
 
     override fun onServiceConnected() {
@@ -33,50 +32,45 @@ class LogKittyAccessibilityService : AccessibilityService() {
         Log.d(TAG, "Accessibility Service Connected")
     }
 
-    /**
-     * Called back by the system when an accessibility event occurs.
-     * We filter strictly for window state changes.
-     */
     override fun onAccessibilityEvent(event: AccessibilityEvent?) {
-        if (event?.eventType == AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED) {
-            val packageName = event.packageName?.toString()
-            if (!packageName.isNullOrBlank()) {
-                // Broadcast the new foreground app to the MainViewModel (via a Receiver or direct observation)
-                // Note: The ViewModel actually uses a receiver or monitors this indirectly.
-                val intent = Intent(ACTION_FOREGROUND_APP_CHANGED).apply {
-                    putExtra("PACKAGE_NAME", packageName)
-                    // Explicitly set package to keep the broadcast internal/secure
-                    setPackage(this@LogKittyAccessibilityService.packageName)
-                }
-                sendBroadcast(intent)
+        if (event?.eventType != AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED) return
+        val packageName = event.packageName?.toString() ?: return
+        if (packageName.isBlank()) return
 
-                // Smart Feature: Auto-Collapse
-                // If the user goes to the Home Screen or opens Recents/App Switcher,
-                // we assume they are done debugging for a moment and collapse the overlay to get out of the way.
-                if (isSystemNavPackage(packageName)) {
-                    val collapseIntent = Intent(ACTION_COLLAPSE_OVERLAY).apply {
-                        setPackage(this@LogKittyAccessibilityService.packageName)
-                    }
-                    sendBroadcast(collapseIntent)
-                }
+        val foregroundIntent = Intent(ACTION_FOREGROUND_APP_CHANGED).apply {
+            putExtra("PACKAGE_NAME", packageName)
+            setPackage(this@LogKittyAccessibilityService.packageName)
+        }
+        sendBroadcast(foregroundIntent)
+
+        val reason = systemTransitionReason(packageName, event.className?.toString())
+        if (reason != null) {
+            val collapseIntent = Intent(ACTION_COLLAPSE_OVERLAY).apply {
+                setPackage(this@LogKittyAccessibilityService.packageName)
+                putExtra(EXTRA_REASON, reason)
             }
+            sendBroadcast(collapseIntent)
         }
     }
 
-    /**
-     * Checks if the package name belongs to known system navigation components (Launchers, SystemUI).
-     */
-    private fun isSystemNavPackage(pkg: String): Boolean {
-        return pkg.contains("launcher", ignoreCase = true) || // Common pattern for 3rd party launchers
-               pkg == "com.android.systemui" || // System UI (Recents, Notification Shade)
-               pkg == "com.google.android.apps.nexuslauncher" || // Pixel Launcher
-               pkg == "com.sec.android.app.launcher" // Samsung One UI Home
+    /** Returns [REASON_HOME], [REASON_RECENTS], or null when the event is irrelevant. */
+    private fun systemTransitionReason(pkg: String, cls: String?): String? {
+        val lowerCls = cls?.lowercase().orEmpty()
+        val isRecents = lowerCls.contains("recents") ||
+            lowerCls.contains("taskswitcher") ||
+            lowerCls.contains("overview")
+        val isLauncher = pkg.contains("launcher", ignoreCase = true) ||
+            pkg == "com.google.android.apps.nexuslauncher" ||
+            pkg == "com.sec.android.app.launcher" ||
+            pkg == "com.android.launcher" ||
+            pkg == "com.android.launcher3"
+        return when {
+            isRecents -> REASON_RECENTS
+            isLauncher -> REASON_HOME
+            pkg == "com.android.systemui" -> REASON_RECENTS
+            else -> null
+        }
     }
 
-    /**
-     * Called when the system wants to interrupt the feedback. Not used here.
-     */
-    override fun onInterrupt() {
-        Log.d(TAG, "onInterrupt")
-    }
+    override fun onInterrupt() { Log.d(TAG, "onInterrupt") }
 }

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/services/LogKittyOverlayService.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/services/LogKittyOverlayService.kt
@@ -15,93 +15,79 @@ import android.os.Build
 import android.os.IBinder
 import android.provider.Settings
 import android.view.Gravity
-import android.view.MotionEvent
+import android.view.KeyEvent
 import android.view.WindowManager
-import androidx.compose.runtime.*
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.core.app.NotificationCompat
-import com.dokar.sheets.BottomSheetState
-import com.dokar.sheets.BottomSheetValue
-import com.dokar.sheets.rememberBottomSheetState
 import com.hereliesaz.logkitty.MainActivity
 import com.hereliesaz.logkitty.MainApplication
 import com.hereliesaz.logkitty.ui.LogBottomSheet
+import com.hereliesaz.logkitty.ui.SheetController
+import com.hereliesaz.logkitty.ui.SheetDetent
 import com.hereliesaz.logkitty.ui.theme.LogKittyTheme
 import com.hereliesaz.logkitty.utils.ComposeLifecycleHelper
-import kotlinx.coroutines.*
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
 
 /**
- * [LogKittyOverlayService] is the core component of the application, responsible for rendering the
- * always-on overlay window.
+ * [LogKittyOverlayService] hosts the always-on Compose overlay.
  *
- * It manages:
- * 1. The System Overlay Window (`WindowManager`).
- * 2. The Jetpack Compose UI host (`ComposeView`).
- * 3. The complex interaction logic that allows touches to pass through the overlay when it is
- *    collapsed or "peeking", but captures them when expanded.
- * 4. The lifecycle synchronization between the Android Service component and the Compose world.
+ * **Touch confinement**
+ * The WindowManager view is resized to match the current sheet detent so taps outside the sheet
+ * fall through to the underlying application — even when the sheet is FULL height (the bottom 90%
+ * of the screen) the window leaves the top 10% untouchable.
  *
- * This service runs as a Foreground Service to ensure the system does not kill it while the user
- * is debugging other applications.
+ * **Back-button handling**
+ * When the sheet is HALF or FULL the window is focusable, so the system delivers back events.
+ * Pressing back collapses the sheet to HIDDEN, and the window immediately drops focus so a second
+ * back is delivered to the underlying app.
+ *
+ * **Home / Recents**
+ * The accessibility service broadcasts [LogKittyAccessibilityService.ACTION_COLLAPSE_OVERLAY] with
+ * a reason; this service collapses the sheet without performing any further action (the system
+ * already handled the home/recents gesture).
  */
 class LogKittyOverlayService : Service() {
 
-    // System Window Manager to add/update/remove the overlay view.
     private lateinit var windowManager: WindowManager
-
-    // The container for our Jetpack Compose UI.
     private var composeView: ComposeView? = null
-
-    // A helper to provide LifecycleOwner, ViewModelStoreOwner, and SavedStateRegistryOwner to Compose.
-    // This is CRITICAL because Services do not naturally provide these, and Compose crashes without them.
     private var lifecycleHelper: ComposeLifecycleHelper? = null
 
-    // State of the bottom sheet (Collapsed, Expanded, Peek).
-    private var bottomSheetState: BottomSheetState? = null
+    private val controller = SheetController()
+    private val serviceScope = CoroutineScope(Dispatchers.Main + SupervisorJob())
 
-    // Flag to track if the user is currently interacting with the raw view (touch down).
-    // This allows us to expand the window bounds *immediately* upon touch, before Compose even processes the gesture.
-    private var isInteractingRaw = false
-
-    /**
-     * Receiver for actions broadcast by the [LogKittyAccessibilityService].
-     * Specifically used to auto-collapse the overlay when the user goes to the Home screen or Recents.
-     */
     private val receiver = object : BroadcastReceiver() {
         override fun onReceive(context: Context?, intent: Intent?) {
             if (intent?.action == LogKittyAccessibilityService.ACTION_COLLAPSE_OVERLAY) {
-                collapseBottomSheet()
+                controller.hide()
             }
         }
     }
 
-    /**
-     * Binding is not supported. This service operates purely as a started service.
-     */
     override fun onBind(intent: Intent?): IBinder? = null
 
-    /**
-     * Handles startup commands.
-     * Supports:
-     * - [ACTION_STOP_SERVICE]: Gracefully shuts down the overlay.
-     * - [ACTION_OPEN_SETTINGS]: Launches the main configuration activity.
-     */
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-        if (intent?.action == ACTION_STOP_SERVICE) {
-            stopSelf()
-            return START_NOT_STICKY
-        }
-        if (intent?.action == ACTION_OPEN_SETTINGS) {
-            val settingsIntent = Intent(this, MainActivity::class.java).apply {
-                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK) // Required when starting Activity from Service
-                putExtra("EXTRA_SHOW_SETTINGS", true)
+        when (intent?.action) {
+            ACTION_STOP_SERVICE -> {
+                stopSelf()
+                return START_NOT_STICKY
             }
-            startActivity(settingsIntent)
+            ACTION_OPEN_SETTINGS -> {
+                val settingsIntent = Intent(this, MainActivity::class.java).apply {
+                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                    putExtra("EXTRA_SHOW_SETTINGS", true)
+                }
+                startActivity(settingsIntent)
+            }
         }
-        // Restart the service if the system kills it (standard for always-on tools).
         return START_STICKY
     }
 
@@ -109,27 +95,19 @@ class LogKittyOverlayService : Service() {
         super.onCreate()
         windowManager = getSystemService(WINDOW_SERVICE) as WindowManager
         createNotificationChannel()
-
-        // Start as foreground service immediately to prevent ANR or system killing.
         val notification = createNotification()
         try {
             if (Build.VERSION.SDK_INT >= 34) {
-                // API 34+ requires declaring the specific foreground service type in manifest and code.
                 startForeground(SERVICE_ID, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE)
             } else {
                 startForeground(SERVICE_ID, notification)
             }
         } catch (e: Exception) {
-            // Fallback for older APIs or if specific permission logic fails slightly differently
             startForeground(SERVICE_ID, notification)
         }
 
-        // Verify overlay permission before attempting to add the view to avoid crashes.
-        if (Settings.canDrawOverlays(this)) {
-            setupBottomSheetOverlay()
-        }
+        if (Settings.canDrawOverlays(this)) setupOverlay()
 
-        // Register the broadcast receiver to listen for "Go Home" events from the accessibility service.
         val filter = IntentFilter(LogKittyAccessibilityService.ACTION_COLLAPSE_OVERLAY)
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             registerReceiver(receiver, filter, RECEIVER_NOT_EXPORTED)
@@ -140,244 +118,176 @@ class LogKittyOverlayService : Service() {
 
     override fun onDestroy() {
         super.onDestroy()
-        // Clean up the Compose view and WindowManager to prevent leaks.
-        if (composeView != null) {
+        serviceScope.cancel()
+        composeView?.let { view ->
             try {
                 lifecycleHelper?.onStop()
                 lifecycleHelper?.onDestroy()
-                windowManager.removeView(composeView)
-            } catch (e: Exception) {
-                e.printStackTrace()
-            }
+                windowManager.removeView(view)
+            } catch (e: Exception) { e.printStackTrace() }
         }
-        try {
-            unregisterReceiver(receiver)
-        } catch (e: Exception) {
-            e.printStackTrace()
-        }
+        try { unregisterReceiver(receiver) } catch (e: Exception) { e.printStackTrace() }
     }
 
-    /**
-     * Programmatically collapses the bottom sheet to its peek state.
-     * Safe to call from background threads (logic dispatched to Main).
-     */
-    private fun collapseBottomSheet() {
-         if (bottomSheetState != null) {
-             CoroutineScope(Dispatchers.Main).launch {
-                 try { bottomSheetState?.collapse() } catch (e: Exception) { e.printStackTrace() }
-             }
-         }
-    }
-
-    /**
-     * Initializes the ComposeView, sets up the window parameters, and attaches it to the WindowManager.
-     */
-    private fun setupBottomSheetOverlay() {
-        // Access the singleton ViewModel from the Application to share state with the Settings UI.
+    private fun setupOverlay() {
         val app = applicationContext as MainApplication
         val viewModel = app.mainViewModel
+        val density = resources.displayMetrics.density
+        val screenHeightPx = resources.displayMetrics.heightPixels
 
-        // Retrieve the system navigation bar height to ensure we don't draw under it (or account for it).
-        // We use getIdentifier because directly accessing window insets in a Service is complex/unreliable across APIs.
         val resourceId = resources.getIdentifier("navigation_bar_height", "dimen", "android")
         val navBarHeightPx = if (resourceId > 0) resources.getDimensionPixelSize(resourceId) else 0
 
-        composeView = ComposeView(this).apply {
-            // CRITICAL: Raw Touch Listener
-            // When the window is "Collapsed" or "Peeking", its height is small.
-            // If the user starts a drag (swipe up), we must INSTANTLY expand the underlying WindowManager window
-            // to MATCH_PARENT so the gesture has room to continue.
-            // If we waited for Compose to tell us, the gesture would exit the window bounds and be lost.
-            setOnTouchListener { _, event ->
-                if (event.action == MotionEvent.ACTION_DOWN) {
-                    isInteractingRaw = true
-                    setWindowToFullScreen(true) // Expand window bounds immediately
-                } else if (event.action == MotionEvent.ACTION_UP || event.action == MotionEvent.ACTION_CANCEL) {
-                    isInteractingRaw = false
-                    // We don't collapse here immediately; we let the LaunchedEffect below handle the settling logic.
+        composeView = object : ComposeView(this) {
+            override fun dispatchKeyEvent(event: KeyEvent): Boolean {
+                if (event.keyCode == KeyEvent.KEYCODE_BACK && event.action == KeyEvent.ACTION_UP) {
+                    if (onBack()) return true
                 }
-                false // Return false to let the event propagate to the Compose layer for actual UI handling.
+                return super.dispatchKeyEvent(event)
             }
-
+        }.apply {
             setContent {
-                val density = LocalDensity.current
+                val composeDensity = LocalDensity.current
                 val fontSizeInt by viewModel.fontSize.collectAsState()
-                
-                // Calculate dynamic heights based on text size.
-                // Collapsed Height = 1 Line of text (approx 1.5x font size) + Vertical Padding (24dp) + Nav Bar.
-                // This ensures the "Peek" strip is exactly tall enough to show one line of logs.
-                val fontSizeSp = fontSizeInt.sp
-                val fontSizePx = with(density) { fontSizeSp.toPx() }
-                val paddingPx = with(density) { 24.dp.toPx() }
-                
-                val contentHeightPx = (fontSizePx * 1.5f) + paddingPx
-                val collapsedTotalHeightPx = (contentHeightPx + navBarHeightPx).toInt()
-                val collapsedHeightDp = with(density) { collapsedTotalHeightPx.toDp() }
-                val navBarHeightDp = with(density) { navBarHeightPx.toDp() }
-
-                // Determine initial state of the sheet.
-                val sheetState = rememberBottomSheetState(
-                    initialValue = BottomSheetValue.Collapsed
-                )
-
-                // Expose sheet state to the outer Service class for programmatic collapse.
-                DisposableEffect(sheetState) {
-                    bottomSheetState = sheetState
-                    onDispose { bottomSheetState = null }
-                }
-
-                // Window State Synchronization Logic
-                // This observes the Compose Sheet State and updates the WindowManager flags accordingly.
-                LaunchedEffect(sheetState.value, isInteractingRaw) {
-                    // Do not shrink the window while the user is actively touching it.
-                    if (isInteractingRaw) return@LaunchedEffect
-
-                    if (sheetState.value == BottomSheetValue.Collapsed) {
-                        // Delay slightly to allow the collapse animation to visually finish before clipping the window.
-                        delay(300)
-                        if (!isInteractingRaw) {
-                            setWindowToCollapsed(collapsedTotalHeightPx)
-                        }
-                    } else {
-                        // If Expanded or Peeking (custom logic often maps peek to expanded in window terms),
-                        // ensure the window fills the screen to receive touches everywhere.
-                        setWindowToFullScreen(false)
-                    }
-                }
+                val fontSpPx = with(composeDensity) { fontSizeInt.sp.toPx() }
+                val paddingPx = with(composeDensity) { 24.dp.toPx() }
+                val peekContentPx = (fontSpPx * 1.5f) + paddingPx
+                val peekTotalPx = (peekContentPx + navBarHeightPx).toInt()
+                val peekDp = with(composeDensity) { peekTotalPx.toDp() }
+                val navBarDp = with(composeDensity) { navBarHeightPx.toDp() }
+                val screenHeightDp = with(composeDensity) { screenHeightPx.toDp() }
 
                 LogKittyTheme {
                     LogBottomSheet(
-                        sheetState = sheetState,
+                        controller = controller,
                         viewModel = viewModel,
-                        screenHeight = with(density) { resources.displayMetrics.heightPixels.toDp() },
-                        navBarHeight = navBarHeightDp,
-                        collapsedHeightDp = collapsedHeightDp,
+                        screenHeight = screenHeightDp,
+                        navBarHeight = navBarDp,
+                        collapsedHeightDp = peekDp,
                         onSaveClick = {
-                            // Launch the file saver activity (requires UI context).
-                            val intent = Intent(this@LogKittyOverlayService, com.hereliesaz.logkitty.FileSaverActivity::class.java)
-                            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                            val intent = Intent(this@LogKittyOverlayService,
+                                com.hereliesaz.logkitty.FileSaverActivity::class.java)
+                                .apply { addFlags(Intent.FLAG_ACTIVITY_NEW_TASK) }
                             startActivity(intent)
                         },
                         onSettingsClick = {
-                            // Launch the settings activity.
-                            val intent = Intent(this@LogKittyOverlayService, MainActivity::class.java)
-                            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                            intent.putExtra("EXTRA_SHOW_SETTINGS", true)
+                            val intent = Intent(this@LogKittyOverlayService, MainActivity::class.java).apply {
+                                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                                putExtra("EXTRA_SHOW_SETTINGS", true)
+                            }
                             startActivity(intent)
-                        }
+                        },
                     )
                 }
             }
         }
-
-        // Initialize the LifecycleHelper to enable Jetpack Compose within this Service.
         lifecycleHelper = ComposeLifecycleHelper(composeView!!)
         lifecycleHelper!!.onCreate()
         lifecycleHelper!!.onStart()
 
-        // Define initial window parameters (Collapsed state).
-        val initialHeight = (100 * resources.displayMetrics.density).toInt()
-        
-        val params = WindowManager.LayoutParams(
+        // Initial layout params: position at bottom, height matched to PEEK detent.
+        val initialHeight = peekHeightPx(density, navBarHeightPx, viewModel.fontSize.value)
+        val params = baseLayoutParams(initialHeight, focusable = false)
+        try { windowManager.addView(composeView, params) }
+        catch (e: Exception) { e.printStackTrace() }
+
+        // React to detent changes: resize the window, toggle focusability for back support.
+        serviceScope.launch {
+            controller.detentFlow.collect { detent ->
+                val fontSize = viewModel.fontSize.value
+                val targetHeight = heightForDetent(detent, density, navBarHeightPx, fontSize, screenHeightPx)
+                val needsFocus = detent == SheetDetent.HALF || detent == SheetDetent.FULL
+                updateWindow(targetHeight, focusable = needsFocus)
+            }
+        }
+    }
+
+    /** Sheet height in pixels for the given detent. Mirrors the heights in [LogBottomSheet]. */
+    private fun heightForDetent(
+        detent: SheetDetent,
+        density: Float,
+        navBarHeightPx: Int,
+        fontSize: Int,
+        screenHeightPx: Int,
+    ): Int = when (detent) {
+        SheetDetent.HIDDEN -> (14f * density).toInt().coerceAtLeast(1)
+        SheetDetent.PEEK -> peekHeightPx(density, navBarHeightPx, fontSize)
+        SheetDetent.HALF -> (screenHeightPx * 0.5f).toInt()
+        SheetDetent.FULL -> (screenHeightPx * 0.9f).toInt()
+    }
+
+    private fun peekHeightPx(density: Float, navBarHeightPx: Int, fontSize: Int): Int {
+        val fontPx = fontSize.toFloat() * density
+        val paddingPx = 24f * density
+        return ((fontPx * 1.5f) + paddingPx + navBarHeightPx).toInt()
+    }
+
+    private fun baseLayoutParams(heightPx: Int, focusable: Boolean): WindowManager.LayoutParams {
+        // FLAG_NOT_TOUCH_MODAL is the key flag for passthrough — without it, any touch on the
+        // screen targets this window even outside its drawn bounds. With it, only touches inside
+        // the window's bounds reach us; everything else continues to the underlying app.
+        val flagsBase = WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS or
+            WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN or
+            WindowManager.LayoutParams.FLAG_NOT_TOUCH_MODAL
+        val flags = if (focusable) flagsBase
+        else flagsBase or
+            WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE or
+            WindowManager.LayoutParams.FLAG_ALT_FOCUSABLE_IM
+        return WindowManager.LayoutParams(
             WindowManager.LayoutParams.MATCH_PARENT,
-            initialHeight,
-            WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY, // Required for drawing over other apps (API 26+)
-            WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE or // Don't steal key input (allows typing in other apps)
-                    WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS or // Allow drawing behind system bars
-                    WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN, // Use absolute coordinates
-            PixelFormat.TRANSLUCENT // Transparent background
+            heightPx,
+            WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY,
+            flags,
+            PixelFormat.TRANSLUCENT
         ).apply {
             gravity = Gravity.BOTTOM
-            y = 0 // Anchor to the absolute bottom
-        }
-
-        try {
-            windowManager.addView(composeView, params)
-        } catch (e: Exception) {
-            e.printStackTrace()
+            y = 0
         }
     }
 
-    /**
-     * Expands the WindowManager layout to cover the entire screen.
-     * @param forceTouchable If true, ensures the window accepts touches immediately (removes FLAG_NOT_TOUCHABLE).
-     */
-    private fun setWindowToFullScreen(forceTouchable: Boolean) {
-        val params = composeView?.layoutParams as? WindowManager.LayoutParams ?: return
-        if (params.height != WindowManager.LayoutParams.MATCH_PARENT) {
-            params.height = WindowManager.LayoutParams.MATCH_PARENT
-            // Remove FLAG_NOT_TOUCHABLE so we can interact with the full UI.
-            params.flags = params.flags and WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE.inv()
-            try { windowManager.updateViewLayout(composeView, params) } catch (e: Exception) { android.util.Log.e("LogKittyOverlayService", "Failed to update window to full screen", e) }
+    private fun updateWindow(heightPx: Int, focusable: Boolean) {
+        val view = composeView ?: return
+        val params = view.layoutParams as? WindowManager.LayoutParams ?: return
+        params.height = heightPx
+        params.flags = baseLayoutParams(heightPx, focusable).flags
+        try { windowManager.updateViewLayout(view, params) }
+        catch (e: Exception) { e.printStackTrace() }
+    }
+
+    /** Intercepts back-button so HALF/FULL collapses to HIDDEN before the app gets it. */
+    private fun onBack(): Boolean {
+        return when (controller.detent) {
+            SheetDetent.HALF, SheetDetent.FULL -> { controller.hide(); true }
+            else -> false
         }
     }
 
-    /**
-     * Shrinks the WindowManager layout to just the height of the collapsed "peek" strip.
-     * This is crucial: it allows clicks on the rest of the screen to pass through to the underlying app.
-     * @param heightPx The target height in pixels.
-     */
-    private fun setWindowToCollapsed(heightPx: Int) {
-        val params = composeView?.layoutParams as? WindowManager.LayoutParams ?: return
-        if (params.height != heightPx) {
-            params.height = heightPx
-            // Remove FLAG_NOT_TOUCHABLE (logic seems redundant here, but ensures we are in a known state).
-            // Note: Even with this flag removed, because the window SIZE is small, touches outside it pass through.
-            params.flags = params.flags and WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE.inv()
-            try { windowManager.updateViewLayout(composeView, params) } catch (e: Exception) { e.printStackTrace() }
-        }
-    }
-
-    /**
-     * Creates the Notification Channel required for Android O+.
-     */
     private fun createNotificationChannel() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            val channel = NotificationChannel(
-                CHANNEL_ID,
-                "Overlay Service",
-                NotificationManager.IMPORTANCE_LOW // Low importance to avoid sound/vibration
-            )
-            val manager = getSystemService(NotificationManager::class.java)
-            manager.createNotificationChannel(channel)
+            val channel = NotificationChannel(CHANNEL_ID, "Overlay Service", NotificationManager.IMPORTANCE_LOW)
+            getSystemService(NotificationManager::class.java).createNotificationChannel(channel)
         }
     }
 
-    /**
-     * Builds the persistent notification for the Foreground Service.
-     */
     private fun createNotification(): Notification {
-        val stopIntent = Intent(this, LogKittyOverlayService::class.java).apply {
-            action = ACTION_STOP_SERVICE
-        }
-        val stopPendingIntent = PendingIntent.getService(
-            this, 0, stopIntent, PendingIntent.FLAG_IMMUTABLE
-        )
-
-        val settingsIntent = Intent(this, LogKittyOverlayService::class.java).apply {
-            action = ACTION_OPEN_SETTINGS
-        }
-        val settingsPendingIntent = PendingIntent.getService(
-            this, 1, settingsIntent, PendingIntent.FLAG_IMMUTABLE
-        )
-
-        // Standard icon (ensure it exists in drawable resources)
-        val icon = android.R.drawable.ic_menu_view
-
+        val stopIntent = Intent(this, LogKittyOverlayService::class.java).apply { action = ACTION_STOP_SERVICE }
+        val stopPending = PendingIntent.getService(this, 0, stopIntent, PendingIntent.FLAG_IMMUTABLE)
+        val settingsIntent = Intent(this, LogKittyOverlayService::class.java).apply { action = ACTION_OPEN_SETTINGS }
+        val settingsPending = PendingIntent.getService(this, 1, settingsIntent, PendingIntent.FLAG_IMMUTABLE)
         return NotificationCompat.Builder(this, CHANNEL_ID)
             .setContentTitle("LogKitty Running")
             .setContentText("Tap to Stop. Expand for Settings.")
-            .setSmallIcon(icon)
-            .setContentIntent(stopPendingIntent) // Tapping notification stops service (maybe change to open settings?)
-            .addAction(android.R.drawable.ic_menu_close_clear_cancel, "Stop Service", stopPendingIntent)
-            .addAction(android.R.drawable.ic_menu_preferences, "App Settings", settingsPendingIntent)
+            .setSmallIcon(android.R.drawable.ic_menu_view)
+            .setContentIntent(stopPending)
+            .addAction(android.R.drawable.ic_menu_close_clear_cancel, "Stop Service", stopPending)
+            .addAction(android.R.drawable.ic_menu_preferences, "App Settings", settingsPending)
             .setOngoing(true)
             .setForegroundServiceBehavior(NotificationCompat.FOREGROUND_SERVICE_IMMEDIATE)
             .build()
     }
 
     companion object {
-        private const val CHANNEL_ID = "ideaz_overlay_channel"
+        private const val CHANNEL_ID = "logkitty_overlay_channel"
         private const val SERVICE_ID = 1001
         private const val ACTION_STOP_SERVICE = "com.hereliesaz.logkitty.STOP_SERVICE"
         private const val ACTION_OPEN_SETTINGS = "com.hereliesaz.logkitty.OPEN_SETTINGS"

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/services/LogKittyOverlayService.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/services/LogKittyOverlayService.kt
@@ -138,14 +138,16 @@ class LogKittyOverlayService : Service() {
         val resourceId = resources.getIdentifier("navigation_bar_height", "dimen", "android")
         val navBarHeightPx = if (resourceId > 0) resources.getDimensionPixelSize(resourceId) else 0
 
-        composeView = object : ComposeView(this) {
-            override fun dispatchKeyEvent(event: KeyEvent): Boolean {
-                if (event.keyCode == KeyEvent.KEYCODE_BACK && event.action == KeyEvent.ACTION_UP) {
-                    if (onBack()) return true
+        composeView = ComposeView(this).apply {
+            // ComposeView is final in modern Compose, so we intercept back via an OnKeyListener
+            // instead of subclassing. The listener fires only when the window is focusable
+            // (HALF/FULL detent), which is exactly when we want to capture back.
+            setOnKeyListener { _, keyCode, event ->
+                if (keyCode == KeyEvent.KEYCODE_BACK && event.action == KeyEvent.ACTION_UP) {
+                    if (onBack()) return@setOnKeyListener true
                 }
-                return super.dispatchKeyEvent(event)
+                false
             }
-        }.apply {
             setContent {
                 val composeDensity = LocalDensity.current
                 val fontSizeInt by viewModel.fontSize.collectAsState()
@@ -247,6 +249,7 @@ class LogKittyOverlayService : Service() {
 
     private fun updateWindow(heightPx: Int, focusable: Boolean) {
         val view = composeView ?: return
+        if (!view.isAttachedToWindow) return
         val params = view.layoutParams as? WindowManager.LayoutParams ?: return
         params.height = heightPx
         params.flags = baseLayoutParams(heightPx, focusable).flags

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/ColorSchemeEditorScreen.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/ColorSchemeEditorScreen.kt
@@ -1,0 +1,116 @@
+package com.hereliesaz.logkitty.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.dp
+
+/**
+ * Per-level color customization. Selecting a swatch opens the [ColorPickerDialog] for that
+ * level and persists the choice via [MainViewModel.setLogColor], which also switches the
+ * active scheme to CUSTOM.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ColorSchemeEditorScreen(
+    viewModel: MainViewModel,
+    onBack: () -> Unit,
+) {
+    val logColors by viewModel.logColors.collectAsState()
+    val scheme by viewModel.colorScheme.collectAsState()
+
+    var editingLevel by remember { mutableStateOf<LogLevel?>(null) }
+    editingLevel?.let { level ->
+        ColorPickerDialog(
+            initialColor = logColors[level] ?: level.defaultColor,
+            onDismiss = { editingLevel = null },
+            onColorSelected = {
+                viewModel.setLogColor(level, it)
+                editingLevel = null
+            }
+        )
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Log Colors — ${scheme.displayName}") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, "Back")
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(16.dp)
+        ) {
+            Text(
+                "Tap a swatch to customize. Editing any color switches the active scheme to Custom.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            HorizontalDivider(modifier = Modifier.padding(vertical = 12.dp))
+
+            LogLevel.values().forEach { level ->
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable { editingLevel = level }
+                        .padding(vertical = 10.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
+                    Column {
+                        Text(level.name, style = MaterialTheme.typography.bodyLarge)
+                        Text(
+                            "Letter: ${level.letter}",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                    Box(
+                        modifier = Modifier
+                            .size(32.dp)
+                            .clip(CircleShape)
+                            .background(logColors[level] ?: level.defaultColor)
+                            .border(1.dp, MaterialTheme.colorScheme.outline, CircleShape)
+                    )
+                }
+                HorizontalDivider()
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/LogBottomSheet.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/LogBottomSheet.kt
@@ -1,71 +1,109 @@
 package com.hereliesaz.logkitty.ui
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.gestures.detectHorizontalDragGestures
+import androidx.compose.foundation.gestures.detectVerticalDragGestures
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Block
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.Save
+import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Settings
-import androidx.compose.material.icons.filled.Visibility
-import androidx.compose.material.icons.filled.VisibilityOff
-import androidx.compose.material3.*
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ScrollableTabRow
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRowDefaults
 import androidx.compose.material3.TabRowDefaults.tabIndicatorOffset
-import androidx.compose.runtime.*
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.dokar.sheets.BottomSheetState
-import com.dokar.sheets.BottomSheetValue
-import com.dokar.sheets.PeekHeight
-import com.dokar.sheets.m3.BottomSheetLayout
+import com.hereliesaz.logkitty.ui.delegates.IndexedLogLine
 import com.hereliesaz.logkitty.ui.theme.CodingFont
 import com.hereliesaz.logkitty.ui.theme.getGoogleFontFamily
-import kotlinx.coroutines.launch
+import kotlin.math.abs
 
 /**
- * [LogBottomSheet] is the primary UI of the application.
+ * The four-detent overlay rewritten for the new gesture and tab model.
  *
- * It acts as the "Face" of LogKitty, rendering the floating window content.
+ * **Detents**
+ *   HIDDEN  – a thin invisible grab-strip; the window shrinks so taps go to the underlying app.
+ *   PEEK    – a one-line ticker showing the latest log entry.
+ *   HALF    – roughly 50% of the screen.
+ *   FULL    – extends so the log fills everything except the bottom 10% of the screen.
  *
- * **Interaction Model:**
- * - **Collapsed:** Shows a tiny "Peek" strip at the bottom (anchored above the nav bar).
- *   Displays the single most recent log line.
- * - **Peek (Half-Expanded):** Shows about 35% of the screen. Good for casual monitoring.
- * - **Expanded:** Shows nearly full screen (limited by system bars) for deep investigation.
+ * **Gestures (handle / header row area)**
+ *   Vertical drag   → step the detent up or down.
+ *   Horizontal drag → switch to the previous/next tab.
  *
- * **Performance:**
- * Uses [LazyColumn] to efficiently render the high-frequency log stream.
+ * **Gestures (below the header)**
+ *   Vertical drag   → scrolls the log (LazyColumn).
+ *   Horizontal drag → switches tabs.
+ *
+ * **Selection model**
+ *   Tap a log line → an action toolbar (copy / search / prohibit) appears at the top of the log area.
+ *   Tap the same line again or use the X in the toolbar to deselect.
  */
 @Composable
 fun LogBottomSheet(
-    sheetState: BottomSheetState,
+    controller: SheetController,
     viewModel: MainViewModel,
     screenHeight: Dp,
     navBarHeight: Dp,
     collapsedHeightDp: Dp,
     onSaveClick: () -> Unit,
-    onSettingsClick: () -> Unit
+    onSettingsClick: () -> Unit,
 ) {
-    val scope = rememberCoroutineScope()
+    val context = LocalContext.current
+    val clipboardManager = LocalClipboardManager.current
 
-    // Check if we are in the smallest state to switch between "Peek View" and "List View".
-    val isHidden = sheetState.value == BottomSheetValue.Collapsed
-
-    // Collect all necessary state from the ViewModel.
-    val systemLogMessages by viewModel.filteredSystemLog.collectAsState()
+    val indexedLog by viewModel.filteredIndexedLog.collectAsState()
     val overlayOpacity by viewModel.overlayOpacity.collectAsState()
     val backgroundColorInt by viewModel.backgroundColor.collectAsState()
     val fontSize by viewModel.fontSize.collectAsState()
@@ -75,123 +113,281 @@ fun LogBottomSheet(
     val selectedTab by viewModel.selectedTab.collectAsState()
     val logColors by viewModel.logColors.collectAsState()
     val isLogReversed by viewModel.isLogReversed.collectAsState()
-    val isContextMode by viewModel.isContextModeEnabled.collectAsState()
+    val tagColoringEnabled by viewModel.tagColoringEnabled.collectAsState()
 
-    val clipboardManager = LocalClipboardManager.current
-    val listState = rememberLazyListState()
-    
-    // Apply user-defined opacity to the background color.
     val sheetBackgroundColor = Color(backgroundColorInt).copy(alpha = overlayOpacity)
-    
-    // Resolve the selected Google Font family.
+
     val currentFontFamily = remember(fontFamilyName) {
         val enumVal = try { CodingFont.valueOf(fontFamilyName) } catch (e: Exception) { CodingFont.SYSTEM }
         getGoogleFontFamily(enumVal.fontName)
     }
 
-    Box(modifier = Modifier.fillMaxSize()) {
+    // Bottom-sheet content always fills the host window — the WindowManager (via [LogKittyOverlayService])
+    // is the source of truth for size, sized exactly to the current detent.
 
-        // --- 1. COLLAPSED VIEW (The "Peek" Strip) ---
-        // This is a custom Box rendered manually when the sheet is collapsed.
-        // We do this because the actual BottomSheet library might hide completely or behave differently
-        // at 0 height. We want a persistent "ticker" at the bottom.
-        if (isHidden) {
-            val rawLatest = systemLogMessages.lastOrNull() ?: "LogKitty Ready"
-            // Strip timestamp if user setting requests it, to save horizontal space in the small strip.
-            val latestLog = if (showTimestamp) rawLatest else rawLatest.replace(Regex("^\\d{2}-\\d{2}\\s\\d{2}:\\d{2}:\\d{2}\\.\\d{3}\\s+"), "")
-            
+    // X-button double-press tracking (clear → hide).
+    var lastClearAt by remember { mutableLongStateOf(0L) }
+
+    var selectedLineId by remember { mutableStateOf<Long?>(null) }
+    val selectedLine = remember(selectedLineId, indexedLog) {
+        selectedLineId?.let { id -> indexedLog.firstOrNull { it.id == id } }
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(sheetBackgroundColor)
+    ) {
+        when (controller.detent) {
+            SheetDetent.HIDDEN -> HiddenHandle(
+                modifier = Modifier.fillMaxSize(),
+                onSwipeUp = { controller.peek() },
+                onTap = { controller.peek() }
+            )
+            SheetDetent.PEEK -> PeekStrip(
+                modifier = Modifier.fillMaxSize(),
+                latest = indexedLog.lastOrNull()?.text ?: "LogKitty Ready",
+                showTimestamp = showTimestamp,
+                fontFamily = currentFontFamily,
+                fontSize = fontSize,
+                navBarHeight = navBarHeight,
+                onTap = { controller.half() },
+                onSwipeUp = { controller.stepUp() },
+                onSwipeDown = { controller.hide() },
+                onSwipeLeft = { viewModel.selectNextTab() },
+                onSwipeRight = { viewModel.selectPreviousTab() }
+            )
+            SheetDetent.HALF, SheetDetent.FULL -> ExpandedView(
+                tabs = tabs,
+                selectedTab = selectedTab,
+                indexedLog = indexedLog,
+                logColors = logColors,
+                tagColoringEnabled = tagColoringEnabled,
+                fontFamily = currentFontFamily,
+                fontSize = fontSize,
+                showTimestamp = showTimestamp,
+                isLogReversed = isLogReversed,
+                navBarHeight = navBarHeight,
+                selectedLine = selectedLine,
+                onSelectLine = { id -> selectedLineId = if (selectedLineId == id) null else id },
+                onClearSelection = { selectedLineId = null },
+                onTabSelected = { viewModel.selectTab(it) },
+                onCloseAppTab = { viewModel.closeTab(it) },
+                onSwipeLeft = { viewModel.selectNextTab() },
+                onSwipeRight = { viewModel.selectPreviousTab() },
+                onHeaderDragUp = { controller.stepUp() },
+                onHeaderDragDown = { controller.stepDown() },
+                onSaveClick = {
+                    controller.hide()
+                    onSaveClick()
+                },
+                onSettingsClick = {
+                    controller.hide()
+                    onSettingsClick()
+                },
+                onClearClick = {
+                    val now = System.currentTimeMillis()
+                    if (now - lastClearAt < 3000L) {
+                        controller.hide()
+                        lastClearAt = 0L
+                    } else {
+                        viewModel.clearActiveTab()
+                        lastClearAt = now
+                    }
+                },
+                onCopyLine = { line ->
+                    clipboardManager.setText(AnnotatedString(line.text))
+                    selectedLineId = null
+                },
+                onSearchLine = { line ->
+                    val query = java.net.URLEncoder.encode(line.text, "UTF-8")
+                    val intent = android.content.Intent(android.content.Intent.ACTION_VIEW,
+                        android.net.Uri.parse("https://www.google.com/search?q=$query")).apply {
+                        addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK)
+                    }
+                    runCatching { context.startActivity(intent) }
+                    selectedLineId = null
+                },
+                onProhibitLine = { line ->
+                    viewModel.prohibitLog(line.text)
+                    selectedLineId = null
+                },
+            )
+        }
+    }
+}
+
+@Composable
+private fun HiddenHandle(
+    modifier: Modifier,
+    onSwipeUp: () -> Unit,
+    onTap: () -> Unit,
+) {
+    Box(
+        modifier = modifier
+            .pointerInputVerticalDrag(
+                threshold = 16f,
+                onUp = onSwipeUp,
+                onDown = { }
+            )
+            .clickable(
+                indication = null,
+                interactionSource = remember { MutableInteractionSource() }
+            ) { onTap() },
+        contentAlignment = Alignment.Center
+    ) {
+        Box(
+            modifier = Modifier
+                .width(48.dp)
+                .height(2.dp)
+                .clip(RoundedCornerShape(1.dp))
+                .background(Color.White.copy(alpha = 0.35f))
+        )
+    }
+}
+
+@Composable
+private fun PeekStrip(
+    modifier: Modifier,
+    latest: String,
+    showTimestamp: Boolean,
+    fontFamily: androidx.compose.ui.text.font.FontFamily?,
+    fontSize: Int,
+    navBarHeight: Dp,
+    onTap: () -> Unit,
+    onSwipeUp: () -> Unit,
+    onSwipeDown: () -> Unit,
+    onSwipeLeft: () -> Unit,
+    onSwipeRight: () -> Unit,
+) {
+    val displayText = if (showTimestamp) latest else latest.replace(
+        Regex("^\\d{2}-\\d{2}\\s\\d{2}:\\d{2}:\\d{2}\\.\\d{3}\\s+"), ""
+    )
+
+    Box(
+        modifier = modifier
+            .pointerInputVerticalDrag(threshold = 24f, onUp = onSwipeUp, onDown = onSwipeDown)
+            .pointerInputHorizontalDrag(threshold = 48f, onLeft = onSwipeLeft, onRight = onSwipeRight)
+            .clickable(
+                indication = null,
+                interactionSource = remember { MutableInteractionSource() }
+            ) { onTap() }
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(bottom = navBarHeight)
+                .fillMaxHeight(),
+            contentAlignment = Alignment.CenterStart
+        ) {
+            ThinHandle(modifier = Modifier.align(Alignment.TopCenter))
+            Text(
+                text = displayText,
+                fontFamily = fontFamily,
+                fontSize = fontSize.sp,
+                style = MaterialTheme.typography.bodySmall,
+                modifier = Modifier.padding(start = 12.dp, end = 12.dp, top = 8.dp),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                color = Color.White
+            )
+        }
+    }
+}
+
+@Composable
+private fun ThinHandle(modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier
+            .padding(top = 4.dp)
+            .width(48.dp)
+            .height(2.dp)
+            .clip(RoundedCornerShape(1.dp))
+            .background(Color.White.copy(alpha = 0.4f))
+    )
+}
+
+@Composable
+private fun ExpandedView(
+    tabs: List<LogTab>,
+    selectedTab: LogTab,
+    indexedLog: List<IndexedLogLine>,
+    logColors: Map<LogLevel, Color>,
+    tagColoringEnabled: Boolean,
+    fontFamily: androidx.compose.ui.text.font.FontFamily?,
+    fontSize: Int,
+    showTimestamp: Boolean,
+    isLogReversed: Boolean,
+    navBarHeight: Dp,
+    selectedLine: IndexedLogLine?,
+    onSelectLine: (Long) -> Unit,
+    onClearSelection: () -> Unit,
+    onTabSelected: (LogTab) -> Unit,
+    onCloseAppTab: (LogTab) -> Unit,
+    onSwipeLeft: () -> Unit,
+    onSwipeRight: () -> Unit,
+    onHeaderDragUp: () -> Unit,
+    onHeaderDragDown: () -> Unit,
+    onSaveClick: () -> Unit,
+    onSettingsClick: () -> Unit,
+    onClearClick: () -> Unit,
+    onCopyLine: (IndexedLogLine) -> Unit,
+    onSearchLine: (IndexedLogLine) -> Unit,
+    onProhibitLine: (IndexedLogLine) -> Unit,
+) {
+    Column(modifier = Modifier.fillMaxSize()) {
+
+        // --- Header zone: handle + tabs + icons (vertical drag = detent, horizontal = tab swap) ---
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .pointerInputVerticalDrag(threshold = 18f, onUp = onHeaderDragUp, onDown = onHeaderDragDown)
+                .pointerInputHorizontalDrag(threshold = 48f, onLeft = onSwipeLeft, onRight = onSwipeRight)
+        ) {
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .height(collapsedHeightDp)
-                    .align(Alignment.BottomCenter)
-                    .background(sheetBackgroundColor)
-                    // Tapping the strip expands it to the "Peek" (35%) state.
-                    .clickable { scope.launch { sheetState.peek() } }
+                    .padding(vertical = 6.dp),
+                contentAlignment = Alignment.Center
             ) {
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        // Ensure we respect the system navigation bar so we don't draw under the gesture area/buttons.
-                        .padding(bottom = navBarHeight)
-                        .fillMaxHeight(),
-                    contentAlignment = Alignment.CenterStart
-                ) {
-                    // Visual Drag Handle indicator
-                    Box(
-                        modifier = Modifier
-                            .align(Alignment.TopCenter)
-                            .width(40.dp)
-                            .height(4.dp)
-                            .padding(top = 4.dp)
-                            .clip(RoundedCornerShape(2.dp))
-                            .background(Color.Gray.copy(alpha = 0.5f))
-                    )
-                    // The single line of log text.
-                    Text(
-                        text = latestLog,
-                        fontFamily = currentFontFamily,
-                        fontSize = fontSize.sp,
-                        style = MaterialTheme.typography.bodySmall,
-                        modifier = Modifier.padding(start = 8.dp, end = 8.dp, top = 8.dp),
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                        color = Color.White
-                    )
-                }
+                ThinHandle()
             }
-        }
 
-        // --- 2. EXPANDED VIEW (The Actual Bottom Sheet) ---
-        BottomSheetLayout(
-            state = sheetState,
-            // We define the "Peek" height as 35% of the screen.
-            peekHeight = PeekHeight.dp((screenHeight * 0.35f).value),
-            modifier = Modifier.fillMaxSize(),
-        ) {
-            Column(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .background(sheetBackgroundColor)
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
             ) {
-                // Drag Handle area
-                Box(
-                    modifier = Modifier.fillMaxWidth().padding(vertical = 12.dp),
-                    contentAlignment = Alignment.Center
-                ) {
-                    Box(
-                        modifier = Modifier
-                            .width(48.dp)
-                            .height(6.dp)
-                            .clip(RoundedCornerShape(3.dp))
-                            .background(MaterialTheme.colorScheme.onSurface.copy(alpha = 0.3f))
-                    )
-                }
-
-                // Tab Row (System, Errors, App-specific tabs)
                 ScrollableTabRow(
-                    selectedTabIndex = tabs.indexOf(selectedTab).takeIf { it >= 0 } ?: 0,
-                    edgePadding = 16.dp,
+                    selectedTabIndex = tabs.indexOf(selectedTab).coerceAtLeast(0),
+                    edgePadding = 8.dp,
                     containerColor = Color.Transparent,
                     divider = {},
+                    modifier = Modifier.weight(1f),
                     indicator = { tabPositions ->
                         if (tabs.isNotEmpty()) {
-                            val index = tabs.indexOf(selectedTab).takeIf { it >= 0 } ?: 0
-                            TabRowDefaults.SecondaryIndicator(Modifier.tabIndicatorOffset(tabPositions[index]))
+                            val idx = tabs.indexOf(selectedTab).coerceAtLeast(0)
+                            TabRowDefaults.SecondaryIndicator(Modifier.tabIndicatorOffset(tabPositions[idx]))
                         }
                     }
                 ) {
                     tabs.forEach { tab ->
+                        val isSelected = selectedTab == tab
                         Tab(
-                            selected = selectedTab == tab,
-                            onClick = { viewModel.selectTab(tab) },
-                            text = { 
+                            selected = isSelected,
+                            onClick = { onTabSelected(tab) },
+                            text = {
                                 Row(verticalAlignment = Alignment.CenterVertically) {
-                                    Text(tab.title)
-                                    // Allow closing app-specific tabs
-                                    if (tab.type == TabType.APP) {
-                                        IconButton(onClick = { viewModel.closeTab(tab) }, modifier = Modifier.size(16.dp)) {
-                                            Icon(Icons.Default.Close, "Close")
+                                    Text(tab.title, maxLines = 1)
+                                    if (isSelected && tab.type == TabType.APP) {
+                                        IconButton(
+                                            onClick = { onCloseAppTab(tab) },
+                                            modifier = Modifier.size(18.dp)
+                                        ) {
+                                            Icon(
+                                                Icons.Default.Close,
+                                                contentDescription = "Close tab",
+                                                modifier = Modifier.size(14.dp)
+                                            )
                                         }
                                     }
                                 }
@@ -200,81 +396,183 @@ fun LogBottomSheet(
                     }
                 }
 
-                // Main Content Area
-                if (systemLogMessages.isEmpty()) {
-                    Box(modifier = Modifier.weight(1f).fillMaxWidth(), contentAlignment = Alignment.Center) {
-                        Text("No logs", color = Color.Gray)
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    IconButton(onClick = onSaveClick, modifier = Modifier.size(36.dp)) {
+                        Icon(Icons.Default.Save, "Save", tint = MaterialTheme.colorScheme.onSurface)
                     }
-                } else {
-                    LazyColumn(
-                        state = listState,
-                        reverseLayout = isLogReversed,
-                        // Add bottom padding to account for the navbar + some breathing room
-                        contentPadding = PaddingValues(bottom = navBarHeight + 16.dp),
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .weight(1f)
-                            .padding(horizontal = 8.dp)
-                    ) {
-                        itemsIndexed(systemLogMessages) { index, message ->
-                            val displayText = if (showTimestamp) message else message.replace(Regex("^\\d{2}-\\d{2}\\s\\d{2}:\\d{2}:\\d{2}\\.\\d{3}\\s+"), "")
-
-                            // Determine color based on log level
-                            val level = LogLevel.fromLine(message)
-                            val color = logColors[level] ?: Color.White
-
-                            Text(
-                                text = displayText,
-                                fontFamily = currentFontFamily,
-                                fontSize = fontSize.sp,
-                                lineHeight = (fontSize * 1.4).sp,
-                                style = MaterialTheme.typography.bodySmall,
-                                modifier = Modifier.padding(vertical = 0.5.dp),
-                                color = color,
-                                maxLines = 10,
-                                overflow = TextOverflow.Ellipsis
-                            )
-                        }
+                    IconButton(onClick = onSettingsClick, modifier = Modifier.size(36.dp)) {
+                        Icon(Icons.Default.Settings, "Settings", tint = MaterialTheme.colorScheme.onSurface)
+                    }
+                    IconButton(onClick = onClearClick, modifier = Modifier.size(36.dp)) {
+                        Icon(Icons.Default.Clear, "Clear / Hide", tint = MaterialTheme.colorScheme.onSurface)
                     }
                 }
             }
+
+            HorizontalDivider(color = Color.White.copy(alpha = 0.08f))
         }
-        
-        // --- 3. HEADER CONTROLS (Floating Icons) ---
-        // Visible only when expanded/peeking.
-        if (!isHidden) {
-             Row(
+
+        // --- Selection action bar (Copy / Search / Prohibit) ---
+        AnimatedVisibility(visible = selectedLine != null, enter = fadeIn(), exit = fadeOut()) {
+            val line = selectedLine ?: return@AnimatedVisibility
+            Row(
                 modifier = Modifier
-                    .align(Alignment.TopEnd)
-                    .padding(top = 48.dp, end = 16.dp)
+                    .fillMaxWidth()
+                    .background(Color.White.copy(alpha = 0.06f))
+                    .padding(horizontal = 12.dp, vertical = 6.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.End
             ) {
-                // Toggle Context Mode (Eye Icon)
-                IconButton(onClick = { viewModel.toggleContextMode() }) {
-                     Icon(
-                         if (isContextMode) Icons.Default.Visibility else Icons.Default.VisibilityOff,
-                         "Context Mode",
-                         tint = MaterialTheme.colorScheme.onSurface
-                     )
+                Text(
+                    text = "Selected entry",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = Color.White.copy(alpha = 0.75f),
+                    modifier = Modifier.weight(1f)
+                )
+                IconButton(onClick = { onCopyLine(line) }, modifier = Modifier.size(32.dp)) {
+                    Icon(Icons.Default.ContentCopy, "Copy this line", tint = MaterialTheme.colorScheme.onSurface)
                 }
-                // Save to File
-                IconButton(onClick = onSaveClick) {
-                     Icon(Icons.Default.Save, "Save", tint = MaterialTheme.colorScheme.onSurface)
+                IconButton(onClick = { onSearchLine(line) }, modifier = Modifier.size(32.dp)) {
+                    Icon(Icons.Default.Search, "Search Google", tint = MaterialTheme.colorScheme.onSurface)
                 }
-                // Copy All to Clipboard
-                IconButton(onClick = {
-                    scope.launch { clipboardManager.setText(androidx.compose.ui.text.AnnotatedString(systemLogMessages.joinToString("\n"))) }
-                }) {
-                     Icon(Icons.Default.ContentCopy, "Copy", tint = MaterialTheme.colorScheme.onSurface)
+                IconButton(onClick = { onProhibitLine(line) }, modifier = Modifier.size(32.dp)) {
+                    Icon(Icons.Default.Block, "Prohibit this tag", tint = MaterialTheme.colorScheme.onSurface)
                 }
-                // Open Settings
-                IconButton(onClick = onSettingsClick) {
-                     Icon(Icons.Default.Settings, "Settings", tint = MaterialTheme.colorScheme.onSurface)
+                IconButton(onClick = onClearSelection, modifier = Modifier.size(32.dp)) {
+                    Icon(Icons.Default.Close, "Deselect", tint = MaterialTheme.colorScheme.onSurface)
                 }
-                // Clear Logs
-                IconButton(onClick = { viewModel.clearLog() }) {
-                    Icon(Icons.Default.Clear, "Clear", tint = MaterialTheme.colorScheme.onSurface)
+            }
+        }
+
+        // --- Log area (vertical = scroll, horizontal = tab swap) ---
+        val listState = rememberLazyListState()
+        Box(
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxWidth()
+                .pointerInputHorizontalDrag(threshold = 64f, onLeft = onSwipeLeft, onRight = onSwipeRight)
+        ) {
+            if (indexedLog.isEmpty()) {
+                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    Text("No logs", color = Color.Gray)
+                }
+            } else {
+                LazyColumn(
+                    state = listState,
+                    reverseLayout = isLogReversed,
+                    contentPadding = PaddingValues(start = 8.dp, end = 8.dp, bottom = navBarHeight + 8.dp),
+                    modifier = Modifier.fillMaxSize()
+                ) {
+                    items(indexedLog, key = { it.id }) { line ->
+                        LogRow(
+                            line = line,
+                            isSelected = selectedLine?.id == line.id,
+                            showTimestamp = showTimestamp,
+                            fontFamily = fontFamily,
+                            fontSize = fontSize,
+                            colors = logColors,
+                            tagColoringEnabled = tagColoringEnabled,
+                            onClick = { onSelectLine(line.id) }
+                        )
+                    }
                 }
             }
         }
     }
+}
+
+@Composable
+private fun LogRow(
+    line: IndexedLogLine,
+    isSelected: Boolean,
+    showTimestamp: Boolean,
+    fontFamily: androidx.compose.ui.text.font.FontFamily?,
+    fontSize: Int,
+    colors: Map<LogLevel, Color>,
+    tagColoringEnabled: Boolean,
+    onClick: () -> Unit,
+) {
+    val text = if (showTimestamp) line.text else line.text.replace(
+        Regex("^\\d{2}-\\d{2}\\s\\d{2}:\\d{2}:\\d{2}\\.\\d{3}\\s+"), ""
+    )
+    val level = LogLevel.fromLine(line.text)
+    val baseColor = colors[level] ?: Color.White
+    val tagColor = if (tagColoringEnabled) TagColors.colorFor(LogLevel.tagFromLine(line.text)) else null
+
+    val annotated = buildAnnotatedString {
+        if (tagColor != null) {
+            val tag = LogLevel.tagFromLine(line.text)
+            if (!tag.isNullOrBlank() && text.contains(tag)) {
+                val idx = text.indexOf(tag)
+                withStyle(SpanStyle(color = baseColor)) { append(text.substring(0, idx)) }
+                withStyle(SpanStyle(color = tagColor, fontWeight = FontWeight.Bold)) { append(tag) }
+                withStyle(SpanStyle(color = baseColor)) { append(text.substring(idx + tag.length)) }
+                return@buildAnnotatedString
+            }
+        }
+        withStyle(SpanStyle(color = baseColor)) { append(text) }
+    }
+
+    val bg = if (isSelected) Color.White.copy(alpha = 0.10f) else Color.Transparent
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(bg)
+            .clickable(
+                indication = null,
+                interactionSource = remember { MutableInteractionSource() },
+                onClick = onClick
+            )
+            .padding(horizontal = 4.dp, vertical = 1.dp)
+    ) {
+        Text(
+            text = annotated,
+            fontFamily = fontFamily,
+            fontSize = fontSize.sp,
+            lineHeight = (fontSize * 1.35f).sp,
+            style = MaterialTheme.typography.bodySmall,
+            overflow = TextOverflow.Visible
+        )
+    }
+}
+
+/**
+ * Modifier that detects vertical drags above a threshold and triggers either [onUp] (drag up)
+ * or [onDown] (drag down). The gesture is one-shot per drag — small movements within the
+ * threshold are ignored to avoid hijacking taps or list scrolling.
+ */
+private fun Modifier.pointerInputVerticalDrag(
+    threshold: Float,
+    onUp: () -> Unit,
+    onDown: () -> Unit,
+): Modifier = androidx.compose.ui.input.pointer.pointerInput(threshold) {
+    detectVerticalDragGestures(
+        onDragStart = { },
+        onDragEnd = { },
+        onDragCancel = { },
+        onVerticalDrag = { change, dragAmount ->
+            if (abs(dragAmount) > threshold) {
+                change.consume()
+                if (dragAmount < 0) onUp() else onDown()
+            }
+        }
+    )
+}
+
+private fun Modifier.pointerInputHorizontalDrag(
+    threshold: Float,
+    onLeft: () -> Unit,
+    onRight: () -> Unit,
+): Modifier = androidx.compose.ui.input.pointer.pointerInput(threshold) {
+    detectHorizontalDragGestures(
+        onDragStart = { },
+        onDragEnd = { },
+        onDragCancel = { },
+        onHorizontalDrag = { change, dragAmount ->
+            if (abs(dragAmount) > threshold) {
+                change.consume()
+                if (dragAmount < 0) onLeft() else onRight()
+            }
+        }
+    )
 }

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/LogBottomSheet.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/LogBottomSheet.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectHorizontalDragGestures
 import androidx.compose.foundation.gestures.detectVerticalDragGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -200,7 +201,9 @@ fun LogBottomSheet(
                     selectedLineId = null
                 },
                 onSearchLine = { line ->
-                    val query = java.net.URLEncoder.encode(line.text, "UTF-8")
+                    // Cap the query — full log lines (stack traces) can blow past the URL/intent
+                    // size limits and silently fail to launch the browser.
+                    val query = java.net.URLEncoder.encode(line.text.take(500), "UTF-8")
                     val intent = android.content.Intent(android.content.Intent.ACTION_VIEW,
                         android.net.Uri.parse("https://www.google.com/search?q=$query")).apply {
                         addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK)
@@ -537,23 +540,29 @@ private fun LogRow(
 }
 
 /**
- * Modifier that detects vertical drags above a threshold and triggers either [onUp] (drag up)
- * or [onDown] (drag down). The gesture is one-shot per drag — small movements within the
- * threshold are ignored to avoid hijacking taps or list scrolling.
+ * Modifier that fires [onUp] / [onDown] exactly once per gesture when the *accumulated*
+ * vertical displacement crosses [threshold]. The per-frame `dragAmount` reported by
+ * Compose is a delta, not a total — accumulating into `totalDrag` is required, otherwise
+ * fast flicks fire repeatedly and slow drags never fire at all.
  */
 private fun Modifier.pointerInputVerticalDrag(
     threshold: Float,
     onUp: () -> Unit,
     onDown: () -> Unit,
-): Modifier = androidx.compose.ui.input.pointer.pointerInput(threshold) {
+): Modifier = this.pointerInput(threshold) {
+    var totalDrag = 0f
+    var fired = false
     detectVerticalDragGestures(
-        onDragStart = { },
-        onDragEnd = { },
-        onDragCancel = { },
+        onDragStart = { totalDrag = 0f; fired = false },
+        onDragEnd = { totalDrag = 0f; fired = false },
+        onDragCancel = { totalDrag = 0f; fired = false },
         onVerticalDrag = { change, dragAmount ->
-            if (abs(dragAmount) > threshold) {
+            if (fired) return@detectVerticalDragGestures
+            totalDrag += dragAmount
+            if (abs(totalDrag) > threshold) {
+                fired = true
                 change.consume()
-                if (dragAmount < 0) onUp() else onDown()
+                if (totalDrag < 0) onUp() else onDown()
             }
         }
     )
@@ -563,15 +572,20 @@ private fun Modifier.pointerInputHorizontalDrag(
     threshold: Float,
     onLeft: () -> Unit,
     onRight: () -> Unit,
-): Modifier = androidx.compose.ui.input.pointer.pointerInput(threshold) {
+): Modifier = this.pointerInput(threshold) {
+    var totalDrag = 0f
+    var fired = false
     detectHorizontalDragGestures(
-        onDragStart = { },
-        onDragEnd = { },
-        onDragCancel = { },
+        onDragStart = { totalDrag = 0f; fired = false },
+        onDragEnd = { totalDrag = 0f; fired = false },
+        onDragCancel = { totalDrag = 0f; fired = false },
         onHorizontalDrag = { change, dragAmount ->
-            if (abs(dragAmount) > threshold) {
+            if (fired) return@detectHorizontalDragGestures
+            totalDrag += dragAmount
+            if (abs(totalDrag) > threshold) {
+                fired = true
                 change.consume()
-                if (dragAmount < 0) onLeft() else onRight()
+                if (totalDrag < 0) onLeft() else onRight()
             }
         }
     )

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/LogColors.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/LogColors.kt
@@ -3,47 +3,148 @@ package com.hereliesaz.logkitty.ui
 import androidx.compose.ui.graphics.Color
 
 /**
- * [LogLevel] defines the standard Android Logcat levels.
+ * [LogLevel] mirrors the canonical Android Logcat priorities.
  *
- * It includes a heuristic parsing method [fromLine] to determine the level of a raw log string.
+ * The default colors come from the "Material" scheme. The active scheme is resolved at runtime
+ * by [LogColorScheme] which can return either a per-level palette or a tag-aware palette.
  */
 enum class LogLevel(val letter: String, val defaultColor: Color) {
-    VERBOSE("V", Color.White),
-    DEBUG("D", Color(0xFF2196F3)), // Material Blue 500
-    INFO("I", Color(0xFF4CAF50)),  // Material Green 500
-    WARNING("W", Color(0xFFFF9800)), // Material Orange 500
-    ERROR("E", Color(0xFFF44336)),   // Material Red 500
-    ASSERT("A", Color(0xFF9C27B0));  // Material Purple 500
+    VERBOSE("V", Color(0xFFBDBDBD)),
+    DEBUG("D", Color(0xFF2196F3)),
+    INFO("I", Color(0xFF4CAF50)),
+    WARNING("W", Color(0xFFFF9800)),
+    ERROR("E", Color(0xFFF44336)),
+    ASSERT("A", Color(0xFF9C27B0));
 
     companion object {
-        /**
-         * Parses a raw log line to determine its [LogLevel].
-         *
-         * Since `logcat` output formats vary by device and command flags (e.g. `time` vs `threadtime`),
-         * this method uses a heuristic approach looking for standard indicators like " D/" or " E ".
-         */
-        fun fromLine(line: String): LogLevel {
-            // Typical format: "MM-DD HH:MM:SS.mmm PID-TID/Package L/Tag: Message"
-            // or "MM-DD HH:MM:SS.mmm PID TID L Tag: Message"
-            return when {
-                line.contains(" V/") -> VERBOSE
-                line.contains(" D/") -> DEBUG
-                line.contains(" I/") -> INFO
-                line.contains(" W/") -> WARNING
-                line.contains(" E/") -> ERROR
-                line.contains(" A/") -> ASSERT
-                // Fallback for space-delimited formats
-                line.contains(" E ") -> ERROR
-                line.contains(" W ") -> WARNING
-                else -> VERBOSE
-            }
+        private val tagWithLetterRegex = Regex("""\s([VDIWEA])/([^\s:]+)""")
+        private val spacedLevelRegex = Regex("""\s([VDIWEA])\s""")
+
+        fun fromLine(line: String): LogLevel = when {
+            tagWithLetterRegex.find(line)?.groupValues?.getOrNull(1) == "V" -> VERBOSE
+            tagWithLetterRegex.find(line)?.groupValues?.getOrNull(1) == "D" -> DEBUG
+            tagWithLetterRegex.find(line)?.groupValues?.getOrNull(1) == "I" -> INFO
+            tagWithLetterRegex.find(line)?.groupValues?.getOrNull(1) == "W" -> WARNING
+            tagWithLetterRegex.find(line)?.groupValues?.getOrNull(1) == "E" -> ERROR
+            tagWithLetterRegex.find(line)?.groupValues?.getOrNull(1) == "A" -> ASSERT
+            spacedLevelRegex.find(line)?.groupValues?.getOrNull(1) == "E" -> ERROR
+            spacedLevelRegex.find(line)?.groupValues?.getOrNull(1) == "W" -> WARNING
+            spacedLevelRegex.find(line)?.groupValues?.getOrNull(1) == "A" -> ASSERT
+            spacedLevelRegex.find(line)?.groupValues?.getOrNull(1) == "I" -> INFO
+            spacedLevelRegex.find(line)?.groupValues?.getOrNull(1) == "D" -> DEBUG
+            spacedLevelRegex.find(line)?.groupValues?.getOrNull(1) == "V" -> VERBOSE
+            else -> VERBOSE
+        }
+
+        fun tagFromLine(line: String): String? {
+            val match = tagWithLetterRegex.find(line) ?: return null
+            return match.groupValues.getOrNull(2)?.trim()?.takeIf { it.isNotEmpty() }
         }
     }
 }
 
 /**
+ * Built-in color schemes for log entries.
+ *
+ * - [MATERIAL]: Modern Material Design palette (default).
+ * - [AOSP]: Mirrors the colors used by Android Studio's Logcat tool window.
+ * - [PIDCAT]: Inspired by Jake Wharton's pidcat — high-contrast terminal tones.
+ * - [MONOCHROME]: Single color per level scaled by intensity, ideal for low-light viewing.
+ * - [SOLARIZED]: Solarized Dark palette for prolonged sessions.
+ * - [CUSTOM]: User-defined per-level colors stored via [com.hereliesaz.logkitty.utils.UserPreferences].
+ */
+enum class LogColorScheme(val displayName: String, val palette: Map<LogLevel, Color>) {
+    MATERIAL("Material", mapOf(
+        LogLevel.VERBOSE to Color(0xFFBDBDBD),
+        LogLevel.DEBUG to Color(0xFF2196F3),
+        LogLevel.INFO to Color(0xFF4CAF50),
+        LogLevel.WARNING to Color(0xFFFF9800),
+        LogLevel.ERROR to Color(0xFFF44336),
+        LogLevel.ASSERT to Color(0xFF9C27B0),
+    )),
+    AOSP("Android Studio", mapOf(
+        LogLevel.VERBOSE to Color(0xFFBBBBBB),
+        LogLevel.DEBUG to Color(0xFF6897BB),
+        LogLevel.INFO to Color(0xFF6A8759),
+        LogLevel.WARNING to Color(0xFFBBB529),
+        LogLevel.ERROR to Color(0xFFFF6B68),
+        LogLevel.ASSERT to Color(0xFFCC7832),
+    )),
+    PIDCAT("Pidcat", mapOf(
+        LogLevel.VERBOSE to Color(0xFFAAAAAA),
+        LogLevel.DEBUG to Color(0xFF00FFFF),
+        LogLevel.INFO to Color(0xFF00FF00),
+        LogLevel.WARNING to Color(0xFFFFFF00),
+        LogLevel.ERROR to Color(0xFFFF0033),
+        LogLevel.ASSERT to Color(0xFFFF66FF),
+    )),
+    MONOCHROME("Monochrome", mapOf(
+        LogLevel.VERBOSE to Color(0xFF666666),
+        LogLevel.DEBUG to Color(0xFF888888),
+        LogLevel.INFO to Color(0xFFAAAAAA),
+        LogLevel.WARNING to Color(0xFFCCCCCC),
+        LogLevel.ERROR to Color(0xFFFFFFFF),
+        LogLevel.ASSERT to Color(0xFFFFFFFF),
+    )),
+    SOLARIZED("Solarized Dark", mapOf(
+        LogLevel.VERBOSE to Color(0xFF93A1A1),
+        LogLevel.DEBUG to Color(0xFF268BD2),
+        LogLevel.INFO to Color(0xFF859900),
+        LogLevel.WARNING to Color(0xFFB58900),
+        LogLevel.ERROR to Color(0xFFDC322F),
+        LogLevel.ASSERT to Color(0xFFD33682),
+    )),
+    CUSTOM("Custom", MATERIAL.palette);
+
+    fun colorFor(level: LogLevel): Color = palette[level] ?: Color.White
+}
+
+/**
+ * Tag-based color overrides applied on top of the level color.
+ *
+ * Returns a color for the *tag portion* of a log line when the tag matches one of the
+ * common Android system components. This delivers richer visual cues without forcing the user
+ * to manage per-tag mappings manually.
+ */
+object TagColors {
+    private val rules: List<Pair<Regex, Color>> = listOf(
+        Regex("^ActivityManager$") to Color(0xFF80DEEA),
+        Regex("^ActivityTaskManager$") to Color(0xFF80DEEA),
+        Regex("^PackageManager$") to Color(0xFFA5D6A7),
+        Regex("^WindowManager$") to Color(0xFFCE93D8),
+        Regex("^InputMethodManager$") to Color(0xFFFFE082),
+        Regex("^ConnectivityService$") to Color(0xFF90CAF9),
+        Regex("^WifiService$") to Color(0xFF90CAF9),
+        Regex("^Bluetooth.*") to Color(0xFF82B1FF),
+        Regex("^Choreographer$") to Color(0xFFFFAB91),
+        Regex("^SurfaceFlinger$") to Color(0xFFB39DDB),
+        Regex("^OpenGLRenderer$") to Color(0xFFB39DDB),
+        Regex("^GraphicsEnvironment$") to Color(0xFFB39DDB),
+        Regex("^System\\.err$") to Color(0xFFEF9A9A),
+        Regex("^AndroidRuntime$") to Color(0xFFEF9A9A),
+        Regex("^DEBUG$") to Color(0xFFEF9A9A),
+        Regex("^libc(\\-?[a-z]*)?$") to Color(0xFFEF9A9A),
+        Regex("^GooglePlayServices.*") to Color(0xFFFFD54F),
+        Regex("^Firebase.*") to Color(0xFFFFD54F),
+        Regex("^Glide$") to Color(0xFFFFCC80),
+        Regex("^OkHttp$") to Color(0xFFFFCC80),
+        Regex("^chromium$", RegexOption.IGNORE_CASE) to Color(0xFFAED581),
+        Regex("^StrictMode$") to Color(0xFFFFB74D),
+        Regex("^GC.*") to Color(0xFFA1887F),
+        Regex("^art$") to Color(0xFFA1887F),
+        Regex("^zygote.*") to Color(0xFFA1887F),
+        Regex("^Compose.*") to Color(0xFF80CBC4),
+    )
+
+    fun colorFor(tag: String?): Color? {
+        if (tag.isNullOrBlank()) return null
+        return rules.firstOrNull { it.first.containsMatchIn(tag) }?.second
+    }
+}
+
+/**
  * Data class representing the full color scheme for logs.
- * Used for theming and persistence.
+ * Maintained for backward compatibility with code that referenced this older shape.
  */
 data class ColorScheme(
     val verbose: Color = LogLevel.VERBOSE.defaultColor,

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/MainViewModel.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/MainViewModel.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.hereliesaz.logkitty.services.LogKittyAccessibilityService
+import com.hereliesaz.logkitty.ui.delegates.IndexedLogLine
 import com.hereliesaz.logkitty.ui.delegates.StateDelegate
 import com.hereliesaz.logkitty.ui.theme.CodingFont
 import com.hereliesaz.logkitty.utils.LogcatReader
@@ -18,6 +19,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -85,6 +87,14 @@ class MainViewModel(
     val showTimestamp: StateFlow<Boolean> = userPreferences.showTimestamp
     val bufferSize: StateFlow<Int> = userPreferences.bufferSize
     val activeLogLevels: StateFlow<Set<String>> = userPreferences.activeLogLevels
+    val colorScheme: StateFlow<LogColorScheme> = userPreferences.colorScheme
+    val tagColoringEnabled: StateFlow<Boolean> = userPreferences.tagColoringEnabled
+
+    /**
+     * Per-tab "cleared" baseline. When the user clears a single tab we record the size of the
+     * underlying log buffer at that moment and skip everything before it for that tab only.
+     */
+    private val _tabClearMarks = MutableStateFlow<Map<String, Long>>(emptyMap())
 
     // Tab Management
     private val systemTab = LogTab("system", "System", TabType.SYSTEM)
@@ -96,59 +106,56 @@ class MainViewModel(
     private val _selectedTab = MutableStateFlow(systemTab)
     val selectedTab: StateFlow<LogTab> = _selectedTab
 
-    // --- The Core Pipeline ---
-    // This Flow combines all inputs to produce the final list of logs shown on screen.
-    // It re-runs whenever any of the inputs (logs, tab, filter, etc.) change.
-    val filteredSystemLog = combine(
-        stateDelegate.systemLog,
-        _selectedTab,
-        customFilter,
-        prohibitedTags,
-        activeLogLevels
-    ) { logs, tab, userFilter, prohibited, levels ->
-        var result = logs
+    private data class FilterInputs(
+        val tab: LogTab,
+        val userFilter: String,
+        val prohibited: Set<String>,
+        val levels: Set<String>,
+        val marks: Map<String, Long>
+    )
 
-        // 1. Filter Log Levels (Verbose, Debug, Info, etc.)
-        // Optimization: Only run if some levels are actually disabled.
-        if (levels.size < LogLevel.values().size) {
-            result = result.filter { line ->
-                val level = LogLevel.fromLine(line)
-                levels.contains(level.name)
-            }
+    /**
+     * Indexed, filtered view of the log stream for the current tab.
+     * Each entry preserves its global id so the UI can stably select / copy / prohibit it.
+     */
+    val filteredIndexedLog: StateFlow<List<IndexedLogLine>> = run {
+        val inputs = combine(_selectedTab, customFilter, prohibitedTags, activeLogLevels, _tabClearMarks) {
+            tab, userFilter, prohibited, levels, marks -> FilterInputs(tab, userFilter, prohibited, levels, marks)
         }
+        combine(stateDelegate.systemLog, inputs) { logs, input ->
+            val clearMark = input.marks[input.tab.id] ?: 0L
+            var result: List<IndexedLogLine> = if (clearMark > 0L) logs.filter { it.id > clearMark } else logs
 
-        // 2. Filter prohibited tags (Blacklist)
-        if (prohibited.isNotEmpty()) {
-            result = result.filter { logLine ->
-                // Check if any prohibited tag exists in the line.
-                // Case-insensitive for better UX.
-                prohibited.none { tag -> logLine.contains(tag, ignoreCase = true) }
+            if (input.levels.size < LogLevel.values().size) {
+                result = result.filter { line -> input.levels.contains(LogLevel.fromLine(line.text).name) }
             }
-        }
-
-        // 3. Tab-based filtering
-        when (tab.type) {
-            TabType.SYSTEM -> { /* Show all (subject to other filters) */ }
-            TabType.ERRORS -> {
-                // Heuristic for finding error logs.
-                result = result.filter { it.contains(" E/") || it.contains(" E ") }
+            if (input.prohibited.isNotEmpty()) {
+                result = result.filter { line -> input.prohibited.none { tag -> line.text.contains(tag, ignoreCase = true) } }
             }
-            TabType.APP -> {
-                // Show logs containing the package name.
-                val pkg = tab.filterValue
-                if (!pkg.isNullOrBlank()) {
-                    result = result.filter { it.contains(pkg, ignoreCase = true) }
+            when (input.tab.type) {
+                TabType.SYSTEM -> { }
+                TabType.ERRORS -> result = result.filter {
+                    val lvl = LogLevel.fromLine(it.text)
+                    lvl == LogLevel.ERROR || lvl == LogLevel.ASSERT
+                }
+                TabType.APP -> {
+                    val pkg = input.tab.filterValue
+                    if (!pkg.isNullOrBlank()) result = result.filter { it.text.contains(pkg, ignoreCase = true) }
                 }
             }
-        }
+            if (input.userFilter.isNotBlank()) {
+                result = result.filter { it.text.contains(input.userFilter, ignoreCase = true) }
+            }
+            result
+        }.stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
+    }
 
-        // 4. User custom text filter (Search bar)
-        if (userFilter.isNotBlank()) {
-            result = result.filter { it.contains(userFilter, ignoreCase = true) }
-        }
-
-        result
-    }.stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
+    /**
+     * Backward-compatible textual view retained for callers (e.g. FileSaverActivity).
+     */
+    val filteredSystemLog: StateFlow<List<String>> = filteredIndexedLog
+        .map { list -> list.map { it.text } }
+        .stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
 
     // --- Accessibility Receiver ---
     // Listens for broadcasts from LogKittyAccessibilityService.
@@ -209,14 +216,35 @@ class MainViewModel(
         _selectedTab.value = tab
     }
 
+    /** Move selection one tab forward / back, wrapping at the ends. */
+    fun selectNextTab() = shiftSelection(+1)
+    fun selectPreviousTab() = shiftSelection(-1)
+
+    private fun shiftSelection(delta: Int) {
+        val list = _tabs.value
+        if (list.isEmpty()) return
+        val idx = list.indexOf(_selectedTab.value).takeIf { it >= 0 } ?: 0
+        val newIdx = ((idx + delta) % list.size + list.size) % list.size
+        _selectedTab.value = list[newIdx]
+    }
+
     fun closeTab(tab: LogTab) {
         if (tab.type == TabType.APP) {
             _tabs.update { it - tab }
-            // If we closed the active tab, switch back to System.
             if (_selectedTab.value == tab) {
                 _selectedTab.value = _tabs.value.firstOrNull() ?: systemTab
             }
+            _tabClearMarks.update { it - tab.id }
         }
+    }
+
+    /**
+     * Clears only the active tab by recording the current max id as that tab's "skip line".
+     * Other tabs continue to see historical data.
+     */
+    fun clearActiveTab() {
+        val tabId = _selectedTab.value.id
+        _tabClearMarks.update { it + (tabId to stateDelegate.currentMaxId) }
     }
 
     override fun onCleared() {
@@ -230,7 +258,15 @@ class MainViewModel(
 
     // --- Actions Delegate to Data Layer ---
 
-    fun clearLog() = stateDelegate.clearLog()
+    /** Clears the entire shared log buffer (all tabs). */
+    fun clearLog() {
+        stateDelegate.clearLog()
+        _tabClearMarks.value = emptyMap()
+    }
+
+    fun setTagColoringEnabled(enabled: Boolean) {
+        userPreferences.setTagColoringEnabled(enabled)
+    }
 
     fun toggleContextMode() {
         userPreferences.setContextModeEnabled(!isContextModeEnabled.value)
@@ -313,6 +349,7 @@ class MainViewModel(
     fun exportPreferences() = userPreferences.exportPreferences()
     fun importPreferences(json: String) = userPreferences.importPreferences(json)
 
-    // Placeholder for future AI prompt features.
-    fun sendPrompt(p: String?) { }
+    fun setColorScheme(scheme: com.hereliesaz.logkitty.ui.LogColorScheme) {
+        userPreferences.setColorScheme(scheme)
+    }
 }

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/SettingsScreen.kt
@@ -1,41 +1,102 @@
 package com.hereliesaz.logkitty.ui
 
+import android.net.Uri
+import android.widget.Toast
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material3.*
-import androidx.compose.runtime.*
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.unit.dp
 import com.hereliesaz.aznavrail.AzButton
 import com.hereliesaz.aznavrail.model.AzButtonShape
 import com.hereliesaz.logkitty.ui.theme.CodingFont
 
 /**
- * [SettingsScreen] provides a full-screen configuration UI.
- *
- * It allows the user to tweak every aspect of the app:
- * - **Appearance:** Opacity, Background Color, Fonts, Timestamps.
- * - **Behavior:** Log Buffer Size, Active Log Levels, Filtering modes.
- * - **Advanced:** Root Access, Log Reversal.
+ * [SettingsScreen] provides a full-screen configuration UI with three navigation targets:
+ * the main settings list, the prohibited-tags manager, and the color-scheme customizer.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SettingsScreen(onBack: () -> Unit, viewModel: MainViewModel) {
+    var currentRoute by remember { mutableStateOf(SettingsRoute.MAIN) }
+
+    when (currentRoute) {
+        SettingsRoute.MAIN -> SettingsMainScreen(
+            viewModel = viewModel,
+            onBack = onBack,
+            onOpenProhibited = { currentRoute = SettingsRoute.PROHIBITED },
+            onOpenColorEditor = { currentRoute = SettingsRoute.COLORS }
+        )
+        SettingsRoute.PROHIBITED -> ProhibitedLogsScreen(
+            viewModel = viewModel,
+            onBack = { currentRoute = SettingsRoute.MAIN }
+        )
+        SettingsRoute.COLORS -> ColorSchemeEditorScreen(
+            viewModel = viewModel,
+            onBack = { currentRoute = SettingsRoute.MAIN }
+        )
+    }
+}
+
+private enum class SettingsRoute { MAIN, PROHIBITED, COLORS }
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun SettingsMainScreen(
+    viewModel: MainViewModel,
+    onBack: () -> Unit,
+    onOpenProhibited: () -> Unit,
+    onOpenColorEditor: () -> Unit,
+) {
+    val context = LocalContext.current
+    val clipboardManager = LocalClipboardManager.current
     val scrollState = rememberScrollState()
 
-    // Collecting StateFlows from ViewModel
     val overlayOpacity by viewModel.overlayOpacity.collectAsState()
     val backgroundColorInt by viewModel.backgroundColor.collectAsState()
     val isContextMode by viewModel.isContextModeEnabled.collectAsState()
@@ -46,11 +107,13 @@ fun SettingsScreen(onBack: () -> Unit, viewModel: MainViewModel) {
     val showTimestamp by viewModel.showTimestamp.collectAsState()
     val bufferSize by viewModel.bufferSize.collectAsState()
     val activeLevels by viewModel.activeLogLevels.collectAsState()
+    val colorScheme by viewModel.colorScheme.collectAsState()
+    val tagColoringEnabled by viewModel.tagColoringEnabled.collectAsState()
+    val prohibitedCount by viewModel.prohibitedTags.collectAsState()
 
-    // Local state for dialogs
     var showColorPicker by remember { mutableStateOf(false) }
+    var showSchemeMenu by remember { mutableStateOf(false) }
 
-    // Color Picker Dialog Overlay
     if (showColorPicker) {
         ColorPickerDialog(
             initialColor = Color(backgroundColorInt),
@@ -60,6 +123,27 @@ fun SettingsScreen(onBack: () -> Unit, viewModel: MainViewModel) {
                 showColorPicker = false
             }
         )
+    }
+
+    val exportLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.CreateDocument("application/json")
+    ) { uri: Uri? ->
+        if (uri != null) runCatching {
+            context.contentResolver.openOutputStream(uri)?.use { out ->
+                out.write(viewModel.exportPreferences().toByteArray())
+            }
+            Toast.makeText(context, "Preferences exported", Toast.LENGTH_SHORT).show()
+        }.onFailure { Toast.makeText(context, "Export failed: ${it.message}", Toast.LENGTH_LONG).show() }
+    }
+
+    val importLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.OpenDocument()
+    ) { uri: Uri? ->
+        if (uri != null) runCatching {
+            val text = context.contentResolver.openInputStream(uri)?.bufferedReader()?.use { it.readText() } ?: ""
+            val ok = viewModel.importPreferences(text)
+            Toast.makeText(context, if (ok) "Preferences imported" else "Invalid file", Toast.LENGTH_SHORT).show()
+        }.onFailure { Toast.makeText(context, "Import failed: ${it.message}", Toast.LENGTH_LONG).show() }
     }
 
     Scaffold(
@@ -81,11 +165,8 @@ fun SettingsScreen(onBack: () -> Unit, viewModel: MainViewModel) {
                 .verticalScroll(scrollState)
                 .padding(16.dp)
         ) {
-
-            // --- SECTION: APPEARANCE ---
             SettingsSectionHeader("Appearance")
 
-            // Background Color Picker
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -105,8 +186,11 @@ fun SettingsScreen(onBack: () -> Unit, viewModel: MainViewModel) {
             }
             HorizontalDivider()
 
-            // Opacity Slider
-            Text("Background Opacity: ${(overlayOpacity * 100).toInt()}%", style = MaterialTheme.typography.bodyLarge, modifier = Modifier.padding(top = 12.dp))
+            Text(
+                "Background Opacity: ${(overlayOpacity * 100).toInt()}%",
+                style = MaterialTheme.typography.bodyLarge,
+                modifier = Modifier.padding(top = 12.dp)
+            )
             Slider(
                 value = overlayOpacity,
                 onValueChange = { viewModel.setOverlayOpacity(it) },
@@ -115,10 +199,46 @@ fun SettingsScreen(onBack: () -> Unit, viewModel: MainViewModel) {
             )
             HorizontalDivider(modifier = Modifier.padding(vertical = 16.dp))
 
-            // --- SECTION: TYPOGRAPHY ---
-            SettingsSectionHeader("Typography")
+            SettingsSectionHeader("Log Colors")
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(vertical = 6.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text("Color Scheme", style = MaterialTheme.typography.bodyLarge)
+                Box {
+                    OutlinedButton(onClick = { showSchemeMenu = true }) { Text(colorScheme.displayName) }
+                    DropdownMenu(expanded = showSchemeMenu, onDismissRequest = { showSchemeMenu = false }) {
+                        LogColorScheme.values().forEach { scheme ->
+                            DropdownMenuItem(
+                                text = { Text(scheme.displayName) },
+                                onClick = {
+                                    viewModel.setColorScheme(scheme)
+                                    showSchemeMenu = false
+                                }
+                            )
+                        }
+                    }
+                }
+            }
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(vertical = 6.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text("Tag-Based Coloring", style = MaterialTheme.typography.bodyLarge)
+                Switch(checked = tagColoringEnabled, onCheckedChange = { viewModel.setTagColoringEnabled(it) })
+            }
+            AzButton(
+                onClick = onOpenColorEditor,
+                text = "Customize Per-Level Colors",
+                shape = AzButtonShape.RECTANGLE,
+                modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)
+            )
 
-            // Font Size Slider
+            HorizontalDivider(modifier = Modifier.padding(vertical = 16.dp))
+
+            SettingsSectionHeader("Typography")
             Text("Font Size: ${fontSize}sp", style = MaterialTheme.typography.bodyLarge)
             Slider(
                 value = fontSize.toFloat(),
@@ -127,7 +247,6 @@ fun SettingsScreen(onBack: () -> Unit, viewModel: MainViewModel) {
                 steps = 15
             )
 
-            // Font Family Dropdown
             var fontExpanded by remember { mutableStateOf(false) }
             Box(modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp)) {
                 OutlinedButton(
@@ -150,7 +269,6 @@ fun SettingsScreen(onBack: () -> Unit, viewModel: MainViewModel) {
                 }
             }
 
-            // Timestamps Toggle
             Row(
                 modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
                 horizontalArrangement = Arrangement.SpaceBetween,
@@ -161,10 +279,8 @@ fun SettingsScreen(onBack: () -> Unit, viewModel: MainViewModel) {
             }
             HorizontalDivider(modifier = Modifier.padding(vertical = 16.dp))
 
-            // --- SECTION: BEHAVIOR ---
             SettingsSectionHeader("Behavior")
 
-            // Log Level Matrix
             Text("Active Log Levels", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.primary)
             Row(
                 modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
@@ -181,7 +297,6 @@ fun SettingsScreen(onBack: () -> Unit, viewModel: MainViewModel) {
                 }
             }
 
-            // Buffer Size Dropdown
             var bufferExpanded by remember { mutableStateOf(false) }
             Row(
                 modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
@@ -205,7 +320,6 @@ fun SettingsScreen(onBack: () -> Unit, viewModel: MainViewModel) {
                 }
             }
 
-            // Context Mode Toggle
             Row(
                 modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
                 horizontalArrangement = Arrangement.SpaceBetween,
@@ -215,17 +329,15 @@ fun SettingsScreen(onBack: () -> Unit, viewModel: MainViewModel) {
                 Switch(checked = isContextMode, onCheckedChange = { viewModel.toggleContextMode() })
             }
 
-            // Root Access Toggle
             Row(
                 modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                Column(modifier = Modifier.weight(1f)) { Text("Root Access", style = MaterialTheme.typography.bodyLarge) }
+                Text("Root Access", style = MaterialTheme.typography.bodyLarge)
                 Switch(checked = isRootEnabled, onCheckedChange = { viewModel.setRootEnabled(it) })
             }
 
-            // Reverse Log Order Toggle
             Row(
                 modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
                 horizontalArrangement = Arrangement.SpaceBetween,
@@ -236,7 +348,39 @@ fun SettingsScreen(onBack: () -> Unit, viewModel: MainViewModel) {
             }
             HorizontalDivider(modifier = Modifier.padding(vertical = 16.dp))
 
-            // --- ACTIONS ---
+            SettingsSectionHeader("Filters")
+            AzButton(
+                onClick = onOpenProhibited,
+                text = "Prohibited Tags (${prohibitedCount.size})",
+                shape = AzButtonShape.RECTANGLE,
+                modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)
+            )
+            HorizontalDivider(modifier = Modifier.padding(vertical = 16.dp))
+
+            SettingsSectionHeader("Backup")
+            AzButton(
+                onClick = { exportLauncher.launch("logkitty_prefs.json") },
+                text = "Export Preferences",
+                shape = AzButtonShape.RECTANGLE,
+                modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)
+            )
+            AzButton(
+                onClick = { importLauncher.launch(arrayOf("application/json", "text/plain", "*/*")) },
+                text = "Import Preferences",
+                shape = AzButtonShape.RECTANGLE,
+                modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)
+            )
+            AzButton(
+                onClick = {
+                    clipboardManager.setText(AnnotatedString(viewModel.exportPreferences()))
+                    Toast.makeText(context, "Copied to clipboard", Toast.LENGTH_SHORT).show()
+                },
+                text = "Copy Preferences JSON",
+                shape = AzButtonShape.RECTANGLE,
+                modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)
+            )
+            HorizontalDivider(modifier = Modifier.padding(vertical = 16.dp))
+
             AzButton(
                 onClick = { viewModel.clearLog() },
                 text = "Clear Log",
@@ -249,6 +393,7 @@ fun SettingsScreen(onBack: () -> Unit, viewModel: MainViewModel) {
                 shape = AzButtonShape.RECTANGLE,
                 modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)
             )
+            Spacer(modifier = Modifier.height(32.dp))
         }
     }
 }

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/SheetController.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/SheetController.kt
@@ -1,0 +1,65 @@
+package com.hereliesaz.logkitty.ui
+
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.mutableStateOf
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * The four detents supported by the LogKitty overlay.
+ *
+ * - [HIDDEN]: nothing visible except a thin swipe-up grab strip; the window shrinks so the
+ *   underlying app receives every touch except inside that strip.
+ * - [PEEK]: a one-line ticker showing the most recent log entry.
+ * - [HALF]: roughly half-height of the screen, the comfortable "browse" position.
+ * - [FULL]: extended down so the log occupies everything but the bottom 10% of the screen.
+ */
+enum class SheetDetent { HIDDEN, PEEK, HALF, FULL }
+
+/**
+ * Holds the current sheet detent in a way that both the Compose UI and the hosting
+ * Service can read and mutate. The Service uses [detentFlow] to size the WindowManager
+ * window; the UI uses [detent] for animations.
+ *
+ * The controller is created once per overlay session and shared across both worlds.
+ */
+@Stable
+class SheetController {
+    private val _detent = mutableStateOf(SheetDetent.PEEK)
+    /** Compose-friendly mutable state for animations. */
+    var detent: SheetDetent
+        get() = _detent.value
+        set(value) {
+            _detent.value = value
+            _detentFlow.value = value
+        }
+
+    private val _detentFlow = MutableStateFlow(SheetDetent.PEEK)
+    val detentFlow: StateFlow<SheetDetent> = _detentFlow.asStateFlow()
+
+    fun hide() { detent = SheetDetent.HIDDEN }
+    fun peek() { detent = SheetDetent.PEEK }
+    fun half() { detent = SheetDetent.HALF }
+    fun full() { detent = SheetDetent.FULL }
+
+    /** Cycle one detent toward HIDDEN. Stops at HIDDEN. */
+    fun stepDown() {
+        detent = when (detent) {
+            SheetDetent.FULL -> SheetDetent.HALF
+            SheetDetent.HALF -> SheetDetent.PEEK
+            SheetDetent.PEEK -> SheetDetent.HIDDEN
+            SheetDetent.HIDDEN -> SheetDetent.HIDDEN
+        }
+    }
+
+    /** Cycle one detent toward FULL. Stops at FULL. */
+    fun stepUp() {
+        detent = when (detent) {
+            SheetDetent.HIDDEN -> SheetDetent.PEEK
+            SheetDetent.PEEK -> SheetDetent.HALF
+            SheetDetent.HALF -> SheetDetent.FULL
+            SheetDetent.FULL -> SheetDetent.FULL
+        }
+    }
+}

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/delegates/StateDelegate.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/delegates/StateDelegate.kt
@@ -9,6 +9,15 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * A single log line with a strictly increasing identifier.
+ *
+ * The id is the basis for **per-tab clearing**: each tab records the highest id it has
+ * "dismissed", and only lines with a larger id are rendered when that tab is selected.
+ */
+data class IndexedLogLine(val id: Long, val text: String)
 
 /**
  * [StateDelegate] is the single source of truth for the raw log data.
@@ -20,9 +29,9 @@ import kotlinx.coroutines.launch
  *
  * **Solution:**
  * This class implements a **Producer-Consumer** pattern using a Kotlin [Channel].
- * 1. [LogcatReader] pushes lines into the Channel as fast as they come (Producer).
+ * 1. [com.hereliesaz.logkitty.utils.LogcatReader] pushes lines into the Channel as fast as they come.
  * 2. A dedicated coroutine reads from the Channel, buffers items for a short window ([BATCH_INTERVAL_MS]),
- *    and then emits them to the StateFlow in a single batch (Consumer).
+ *    and then emits them to the StateFlow in a single batch.
  *
  * This reduces UI updates from N/sec to roughly 10/sec (100ms interval), keeping the UI buttery smooth.
  */
@@ -31,44 +40,29 @@ class StateDelegate(
     dispatcher: CoroutineDispatcher = Dispatchers.Default
 ) {
     companion object {
-        // Maximum number of lines to keep in memory. Oldest are dropped.
-        private const val MAX_LOG_SIZE = 1000
-
-        // Debounce interval. We collect logs for this duration before updating the UI.
+        private const val MAX_LOG_SIZE = 5000
         private const val BATCH_INTERVAL_MS = 100L
     }
 
-    /**
-     * Internal event wrapper. Currently only handles System logs, but extensible for other event types.
-     */
     private sealed interface LogEvent {
         data class System(val msg: String) : LogEvent
     }
 
-    // The unlimited channel ensures we don't block the LogcatReader if the processing lags slightly.
+    private val idCounter = AtomicLong(0L)
     private val logChannel = Channel<LogEvent>(Channel.UNLIMITED)
 
     init {
-        // Start the processing loop on a background thread.
         scope.launch(dispatcher) {
             val buffer = mutableListOf<LogEvent>()
             while (true) {
-                // 1. Wait for the first item (suspends until data is available).
                 val first = logChannel.receive()
                 buffer.add(first)
-
-                // 2. Wait a fraction of a second to see if more logs arrive "at the same time".
                 delay(BATCH_INTERVAL_MS)
-
-                // 3. Drain the channel of all items that arrived during the delay.
-                // tryReceive() is non-blocking.
                 var result = logChannel.tryReceive()
                 while (result.isSuccess) {
                     buffer.add(result.getOrThrow())
                     result = logChannel.tryReceive()
                 }
-
-                // 4. Process the accumulated batch in one go.
                 if (buffer.isNotEmpty()) {
                     processLogBatch(buffer)
                     buffer.clear()
@@ -77,76 +71,55 @@ class StateDelegate(
         }
     }
 
-    /**
-     * Processes a batch of events and updates the StateFlow.
-     */
     private fun processLogBatch(events: List<LogEvent>) {
-        val systemLines = ArrayList<String>()
-
-        // Extract raw strings from the event wrappers.
+        val systemLines = ArrayList<IndexedLogLine>()
         for (event in events) {
             when (event) {
                 is LogEvent.System -> {
-                    // Split multiline logs if necessary and filter empty lines.
-                    event.msg.split('\n').filterTo(systemLines) { it.isNotBlank() }
+                    event.msg.split('\n').forEach { raw ->
+                        if (raw.isNotBlank()) {
+                            systemLines.add(IndexedLogLine(idCounter.incrementAndGet(), raw))
+                        }
+                    }
                 }
             }
         }
-
-        // Only trigger a state update if we actually have valid lines.
         if (systemLines.isNotEmpty()) {
             _systemLog.appendCapped(systemLines)
         }
     }
 
-    // The backing MutableStateFlow. Initialize with empty list.
-    private val _systemLog = MutableStateFlow<List<String>>(emptyList())
+    private val _systemLog = MutableStateFlow<List<IndexedLogLine>>(emptyList())
 
     /**
-     * The public read-only stream of log lines.
-     * The UI collects this to render the LazyColumn.
+     * Stream of indexed log lines. Each entry carries a unique increasing id so that
+     * per-tab clearing can skip historical entries without dropping them for other tabs.
      */
     val systemLog = _systemLog.asStateFlow()
 
     /**
-     * Entry point for the LogcatReader to add a line.
-     * This is non-blocking (uses trySend on an UNLIMITED channel).
+     * Highest id observed so far. Useful for "clear this tab" semantics where the caller
+     * stores this value and later filters lines whose id is greater than the saved marker.
      */
+    val currentMaxId: Long get() = idCounter.get()
+
     fun appendSystemLog(msg: String) {
         logChannel.trySend(LogEvent.System(msg))
     }
 
-    /**
-     * Extension function to append new lines while enforcing the [MAX_LOG_SIZE] cap.
-     * Includes memory optimization to avoid allocating excessive temporary lists.
-     */
-    private fun MutableStateFlow<List<String>>.appendCapped(lines: List<String>) {
-         this.update { current ->
+    private fun MutableStateFlow<List<IndexedLogLine>>.appendCapped(lines: List<IndexedLogLine>) {
+        this.update { current ->
             val totalSize = current.size + lines.size
             if (totalSize <= MAX_LOG_SIZE) {
-                // If within limits, simple concatenation is fine.
                 current + lines
             } else {
-                // If we exceed the limit, we need to drop the oldest items.
-                // Calculate how many items from the 'current' list we can keep.
                 val keepFromCurrent = MAX_LOG_SIZE - lines.size
-
                 if (keepFromCurrent <= 0) {
-                    // Edge case: The incoming batch is larger than the entire buffer size.
-                    // Just take the last N items of the incoming batch.
                     lines.takeLast(MAX_LOG_SIZE)
                 } else {
-                    // Optimization: Pre-allocate the ArrayList to the exact size needed.
-                    val result = java.util.ArrayList<String>(MAX_LOG_SIZE)
-
-                    // Copy the tail of the existing list.
-                    // Accessing 'current' by index is O(1) assuming it's an ArrayList (standard in Kotlin).
+                    val result = java.util.ArrayList<IndexedLogLine>(MAX_LOG_SIZE)
                     val start = current.size - keepFromCurrent
-                    for (i in start until current.size) {
-                        result.add(current[i])
-                    }
-
-                    // Append all new lines.
+                    for (i in start until current.size) result.add(current[i])
                     result.addAll(lines)
                     result
                 }
@@ -155,7 +128,7 @@ class StateDelegate(
     }
 
     /**
-     * Clears the current log buffer.
+     * Clears the global log buffer. Per-tab clearing is handled by the ViewModel via id markers.
      */
     fun clearLog() {
         _systemLog.value = emptyList()

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/utils/UserPreferences.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/utils/UserPreferences.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.SharedPreferences
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
+import com.hereliesaz.logkitty.ui.LogColorScheme
 import com.hereliesaz.logkitty.ui.LogLevel
 import com.hereliesaz.logkitty.ui.theme.CodingFont
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -31,7 +32,9 @@ data class ExportedPreferences(
     val logColors: Map<String, Int>,
     val showTimestamp: Boolean,
     val bufferSize: Int,
-    val activeLogLevels: Set<String>
+    val activeLogLevels: Set<String>,
+    val colorScheme: String = LogColorScheme.MATERIAL.name,
+    val tagColoringEnabled: Boolean = true
 )
 
 /**
@@ -106,9 +109,17 @@ class UserPreferences(context: Context) {
     private val _prohibitedTags = MutableStateFlow(loadProhibitedTags())
     val prohibitedTags: StateFlow<Set<String>> = _prohibitedTags.asStateFlow()
 
+    // --- Preference: Color Scheme ---
+    private val _colorScheme = MutableStateFlow(loadColorScheme())
+    val colorScheme: StateFlow<LogColorScheme> = _colorScheme.asStateFlow()
+
+    // --- Preference: Tag-Based Coloring ---
+    private val _tagColoringEnabled = MutableStateFlow(prefs.getBoolean(KEY_TAG_COLORING, true))
+    val tagColoringEnabled: StateFlow<Boolean> = _tagColoringEnabled.asStateFlow()
+
     // --- Preference: Log Colors ---
-    // Map of LogLevel to ARGB Color Integer.
-    private val _logColors = MutableStateFlow(loadLogColors())
+    // Map of LogLevel to ARGB Color Integer. Reflects the active scheme until the user customizes.
+    private val _logColors = MutableStateFlow(loadLogColors(_colorScheme.value))
     val logColors: StateFlow<Map<LogLevel, Color>> = _logColors.asStateFlow()
 
     // --- Setters ---
@@ -192,28 +203,60 @@ class UserPreferences(context: Context) {
     }
 
     /**
-     * Customizes the color for a specific log level.
+     * Customizes the color for a specific log level. Switches the scheme to CUSTOM so further
+     * scheme changes don't silently overwrite the user's overrides.
      */
     fun setLogColor(level: LogLevel, color: Color) {
         val current = _logColors.value.toMutableMap()
         current[level] = color
         _logColors.value = current
-        // Persist using a dynamic key like "color_ERROR"
-        prefs.edit().putInt(getKeyForColor(level), color.toArgb()).apply()
+        prefs.edit()
+            .putInt(getKeyForColor(level), color.toArgb())
+            .putString(KEY_COLOR_SCHEME, LogColorScheme.CUSTOM.name)
+            .apply()
+        _colorScheme.value = LogColorScheme.CUSTOM
     }
 
     /**
-     * Resets all log colors to their hardcoded defaults.
+     * Resets all log colors to the current scheme's defaults (clearing user overrides).
      */
     fun resetLogColors() {
         val editor = prefs.edit()
-        val defaultColors = mutableMapOf<LogLevel, Color>()
+        val scheme = if (_colorScheme.value == LogColorScheme.CUSTOM) LogColorScheme.MATERIAL else _colorScheme.value
+        val baseColors = mutableMapOf<LogLevel, Color>()
         LogLevel.values().forEach { level ->
             editor.remove(getKeyForColor(level))
-            defaultColors[level] = level.defaultColor
+            baseColors[level] = scheme.colorFor(level)
+        }
+        editor.putString(KEY_COLOR_SCHEME, scheme.name).apply()
+        _colorScheme.value = scheme
+        _logColors.value = baseColors
+    }
+
+    /**
+     * Switches the active color scheme. Per-level overrides are dropped when moving away from CUSTOM.
+     */
+    fun setColorScheme(scheme: LogColorScheme) {
+        val editor = prefs.edit()
+        editor.putString(KEY_COLOR_SCHEME, scheme.name)
+        val palette = mutableMapOf<LogLevel, Color>()
+        LogLevel.values().forEach { level ->
+            if (scheme == LogColorScheme.CUSTOM) {
+                val saved = prefs.getInt(getKeyForColor(level), Int.MIN_VALUE)
+                palette[level] = if (saved == Int.MIN_VALUE) LogColorScheme.MATERIAL.colorFor(level) else Color(saved)
+            } else {
+                editor.remove(getKeyForColor(level))
+                palette[level] = scheme.colorFor(level)
+            }
         }
         editor.apply()
-        _logColors.value = defaultColors
+        _colorScheme.value = scheme
+        _logColors.value = palette
+    }
+
+    fun setTagColoringEnabled(enabled: Boolean) {
+        prefs.edit().putBoolean(KEY_TAG_COLORING, enabled).apply()
+        _tagColoringEnabled.value = enabled
     }
 
     // --- Helpers ---
@@ -226,13 +269,23 @@ class UserPreferences(context: Context) {
         prefs.edit().putStringSet(KEY_PROHIBITED_TAGS, tags).apply()
     }
 
-    private fun loadLogColors(): Map<LogLevel, Color> {
+    private fun loadLogColors(scheme: LogColorScheme): Map<LogLevel, Color> {
         val colors = mutableMapOf<LogLevel, Color>()
         LogLevel.values().forEach { level ->
-            val colorInt = prefs.getInt(getKeyForColor(level), level.defaultColor.toArgb())
-            colors[level] = Color(colorInt)
+            if (scheme == LogColorScheme.CUSTOM) {
+                val saved = prefs.getInt(getKeyForColor(level), Int.MIN_VALUE)
+                colors[level] = if (saved == Int.MIN_VALUE) LogColorScheme.MATERIAL.colorFor(level) else Color(saved)
+            } else {
+                colors[level] = scheme.colorFor(level)
+            }
         }
         return colors
+    }
+
+    private fun loadColorScheme(): LogColorScheme {
+        val name = prefs.getString(KEY_COLOR_SCHEME, LogColorScheme.MATERIAL.name)
+            ?: LogColorScheme.MATERIAL.name
+        return try { LogColorScheme.valueOf(name) } catch (e: Exception) { LogColorScheme.MATERIAL }
     }
 
     private fun getKeyForColor(level: LogLevel) = "color_${level.name}"
@@ -256,21 +309,23 @@ class UserPreferences(context: Context) {
             logColors = colorMap,
             showTimestamp = _showTimestamp.value,
             bufferSize = _bufferSize.value,
-            activeLogLevels = _activeLogLevels.value
+            activeLogLevels = _activeLogLevels.value,
+            colorScheme = _colorScheme.value.name,
+            tagColoringEnabled = _tagColoringEnabled.value
         )
         return try {
-            Json.encodeToString(exported)
+            Json { prettyPrint = true }.encodeToString(exported)
         } catch (e: Exception) { "{}" }
     }
 
     /**
      * Imports preferences from a JSON string, updating both the persistent store and the live flows.
      */
-    fun importPreferences(jsonString: String) {
-        try {
-            val imported = Json.decodeFromString<ExportedPreferences>(jsonString)
+    fun importPreferences(jsonString: String): Boolean {
+        return try {
+            val parser = Json { ignoreUnknownKeys = true; isLenient = true }
+            val imported = parser.decodeFromString<ExportedPreferences>(jsonString)
 
-            // Apply simple values
             setContextModeEnabled(imported.contextMode)
             setCustomFilter(imported.customFilter)
             setOverlayOpacity(imported.overlayOpacity)
@@ -281,8 +336,8 @@ class UserPreferences(context: Context) {
             setLogReversed(imported.isLogReversed)
             setShowTimestamp(imported.showTimestamp)
             setBufferSize(imported.bufferSize)
-            
-            // Apply Collections
+            setTagColoringEnabled(imported.tagColoringEnabled)
+
             val levels = imported.activeLogLevels.toMutableSet()
             prefs.edit().putStringSet(KEY_ACTIVE_LOG_LEVELS, levels).apply()
             _activeLogLevels.value = levels
@@ -291,25 +346,26 @@ class UserPreferences(context: Context) {
             _prohibitedTags.value = tags
             saveProhibitedTags(tags)
 
-            // Apply Colors
+            val scheme = try { LogColorScheme.valueOf(imported.colorScheme) } catch (e: Exception) { LogColorScheme.MATERIAL }
+
             val editor = prefs.edit()
             val newColors = mutableMapOf<LogLevel, Color>()
-            // Initialize with defaults in case JSON is missing some keys
-            LogLevel.values().forEach { newColors[it] = it.defaultColor }
+            LogLevel.values().forEach { newColors[it] = scheme.colorFor(it) }
 
             imported.logColors.forEach { (levelName, colorInt) ->
                 try {
                     val level = LogLevel.valueOf(levelName)
-                    val color = Color(colorInt)
-                    newColors[level] = color
+                    newColors[level] = Color(colorInt)
                     editor.putInt(getKeyForColor(level), colorInt)
                 } catch (e: IllegalArgumentException) { }
             }
-            editor.apply()
+            editor.putString(KEY_COLOR_SCHEME, scheme.name).apply()
+            _colorScheme.value = scheme
             _logColors.value = newColors
-
+            true
         } catch (e: Exception) {
             e.printStackTrace()
+            false
         }
     }
 
@@ -327,5 +383,7 @@ class UserPreferences(context: Context) {
         private const val KEY_SHOW_TIMESTAMP = "show_timestamp"
         private const val KEY_BUFFER_SIZE = "buffer_size"
         private const val KEY_ACTIVE_LOG_LEVELS = "active_log_levels"
+        private const val KEY_COLOR_SCHEME = "color_scheme"
+        private const val KEY_TAG_COLORING = "tag_coloring_enabled"
     }
 }

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,5 +1,20 @@
 # TODO Roadmap & Tactical Implementation Plan
 
+## 0. v0.6 — Overhaul (DONE)
+- [x] Replaced dokar3 bottom-sheet with a custom 4-detent overlay (HIDDEN / PEEK / HALF / FULL).
+- [x] Window size now mirrors the active detent, so taps outside the sheet always reach the underlying app.
+- [x] Thin (2dp) drag handle; gesture zones split between header (detent change) and log area (scroll), with side-swipe = tab switch in both.
+- [x] Tabs: System, Errors, and per-app — close-X only shows on the selected APP tab.
+- [x] X icon does two things: first press clears the active tab; second press (within 3s) hides the sheet.
+- [x] Save & Settings buttons collapse the sheet to HIDDEN before launching their action.
+- [x] Home / Recents collapse via the accessibility broadcast; back-button collapses HALF/FULL → HIDDEN, then second back goes to the app below.
+- [x] Selectable log entries with a Copy / Search (Google) / Prohibit action toolbar.
+- [x] Comprehensive color schemes: Material, Android Studio, Pidcat, Monochrome, Solarized, Custom. Tag-based highlights for common Android components (toggleable).
+- [x] Settings now houses the Prohibited list, Color Scheme editor, and Preferences export / import (JSON via SAF + clipboard).
+- [x] Removed the legacy AI-prompt placeholder.
+
+
+
 ## 1. Runtime Hardening & Safety Rails
 **Goal:** Prevent crashes and guide the user through the "Hostile" Android permission landscape.
 

--- a/docs/file_descriptions.md
+++ b/docs/file_descriptions.md
@@ -22,15 +22,17 @@
 *   `LogKittyAccessibilityService.kt`: Background service that detects `TYPE_WINDOW_STATE_CHANGED` events to identify the foreground package for context-aware filtering.
 
 ### ui/
-*   `LogBottomSheet.kt`: The primary UI composable. Renders the persistent bottom sheet, log list, and control header.
-*   `MainViewModel.kt`: The central logic controller. Bridges the `LogcatReader` data, `UserPreferences`, and the UI. Handles filtering and state management.
-*   `SettingsScreen.kt`: A dedicated screen for configuring app behavior (opacity, buffer size, prohibited logs, etc.).
+*   `LogBottomSheet.kt`: The primary UI composable. Custom 4-detent overlay (HIDDEN/PEEK/HALF/FULL) with tab row, gesture zones, and selectable log items.
+*   `SheetController.kt`: Shared state holder for the active detent — consumed by both the Compose UI (for animation) and the hosting Service (for window sizing).
+*   `MainViewModel.kt`: The central logic controller. Bridges the `LogcatReader` data, `UserPreferences`, and the UI. Handles per-tab clearing and side-swipe tab navigation.
+*   `SettingsScreen.kt`: A dedicated screen for configuring app behavior. Hosts navigation into the prohibited-tags list, the color scheme editor, and preferences export/import.
 *   `ProhibitedLogsScreen.kt`: UI for managing the list of prohibited log tags/strings.
-*   `LogColors.kt`: Definitions for log level colors (Verbose, Debug, Info, Warn, Error, Assert).
+*   `ColorSchemeEditorScreen.kt`: Per-level color customization. Selecting any swatch flips the active scheme to CUSTOM.
+*   `LogColors.kt`: Log level enum plus the built-in `LogColorScheme` palettes (Material, AOSP, Pidcat, Monochrome, Solarized, Custom) and the tag-based highlight rules.
 *   `ColorPickerDialog.kt`: A dialog composable for picking colors (used in settings).
 
 ### ui/delegates/
-*   `StateDelegate.kt`: The data holder and processor. Manages the circular log buffer and handles the high-frequency log stream batching.
+*   `StateDelegate.kt`: The data holder and processor. Tags every log line with a monotonically-increasing `IndexedLogLine.id` (the basis for per-tab clearing), batches incoming lines, and caps the rolling buffer.
 
 ### ui/theme/
 *   `Theme.kt`: Jetpack Compose theme definition.

--- a/version.properties
+++ b/version.properties
@@ -1,3 +1,3 @@
 major=0
-minor=5
+minor=6
 patch=0


### PR DESCRIPTION
## Summary

Whole-app pass against the punchlist:

### Overlay & window
- Replaced dokar3 `BottomSheetLayout` with a custom 4-detent sheet: **HIDDEN / PEEK / HALF / FULL**.
- `LogKittyOverlayService` now sizes the WindowManager view to match the active detent and sets `FLAG_NOT_TOUCH_MODAL`, so taps outside the sheet always reach the underlying app. The system overlay no longer steals touches across the screen.
- FULL height = 90% of screen — the log display extends down to the bottom-10% mark.
- HIDDEN leaves only a 14dp swipe-up/tap grab strip at the bottom.

### Gestures
- Header (handle + tabs + icon row): vertical drag steps the detent up/down, horizontal drag flips tabs.
- Log area: vertical drag scrolls the LazyColumn, horizontal drag flips tabs.
- Thin **2dp** drag handle replaces the chunky 6dp pill.

### Tabs
- System, Errors, and one per foreground-app captured by the accessibility service.
- The close-`X` only appears on the **selected** APP tab.
- Side-swipe navigates between tabs in both PEEK and HALF/FULL detents.

### Icon-bar buttons
- **X**: first press clears the active tab only (per-tab marker via `IndexedLogLine` ids — other tabs keep their history). Second press within 3s collapses the sheet to HIDDEN.
- **Save** and **Settings**: hide the sheet to HIDDEN first, then launch their action.
- Back key collapses HALF/FULL → HIDDEN; a second back propagates to the app below (window is only focusable in HALF/FULL).
- Home/Recents collapse via accessibility broadcast — the system performs the navigation as usual.

### Log entries
- Tap a line to select; toolbar above the log offers **Copy / Search (Google) / Prohibit**.
- Prohibit extracts the tag and adds it to the persisted block-list.
- Prohibited list manager is now reachable from Settings (was orphan UI before).

### Color schemes
- Six built-in schemes — **Material (default), Android Studio, Pidcat, Monochrome, Solarized, Custom**.
- Tag-based coloring for common Android components (toggleable).
- Per-level color editor (any edit auto-switches the active scheme to CUSTOM).
- All preferences persist via SharedPreferences and are covered by `backup_rules.xml` / `data_extraction_rules.xml` (already in place).
- New **Export Preferences** / **Import Preferences** entries in Settings (SAF + clipboard fallback).

### Misc
- Removed the dead `sendPrompt` AI placeholder.
- Bumped `version.properties` to 0.6.0.
- Updated `docs/file_descriptions.md` and `docs/TODO.md`.

## Test plan
- [ ] PEEK → swipe up to HALF, then up to FULL; swipe down through PEEK to HIDDEN.
- [ ] In HIDDEN, swipe up or tap the thin strip to return to PEEK.
- [ ] HALF or FULL: tap outside the sheet — touches must hit the app behind it.
- [ ] Side-swipe inside any non-HIDDEN detent switches tabs.
- [ ] Open an app, confirm a tab appears; select it; verify close-X appears only on the selected APP tab and removing the tab does not affect System/Errors.
- [ ] Press X — only the active tab's logs disappear. Press X again within 3s — sheet hides.
- [ ] Save & Settings — sheet hides before action.
- [ ] Back key in HALF/FULL hides the sheet; second back goes to the app.
- [ ] Home / Recents from any expanded detent — sheet hides immediately and the system action proceeds.
- [ ] Tap a log line — Copy / Search / Prohibit toolbar appears. Verify each action.
- [ ] Settings → Color Scheme → switch through all six. Customize one level and verify scheme flips to Custom.
- [ ] Settings → Export Preferences → saves JSON. Re-import — values restored.
- [ ] Verify ProhibitedLogsScreen lists prohibited tags and the remove button works.
- [ ] `./gradlew assembleDebug` (sandbox here lacks network for the foojay plugin — please run in CI).

https://claude.ai/code/session_019R2H1qphG72iG4GbpTYoU6

---
_Generated by [Claude Code](https://claude.ai/code/session_019R2H1qphG72iG4GbpTYoU6)_