### PR TITLE
fix(overlay): launcher-aware passthrough, no-handle gesture, log behind nav bar

### DIFF
--- a/app/src/main/kotlin/com/hereliesaz/logkitty/services/LogKittyAccessibilityService.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/services/LogKittyAccessibilityService.kt
@@ -25,6 +25,15 @@ class LogKittyAccessibilityService : AccessibilityService() {
         const val EXTRA_REASON = "reason"
         const val REASON_HOME = "home"
         const val REASON_RECENTS = "recents"
+
+        fun isLauncherPackage(pkg: String?): Boolean {
+            if (pkg.isNullOrBlank()) return false
+            return pkg == "com.google.android.apps.nexuslauncher" ||
+                pkg == "com.sec.android.app.launcher" ||
+                pkg == "com.android.launcher" ||
+                pkg == "com.android.launcher3" ||
+                pkg.contains("launcher", ignoreCase = true)
+        }
     }
 
     override fun onServiceConnected() {
@@ -59,14 +68,9 @@ class LogKittyAccessibilityService : AccessibilityService() {
         val isRecents = lowerCls.contains("recents") ||
             lowerCls.contains("taskswitcher") ||
             lowerCls.contains("overview")
-        val isLauncher = pkg.contains("launcher", ignoreCase = true) ||
-            pkg == "com.google.android.apps.nexuslauncher" ||
-            pkg == "com.sec.android.app.launcher" ||
-            pkg == "com.android.launcher" ||
-            pkg == "com.android.launcher3"
         return when {
             isRecents -> REASON_RECENTS
-            isLauncher -> REASON_HOME
+            isLauncherPackage(pkg) -> REASON_HOME
             pkg == "com.android.systemui" -> REASON_RECENTS
             else -> null
         }

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/services/LogKittyOverlayService.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/services/LogKittyOverlayService.kt
@@ -35,15 +35,22 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 
 /**
  * [LogKittyOverlayService] hosts the always-on Compose overlay.
  *
  * **Touch confinement**
- * The WindowManager view is resized to match the current sheet detent so taps outside the sheet
- * fall through to the underlying application — even when the sheet is FULL height (the bottom 90%
- * of the screen) the window leaves the top 10% untouchable.
+ * The WindowManager view is resized per detent. HIDDEN and PEEK shrink to a strip at the bottom
+ * so the rest of the screen reaches the underlying app. HALF and FULL extend to full screen height
+ * so the Compose layer can render a transparent scrim above the sheet — a tap on that scrim
+ * steps the detent down by one.
+ *
+ * **Launcher passthrough**
+ * The accessibility service exposes the foreground package via the shared ViewModel. While the
+ * launcher is foreground the overlay disables itself ([SheetController.isEnabled] = false) and
+ * the window shrinks to 1 px so the system swipe-up-for-app-drawer gesture is untouched.
  *
  * **Back-button handling**
  * When the sheet is HALF or FULL the window is focusable, so the system delivers back events.
@@ -187,35 +194,61 @@ class LogKittyOverlayService : Service() {
         lifecycleHelper!!.onCreate()
         lifecycleHelper!!.onStart()
 
-        // Initial layout params: position at bottom, height matched to PEEK detent.
-        val initialHeight = peekHeightPx(density, navBarHeightPx, viewModel.fontSize.value)
+        // Initial layout params match the controller's starting detent (HIDDEN, enabled).
+        val initialHeight = heightForDetent(
+            controller.detent,
+            controller.isEnabled,
+            density,
+            navBarHeightPx,
+            viewModel.fontSize.value,
+            screenHeightPx,
+        )
         val params = baseLayoutParams(initialHeight, focusable = false)
         try { windowManager.addView(composeView, params) }
         catch (e: Exception) { e.printStackTrace() }
 
-        // React to detent changes: resize the window, toggle focusability for back support.
+        // React to detent + enabled changes: resize the window, toggle focusability for back support.
         serviceScope.launch {
-            controller.detentFlow.collect { detent ->
-                val fontSize = viewModel.fontSize.value
-                val targetHeight = heightForDetent(detent, density, navBarHeightPx, fontSize, screenHeightPx)
-                val needsFocus = detent == SheetDetent.HALF || detent == SheetDetent.FULL
-                updateWindow(targetHeight, focusable = needsFocus)
+            combine(controller.detentFlow, controller.isEnabledFlow) { d, e -> d to e }
+                .collect { (detent, enabled) ->
+                    val fontSize = viewModel.fontSize.value
+                    val targetHeight = heightForDetent(
+                        detent, enabled, density, navBarHeightPx, fontSize, screenHeightPx
+                    )
+                    val needsFocus = enabled && (detent == SheetDetent.HALF || detent == SheetDetent.FULL)
+                    updateWindow(targetHeight, focusable = needsFocus)
+                }
+        }
+
+        // While on the launcher, disable the overlay so the system swipe-up-for-app-drawer
+        // gesture is untouched. Re-enable when any other foreground app comes up.
+        serviceScope.launch {
+            viewModel.currentForegroundApp.collect { pkg ->
+                controller.isEnabled = !LogKittyAccessibilityService.isLauncherPackage(pkg)
             }
         }
     }
 
-    /** Sheet height in pixels for the given detent. Mirrors the heights in [LogBottomSheet]. */
+    /**
+     * Sheet height in pixels for the given detent and enabled state.
+     *
+     * HALF and FULL use the full screen height — the Compose layer draws a transparent
+     * scrim above the sheet body so a tap outside steps the detent down by one.
+     */
     private fun heightForDetent(
         detent: SheetDetent,
+        enabled: Boolean,
         density: Float,
         navBarHeightPx: Int,
         fontSize: Int,
         screenHeightPx: Int,
-    ): Int = when (detent) {
-        SheetDetent.HIDDEN -> (14f * density).toInt().coerceAtLeast(1)
-        SheetDetent.PEEK -> peekHeightPx(density, navBarHeightPx, fontSize)
-        SheetDetent.HALF -> (screenHeightPx * 0.5f).toInt()
-        SheetDetent.FULL -> (screenHeightPx * 0.9f).toInt()
+    ): Int {
+        if (!enabled) return 1
+        return when (detent) {
+            SheetDetent.HIDDEN -> (14f * density).toInt().coerceAtLeast(1)
+            SheetDetent.PEEK -> peekHeightPx(density, navBarHeightPx, fontSize)
+            SheetDetent.HALF, SheetDetent.FULL -> screenHeightPx
+        }
     }
 
     private fun peekHeightPx(density: Float, navBarHeightPx: Int, fontSize: Int): Int {

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/services/LogKittyOverlayService.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/services/LogKittyOverlayService.kt
@@ -207,11 +207,16 @@ class LogKittyOverlayService : Service() {
         try { windowManager.addView(composeView, params) }
         catch (e: Exception) { e.printStackTrace() }
 
-        // React to detent + enabled changes: resize the window, toggle focusability for back support.
+        // React to detent + enabled + font-size changes: resize the window, toggle focusability
+        // for back support. Including fontSize here means the PEEK strip resizes immediately
+        // when the user changes it in settings, instead of waiting for the next detent change.
         serviceScope.launch {
-            combine(controller.detentFlow, controller.isEnabledFlow) { d, e -> d to e }
-                .collect { (detent, enabled) ->
-                    val fontSize = viewModel.fontSize.value
+            combine(
+                controller.detentFlow,
+                controller.isEnabledFlow,
+                viewModel.fontSize,
+            ) { detent, enabled, fontSize -> Triple(detent, enabled, fontSize) }
+                .collect { (detent, enabled, fontSize) ->
                     val targetHeight = heightForDetent(
                         detent, enabled, density, navBarHeightPx, fontSize, screenHeightPx
                     )

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/LogBottomSheet.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/LogBottomSheet.kt
@@ -18,14 +18,11 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Block
 import androidx.compose.material.icons.filled.Clear
@@ -52,7 +49,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
@@ -74,18 +70,18 @@ import kotlin.math.abs
  * The four-detent overlay rewritten for the new gesture and tab model.
  *
  * **Detents**
- *   HIDDEN  – a thin invisible grab-strip; the window shrinks so taps go to the underlying app.
+ *   HIDDEN  – an invisible swipe-up zone at the bottom edge; the window shrinks so the
+ *             underlying app receives every touch outside that strip. The launcher disables
+ *             the overlay entirely so the swipe-up-for-app-drawer gesture is untouched.
  *   PEEK    – a one-line ticker showing the latest log entry.
- *   HALF    – roughly 50% of the screen.
- *   FULL    – extends so the log fills everything except the bottom 10% of the screen.
+ *   HALF    – roughly 50% of the screen, with a transparent scrim above.
+ *   FULL    – the log fills everything except the bottom 10% of the screen, scrim above.
  *
- * **Gestures (handle / header row area)**
- *   Vertical drag   → step the detent up or down.
- *   Horizontal drag → switch to the previous/next tab.
- *
- * **Gestures (below the header)**
- *   Vertical drag   → scrolls the log (LazyColumn).
- *   Horizontal drag → switches tabs.
+ * **Gestures**
+ *   Swipe up from the HIDDEN strip → step to PEEK (then HALF, then FULL on subsequent swipes).
+ *   Tap anywhere on the scrim above an expanded sheet → step down by one detent.
+ *   Header row vertical drag       → step the detent up or down.
+ *   Header / row horizontal drag   → switch to the previous/next tab.
  *
  * **Selection model**
  *   Tap a log line → an action toolbar (copy / search / prohibit) appears at the top of the log area.
@@ -134,119 +130,134 @@ fun LogBottomSheet(
         selectedLineId?.let { id -> indexedLog.firstOrNull { it.id == id } }
     }
 
-    Box(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(sheetBackgroundColor)
-    ) {
-        when (controller.detent) {
-            SheetDetent.HIDDEN -> HiddenHandle(
+    val current = controller.detent
+    Box(modifier = Modifier.fillMaxSize()) {
+        when (current) {
+            SheetDetent.HIDDEN -> HiddenSwipeZone(
                 modifier = Modifier.fillMaxSize(),
-                onSwipeUp = { controller.peek() },
-                onTap = { controller.peek() }
+                onSwipeUp = { controller.stepUp() }
             )
-            SheetDetent.PEEK -> PeekStrip(
-                modifier = Modifier.fillMaxSize(),
-                latest = indexedLog.lastOrNull()?.text ?: "LogKitty Ready",
-                showTimestamp = showTimestamp,
-                fontFamily = currentFontFamily,
-                fontSize = fontSize,
-                navBarHeight = navBarHeight,
-                onTap = { controller.half() },
-                onSwipeUp = { controller.stepUp() },
-                onSwipeDown = { controller.hide() },
-                onSwipeLeft = { viewModel.selectNextTab() },
-                onSwipeRight = { viewModel.selectPreviousTab() }
-            )
-            SheetDetent.HALF, SheetDetent.FULL -> ExpandedView(
-                tabs = tabs,
-                selectedTab = selectedTab,
-                indexedLog = indexedLog,
-                logColors = logColors,
-                tagColoringEnabled = tagColoringEnabled,
-                fontFamily = currentFontFamily,
-                fontSize = fontSize,
-                showTimestamp = showTimestamp,
-                isLogReversed = isLogReversed,
-                navBarHeight = navBarHeight,
-                selectedLine = selectedLine,
-                onSelectLine = { id -> selectedLineId = if (selectedLineId == id) null else id },
-                onClearSelection = { selectedLineId = null },
-                onTabSelected = { viewModel.selectTab(it) },
-                onCloseAppTab = { viewModel.closeTab(it) },
-                onSwipeLeft = { viewModel.selectNextTab() },
-                onSwipeRight = { viewModel.selectPreviousTab() },
-                onHeaderDragUp = { controller.stepUp() },
-                onHeaderDragDown = { controller.stepDown() },
-                onSaveClick = {
-                    controller.hide()
-                    onSaveClick()
-                },
-                onSettingsClick = {
-                    controller.hide()
-                    onSettingsClick()
-                },
-                onClearClick = {
-                    val now = System.currentTimeMillis()
-                    if (now - lastClearAt < 3000L) {
-                        controller.hide()
-                        lastClearAt = 0L
-                    } else {
-                        viewModel.clearActiveTab()
-                        lastClearAt = now
-                    }
-                },
-                onCopyLine = { line ->
-                    clipboardManager.setText(AnnotatedString(line.text))
-                    selectedLineId = null
-                },
-                onSearchLine = { line ->
-                    // Cap the query — full log lines (stack traces) can blow past the URL/intent
-                    // size limits and silently fail to launch the browser.
-                    val query = java.net.URLEncoder.encode(line.text.take(500), "UTF-8")
-                    val intent = android.content.Intent(android.content.Intent.ACTION_VIEW,
-                        android.net.Uri.parse("https://www.google.com/search?q=$query")).apply {
-                        addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK)
-                    }
-                    runCatching { context.startActivity(intent) }
-                    selectedLineId = null
-                },
-                onProhibitLine = { line ->
-                    viewModel.prohibitLog(line.text)
-                    selectedLineId = null
-                },
-            )
+            SheetDetent.PEEK -> Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(sheetBackgroundColor)
+            ) {
+                PeekStrip(
+                    modifier = Modifier.fillMaxSize(),
+                    latest = indexedLog.lastOrNull()?.text ?: "LogKitty Ready",
+                    showTimestamp = showTimestamp,
+                    fontFamily = currentFontFamily,
+                    fontSize = fontSize,
+                    navBarHeight = navBarHeight,
+                    onTap = { controller.stepUp() },
+                    onSwipeUp = { controller.stepUp() },
+                    onSwipeDown = { controller.hide() },
+                    onSwipeLeft = { viewModel.selectNextTab() },
+                    onSwipeRight = { viewModel.selectPreviousTab() }
+                )
+            }
+            SheetDetent.HALF, SheetDetent.FULL -> {
+                val sheetFraction = if (current == SheetDetent.HALF) 0.5f else 0.9f
+                val sheetHeight = screenHeight * sheetFraction
+                // Transparent scrim covers the whole window; tap anywhere above the sheet
+                // steps the detent down by one.
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .clickable(
+                            indication = null,
+                            interactionSource = remember { MutableInteractionSource() }
+                        ) { controller.stepDown() }
+                )
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(sheetHeight)
+                        .align(Alignment.BottomCenter)
+                        .background(sheetBackgroundColor)
+                ) {
+                    ExpandedView(
+                        tabs = tabs,
+                        selectedTab = selectedTab,
+                        indexedLog = indexedLog,
+                        logColors = logColors,
+                        tagColoringEnabled = tagColoringEnabled,
+                        fontFamily = currentFontFamily,
+                        fontSize = fontSize,
+                        showTimestamp = showTimestamp,
+                        isLogReversed = isLogReversed,
+                        navBarHeight = navBarHeight,
+                        selectedLine = selectedLine,
+                        onSelectLine = { id -> selectedLineId = if (selectedLineId == id) null else id },
+                        onClearSelection = { selectedLineId = null },
+                        onTabSelected = { viewModel.selectTab(it) },
+                        onCloseAppTab = { viewModel.closeTab(it) },
+                        onSwipeLeft = { viewModel.selectNextTab() },
+                        onSwipeRight = { viewModel.selectPreviousTab() },
+                        onHeaderDragUp = { controller.stepUp() },
+                        onHeaderDragDown = { controller.stepDown() },
+                        onSaveClick = {
+                            controller.hide()
+                            onSaveClick()
+                        },
+                        onSettingsClick = {
+                            controller.hide()
+                            onSettingsClick()
+                        },
+                        onClearClick = {
+                            val now = System.currentTimeMillis()
+                            if (now - lastClearAt < 3000L) {
+                                controller.hide()
+                                lastClearAt = 0L
+                            } else {
+                                viewModel.clearActiveTab()
+                                lastClearAt = now
+                            }
+                        },
+                        onCopyLine = { line ->
+                            clipboardManager.setText(AnnotatedString(line.text))
+                            selectedLineId = null
+                        },
+                        onSearchLine = { line ->
+                            // Cap the query — full log lines (stack traces) can blow past the URL/intent
+                            // size limits and silently fail to launch the browser.
+                            val query = java.net.URLEncoder.encode(line.text.take(500), "UTF-8")
+                            val intent = android.content.Intent(android.content.Intent.ACTION_VIEW,
+                                android.net.Uri.parse("https://www.google.com/search?q=$query")).apply {
+                                addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK)
+                            }
+                            runCatching { context.startActivity(intent) }
+                            selectedLineId = null
+                        },
+                        onProhibitLine = { line ->
+                            viewModel.prohibitLog(line.text)
+                            selectedLineId = null
+                        },
+                    )
+                }
+            }
         }
     }
 }
 
+/**
+ * Invisible swipe-up zone. A vertical drag fires [onSwipeUp] once per gesture, advancing
+ * the sheet by one detent. No visible handle — the user finds it via the same edge-swipe
+ * affordance the system uses for the app drawer (the launcher itself disables this zone
+ * via [SheetController.isEnabled], so the gestures don't conflict there).
+ */
 @Composable
-private fun HiddenHandle(
+private fun HiddenSwipeZone(
     modifier: Modifier,
     onSwipeUp: () -> Unit,
-    onTap: () -> Unit,
 ) {
     Box(
-        modifier = modifier
-            .pointerInputVerticalDrag(
-                threshold = 16f,
-                onUp = onSwipeUp,
-                onDown = { }
-            )
-            .clickable(
-                indication = null,
-                interactionSource = remember { MutableInteractionSource() }
-            ) { onTap() },
-        contentAlignment = Alignment.Center
-    ) {
-        Box(
-            modifier = Modifier
-                .width(48.dp)
-                .height(2.dp)
-                .clip(RoundedCornerShape(1.dp))
-                .background(Color.White.copy(alpha = 0.35f))
+        modifier = modifier.pointerInputVerticalDrag(
+            threshold = 16f,
+            onUp = onSwipeUp,
+            onDown = { }
         )
-    }
+    )
 }
 
 @Composable
@@ -283,31 +294,18 @@ private fun PeekStrip(
                 .fillMaxHeight(),
             contentAlignment = Alignment.CenterStart
         ) {
-            ThinHandle(modifier = Modifier.align(Alignment.TopCenter))
             Text(
                 text = displayText,
                 fontFamily = fontFamily,
                 fontSize = fontSize.sp,
                 style = MaterialTheme.typography.bodySmall,
-                modifier = Modifier.padding(start = 12.dp, end = 12.dp, top = 8.dp),
+                modifier = Modifier.padding(horizontal = 12.dp),
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
                 color = Color.White
             )
         }
     }
-}
-
-@Composable
-private fun ThinHandle(modifier: Modifier = Modifier) {
-    Box(
-        modifier = modifier
-            .padding(top = 4.dp)
-            .width(48.dp)
-            .height(2.dp)
-            .clip(RoundedCornerShape(1.dp))
-            .background(Color.White.copy(alpha = 0.4f))
-    )
 }
 
 @Composable
@@ -340,22 +338,14 @@ private fun ExpandedView(
 ) {
     Column(modifier = Modifier.fillMaxSize()) {
 
-        // --- Header zone: handle + tabs + icons (vertical drag = detent, horizontal = tab swap) ---
+        // --- Header zone: tabs + icons (vertical drag = detent, horizontal = tab swap) ---
+        // No visible handle — the header itself is the drag target.
         Column(
             modifier = Modifier
                 .fillMaxWidth()
                 .pointerInputVerticalDrag(threshold = 18f, onUp = onHeaderDragUp, onDown = onHeaderDragDown)
                 .pointerInputHorizontalDrag(threshold = 48f, onLeft = onSwipeLeft, onRight = onSwipeRight)
         ) {
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(vertical = 6.dp),
-                contentAlignment = Alignment.Center
-            ) {
-                ThinHandle()
-            }
-
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 verticalAlignment = Alignment.CenterVertically
@@ -463,7 +453,9 @@ private fun ExpandedView(
                 LazyColumn(
                     state = listState,
                     reverseLayout = isLogReversed,
-                    contentPadding = PaddingValues(start = 8.dp, end = 8.dp, bottom = navBarHeight + 8.dp),
+                    // No nav-bar bottom inset — the log is allowed to draw behind the system
+                    // navigation bar so as many lines as possible are visible.
+                    contentPadding = PaddingValues(start = 8.dp, end = 8.dp, bottom = 0.dp),
                     modifier = Modifier.fillMaxSize()
                 ) {
                     items(indexedLog, key = { it.id }) { line ->

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/SheetController.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/SheetController.kt
@@ -9,8 +9,8 @@ import kotlinx.coroutines.flow.asStateFlow
 /**
  * The four detents supported by the LogKitty overlay.
  *
- * - [HIDDEN]: nothing visible except a thin swipe-up grab strip; the window shrinks so the
- *   underlying app receives every touch except inside that strip.
+ * - [HIDDEN]: an invisible swipe-up zone at the bottom of the screen; the window shrinks so the
+ *   underlying app receives every touch outside that strip. A swipe up advances to [PEEK].
  * - [PEEK]: a one-line ticker showing the most recent log entry.
  * - [HALF]: roughly half-height of the screen, the comfortable "browse" position.
  * - [FULL]: extended down so the log occupies everything but the bottom 10% of the screen.
@@ -22,11 +22,14 @@ enum class SheetDetent { HIDDEN, PEEK, HALF, FULL }
  * Service can read and mutate. The Service uses [detentFlow] to size the WindowManager
  * window; the UI uses [detent] for animations.
  *
+ * [isEnabled] is set to false while the user is on the launcher: the overlay shrinks
+ * its window so it no longer intercepts the system swipe-up-for-app-drawer gesture.
+ *
  * The controller is created once per overlay session and shared across both worlds.
  */
 @Stable
 class SheetController {
-    private val _detent = mutableStateOf(SheetDetent.PEEK)
+    private val _detent = mutableStateOf(SheetDetent.HIDDEN)
     /** Compose-friendly mutable state for animations. */
     var detent: SheetDetent
         get() = _detent.value
@@ -35,8 +38,22 @@ class SheetController {
             _detentFlow.value = value
         }
 
-    private val _detentFlow = MutableStateFlow(SheetDetent.PEEK)
+    private val _detentFlow = MutableStateFlow(SheetDetent.HIDDEN)
     val detentFlow: StateFlow<SheetDetent> = _detentFlow.asStateFlow()
+
+    private val _isEnabled = mutableStateOf(true)
+    private val _isEnabledFlow = MutableStateFlow(true)
+    var isEnabled: Boolean
+        get() = _isEnabled.value
+        set(value) {
+            if (_isEnabled.value == value) return
+            _isEnabled.value = value
+            _isEnabledFlow.value = value
+            if (!value) {
+                detent = SheetDetent.HIDDEN
+            }
+        }
+    val isEnabledFlow: StateFlow<Boolean> = _isEnabledFlow.asStateFlow()
 
     fun hide() { detent = SheetDetent.HIDDEN }
     fun peek() { detent = SheetDetent.PEEK }


### PR DESCRIPTION
## Summary

Implements the requested overlay rework:

1. **Log displays behind the navigation bar.** The expanded view's `LazyColumn` no longer pads the bottom by `navBarHeight`, so log lines extend into the nav-bar area.
2. **More lines visible.** Removing the bottom inset, the visible handle in the expanded view header, and the handle in the peek strip frees several rows of vertical space.
3. **Tap outside closes by one detent.** For HALF/FULL the overlay window is now full-screen and Compose draws a transparent scrim above the sheet; a tap on it calls `controller.stepDown()`.
4. **Launcher disables the overlay.** `SheetController.isEnabled` is wired to `viewModel.currentForegroundApp` via `LogKittyAccessibilityService.isLauncherPackage(...)`. While the launcher is foreground the window shrinks to 1 px so the swipe-up-for-app-drawer gesture is untouched.
5. **No visible handle.** HIDDEN is now an invisible swipe-up zone at the bottom edge — each swipe steps the detent up by one (HIDDEN → PEEK → HALF → FULL). PEEK tap also steps up. The 3-button / gesture nav bar stays interactive because the system bar window sits above this overlay.

## Files

- `LogKittyAccessibilityService.kt` — extracted `isLauncherPackage(pkg)` helper into the companion object.
- `SheetController.kt` — default detent is now `HIDDEN`; new `isEnabled` / `isEnabledFlow` for launcher-driven disable.
- `LogKittyOverlayService.kt` — observes `currentForegroundApp`; combines `detentFlow` × `isEnabledFlow` to size the window; HALF/FULL window is now full-screen height.
- `LogBottomSheet.kt` — removed `ThinHandle` everywhere; new `HiddenSwipeZone`; HALF/FULL renders scrim + sheet container; LazyColumn `bottom = 0.dp`.

## Test plan

- [ ] Service starts → HIDDEN, no visible handle, swipe-up from bottom advances to PEEK.
- [ ] Tap PEEK strip or swipe up → HALF (full-screen window, scrim above the sheet).
- [ ] Tap on the empty area above the sheet → steps down one detent.
- [ ] Swipe up again on HALF (via header) → FULL.
- [ ] Back button on HALF/FULL collapses to HIDDEN.
- [ ] Pressing home / opening the launcher disables the overlay (no swipe zone interferes with the app-drawer gesture).
- [ ] Opening any other app re-enables the overlay (HIDDEN strip ready).
- [ ] Nav bar buttons remain tappable while the sheet is HALF/FULL.
- [ ] Gesture-nav home swipe still works while the sheet is HALF/FULL.
- [ ] Bottom log lines visibly extend behind the system nav bar.

https://claude.ai/code/session_01WoHg1Wz5zJvGc8Np99yKA5

---
_Generated by [Claude Code](https://claude.ai/code/session_01WoHg1Wz5zJvGc8Np99yKA5)_

## Summary by Sourcery

Rework the log overlay sheet behavior to start hidden, use a launcher-aware enable flag, and provide scrim-based gestures for expanding and collapsing while allowing logs to draw behind the navigation bar.

New Features:
- Introduce a launcher-aware enable/disable flag for the overlay that collapses the window to a minimal height when disabled.
- Add a full-screen scrim interaction for HALF and FULL detents that lets users tap outside the sheet to step down one detent.
- Expose an invisible bottom-edge swipe zone detent that replaces the visible handle for bringing up the sheet.

Bug Fixes:
- Ensure launcher home and app-drawer gestures are not intercepted by the overlay by disabling it when the launcher is foreground.

Enhancements:
- Change the default sheet detent from PEEK to HIDDEN so the overlay starts unobtrusively.
- Resize the overlay window based on both detent and font size so the PEEK strip responds immediately to font changes.
- Allow the expanded log list to render behind the system navigation bar to show more log lines on screen.
- Simplify header interactions by using the header row itself as the drag target instead of a dedicated handle.