### PR TITLE
fix(overlay): real fill in HALF/FULL + nav-bar decoration

### DIFF
--- a/app/src/main/kotlin/com/hereliesaz/logkitty/services/LogKittyOverlayService.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/services/LogKittyOverlayService.kt
@@ -286,9 +286,10 @@ class LogKittyOverlayService : Service() {
                 Box(modifier = Modifier.fillMaxSize().background(color))
             }
         }
-        navDecorLifecycle = ComposeLifecycleHelper(view)
-        navDecorLifecycle!!.onCreate()
-        navDecorLifecycle!!.onStart()
+        navDecorLifecycle = ComposeLifecycleHelper(view).apply {
+            onCreate()
+            onStart()
+        }
 
         val flags = WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE or
             WindowManager.LayoutParams.FLAG_NOT_TOUCH_MODAL or

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/services/LogKittyOverlayService.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/services/LogKittyOverlayService.kt
@@ -17,8 +17,13 @@ import android.provider.Settings
 import android.view.Gravity
 import android.view.KeyEvent
 import android.view.WindowManager
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
@@ -27,6 +32,7 @@ import androidx.core.app.NotificationCompat
 import com.hereliesaz.logkitty.MainActivity
 import com.hereliesaz.logkitty.MainApplication
 import com.hereliesaz.logkitty.ui.LogBottomSheet
+import com.hereliesaz.logkitty.ui.MainViewModel
 import com.hereliesaz.logkitty.ui.SheetController
 import com.hereliesaz.logkitty.ui.SheetDetent
 import com.hereliesaz.logkitty.ui.theme.LogKittyTheme
@@ -67,6 +73,13 @@ class LogKittyOverlayService : Service() {
     private lateinit var windowManager: WindowManager
     private var composeView: ComposeView? = null
     private var lifecycleHelper: ComposeLifecycleHelper? = null
+
+    // The second, non-touchable overlay window painted on top of the system navigation bar.
+    // It uses TYPE_ACCESSIBILITY_OVERLAY so it sits *above* the nav bar in z-order, hiding
+    // the bar's opaque background with our sheet color. FLAG_NOT_TOUCHABLE + NOT_TOUCH_MODAL
+    // means touches pass through to the nav bar buttons / gesture area below.
+    private var navDecorView: ComposeView? = null
+    private var navDecorLifecycle: ComposeLifecycleHelper? = null
 
     private val controller = SheetController()
     private val serviceScope = CoroutineScope(Dispatchers.Main + SupervisorJob())
@@ -130,6 +143,13 @@ class LogKittyOverlayService : Service() {
             try {
                 lifecycleHelper?.onStop()
                 lifecycleHelper?.onDestroy()
+                windowManager.removeView(view)
+            } catch (e: Exception) { e.printStackTrace() }
+        }
+        navDecorView?.let { view ->
+            try {
+                navDecorLifecycle?.onStop()
+                navDecorLifecycle?.onDestroy()
                 windowManager.removeView(view)
             } catch (e: Exception) { e.printStackTrace() }
         }
@@ -231,6 +251,70 @@ class LogKittyOverlayService : Service() {
             viewModel.currentForegroundApp.collect { pkg ->
                 controller.isEnabled = !LogKittyAccessibilityService.isLauncherPackage(pkg)
             }
+        }
+
+        setupNavBarDecoration(viewModel, navBarHeightPx)
+    }
+
+    /**
+     * Add a non-interactive overlay strip sitting on top of the system navigation bar so the
+     * bar's opaque background visually disappears — replaced by the same translucent sheet
+     * color. Uses TYPE_ACCESSIBILITY_OVERLAY because that window type renders *above* the
+     * nav bar (TYPE_APPLICATION_OVERLAY renders behind it). Requires that the user has
+     * granted accessibility permission to LogKittyAccessibilityService; if they haven't, the
+     * addView call will throw and we fall back to the un-decorated nav bar.
+     *
+     * FLAG_NOT_TOUCHABLE + FLAG_NOT_TOUCH_MODAL: touches in this strip pass through to the
+     * system nav bar below, so 3-button taps and gesture-nav swipes keep working.
+     */
+    private fun setupNavBarDecoration(
+        viewModel: MainViewModel,
+        navBarHeightPx: Int,
+    ) {
+        if (navBarHeightPx <= 0) return
+        val view = ComposeView(this).apply {
+            setContent {
+                val opacity by viewModel.overlayOpacity.collectAsState()
+                val bgInt by viewModel.backgroundColor.collectAsState()
+                val detent by controller.detentFlow.collectAsState()
+                val enabled by controller.isEnabledFlow.collectAsState()
+                // Match the sheet body: same translucent color, only visible when the
+                // sheet itself is visible. HIDDEN and the disabled-on-launcher state leave
+                // the nav bar untouched.
+                val visible = enabled && detent != SheetDetent.HIDDEN
+                val color = if (visible) Color(bgInt).copy(alpha = opacity) else Color.Transparent
+                Box(modifier = Modifier.fillMaxSize().background(color))
+            }
+        }
+        navDecorLifecycle = ComposeLifecycleHelper(view)
+        navDecorLifecycle!!.onCreate()
+        navDecorLifecycle!!.onStart()
+
+        val flags = WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE or
+            WindowManager.LayoutParams.FLAG_NOT_TOUCH_MODAL or
+            WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE or
+            WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS or
+            WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN
+        val params = WindowManager.LayoutParams(
+            WindowManager.LayoutParams.MATCH_PARENT,
+            navBarHeightPx,
+            WindowManager.LayoutParams.TYPE_ACCESSIBILITY_OVERLAY,
+            flags,
+            PixelFormat.TRANSLUCENT,
+        ).apply {
+            gravity = Gravity.BOTTOM
+            y = 0
+        }
+        try {
+            windowManager.addView(view, params)
+            navDecorView = view
+        } catch (e: Exception) {
+            // Likely no active AccessibilityService — fall back silently; the main overlay
+            // still works, the nav bar just stays opaque.
+            navDecorLifecycle?.onStop()
+            navDecorLifecycle?.onDestroy()
+            navDecorLifecycle = null
+            e.printStackTrace()
         }
     }
 

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/LogBottomSheet.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/LogBottomSheet.kt
@@ -157,26 +157,35 @@ fun LogBottomSheet(
                 )
             }
             SheetDetent.HALF, SheetDetent.FULL -> {
-                val sheetFraction = if (current == SheetDetent.HALF) 0.5f else 0.9f
-                val sheetHeight = screenHeight * sheetFraction
-                // Transparent scrim covers the whole window; tap anywhere above the sheet
-                // steps the detent down by one.
-                Box(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .clickable(
-                            indication = null,
-                            interactionSource = remember { MutableInteractionSource() }
-                        ) { controller.stepDown() }
-                )
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(sheetHeight)
-                        .align(Alignment.BottomCenter)
-                        .background(sheetBackgroundColor)
-                ) {
-                    ExpandedView(
+                // Split the window into scrim (top) and sheet (bottom) by weight so the
+                // sheet always uses its full share of the *actually measured* window —
+                // independent of any insets the system applies to the configured height.
+                val scrimWeight: Float
+                val sheetWeight: Float
+                if (current == SheetDetent.HALF) {
+                    scrimWeight = 1f; sheetWeight = 1f      // 50 / 50
+                } else {
+                    scrimWeight = 1f; sheetWeight = 9f      // 10 / 90
+                }
+                Column(modifier = Modifier.fillMaxSize()) {
+                    // Transparent scrim — tap anywhere above the sheet steps the detent
+                    // down by one.
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .weight(scrimWeight)
+                            .clickable(
+                                indication = null,
+                                interactionSource = remember { MutableInteractionSource() }
+                            ) { controller.stepDown() }
+                    )
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .weight(sheetWeight)
+                            .background(sheetBackgroundColor)
+                    ) {
+                        ExpandedView(
                         tabs = tabs,
                         selectedTab = selectedTab,
                         indexedLog = indexedLog,
@@ -234,6 +243,7 @@ fun LogBottomSheet(
                             selectedLineId = null
                         },
                     )
+                    }
                 }
             }
         }
@@ -526,7 +536,7 @@ private fun LogRow(
             fontSize = fontSize.sp,
             lineHeight = (fontSize * 1.35f).sp,
             style = MaterialTheme.typography.bodySmall,
-            overflow = TextOverflow.Visible
+            overflow = TextOverflow.Visible,
         )
     }
 }

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/LogBottomSheet.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/LogBottomSheet.kt
@@ -160,13 +160,9 @@ fun LogBottomSheet(
                 // Split the window into scrim (top) and sheet (bottom) by weight so the
                 // sheet always uses its full share of the *actually measured* window —
                 // independent of any insets the system applies to the configured height.
-                val scrimWeight: Float
-                val sheetWeight: Float
-                if (current == SheetDetent.HALF) {
-                    scrimWeight = 1f; sheetWeight = 1f      // 50 / 50
-                } else {
-                    scrimWeight = 1f; sheetWeight = 9f      // 10 / 90
-                }
+                // HALF = 1:1 (≈ 50/50 split), FULL = 1:9 (≈ 10/90 split).
+                val scrimWeight = 1f
+                val sheetWeight = if (current == SheetDetent.HALF) 1f else 9f
                 Column(modifier = Modifier.fillMaxSize()) {
                     // Transparent scrim — tap anywhere above the sheet steps the detent
                     // down by one.


### PR DESCRIPTION
## Summary

Two follow-ups from the merged #84:

### 1. HALF/FULL sheet was effectively zero-height

The expanded sheet was built as a `Box.fillMaxSize` with an inner `Box.height(screenHeight * fraction).align(BottomCenter)`. On devices where the configured window size and the actually-measured Compose tree disagree (display cutouts, the LAYOUT_NO_LIMITS interaction), `screenHeight` came in too small, the inner Box collapsed to roughly the header height, and the `LazyColumn` had no room for rows past the first.

Rebuilt the HALF/FULL branch as a `Column` with `weight()`-based scrim and sheet children, so the sheet always gets its share of the *measured* window. HALF = 1:1, FULL = 1:9.

### 2. Force the nav bar's background transparent

Added a second WindowManager view sized to the system nav bar at the bottom of the screen, registered with `TYPE_ACCESSIBILITY_OVERLAY` so it sits *above* the nav bar in z-order. `FLAG_NOT_TOUCHABLE | FLAG_NOT_TOUCH_MODAL` means touches in that strip pass through to the nav bar buttons / gesture handles.

The decoration paints the same translucent sheet color used in the main overlay, so the nav bar's opaque background visually disappears while the sheet is visible. It goes transparent again when the sheet is `HIDDEN` or while the launcher disables the overlay, leaving the user's other apps untouched. Falls back silently if the addView call throws (i.e. when the accessibility service isn't connected).

## Files

- `LogBottomSheet.kt` — HALF/FULL switched from fixed-height `align(BottomCenter)` to `Column` + `weight()`. Reverted the maxLines/Ellipsis change since the user clarified soft-wrap wasn't the bug.
- `LogKittyOverlayService.kt` — new `setupNavBarDecoration` adds the second window, lifecycle cleaned up in `onDestroy`. Uses `TYPE_ACCESSIBILITY_OVERLAY`.

## Test plan

- [ ] PEEK still shows one ticker line.
- [ ] HALF expansion shows many log rows filling roughly half the screen.
- [ ] FULL expansion shows even more rows.
- [ ] Scrim above the sheet still steps the detent down on tap.
- [ ] Header drag-up still steps the detent up.
- [ ] With accessibility granted: nav bar background appears tinted to match the sheet while the sheet is visible.
- [ ] Nav bar buttons / gesture handle still receive touches while the decoration is up.
- [ ] On the launcher (sheet disabled) the nav bar looks normal — no tint.
- [ ] If accessibility isn't granted, the main overlay still works and the nav bar stays opaque.

https://claude.ai/code/session_01WoHg1Wz5zJvGc8Np99yKA5

---
_Generated by [Claude Code](https://claude.ai/code/session_01WoHg1Wz5zJvGc8Np99yKA5)_

## Summary by Sourcery

Adjust overlay bottom sheet sizing and add a navigation bar decoration overlay to improve visual integration and reliability of HALF/FULL modes.

New Features:
- Add a non-interactive accessibility overlay strip above the system navigation bar that tints the bar to match the sheet while the overlay is visible.

Bug Fixes:
- Fix HALF and FULL bottom sheet modes rendering at near-zero height on devices where measured window height differs from configured screen height.

Enhancements:
- Refine HALF/FULL bottom sheet layout to use weighted scrim and sheet sections so the sheet consistently occupies its intended portion of the screen.
- Ensure the nav bar decoration overlay respects overlay visibility and launcher-disabled states while preserving nav bar touch interaction.