### PR TITLE
Fix detent line counts, notification off-switch, per-app monitoring; bump AzNavRail 9.7

### DIFF
--- a/app/src/main/kotlin/com/hereliesaz/logkitty/services/LogKittyOverlayService.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/services/LogKittyOverlayService.kt
@@ -214,8 +214,9 @@ class LogKittyOverlayService : Service() {
         // nav bar without needing extra per-line headroom here.
         val lineHeightPx = fontSize.toFloat() * density * 1.35f
 
-        // HIDDEN: one line + a small breathing margin → reads as a collapsed strip.
-        val hiddenPx = (lineHeightPx * 1) + (8f * density) + navBarHeightPx
+        // HIDDEN: a single line sitting right under the sheet's top edge, plus the nav bar the
+        // sheet draws behind. Keep the non-line margin tiny so the strip hugs one line.
+        val hiddenPx = (lineHeightPx * 1) + (1f * density) + navBarHeightPx
         val hiddenDp = (hiddenPx / density).dp
 
         // PEEK: size for four lines so three are reliably visible once the nav bar is subtracted.

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/services/LogKittyOverlayService.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/services/LogKittyOverlayService.kt
@@ -209,8 +209,10 @@ class LogKittyOverlayService : Service() {
     private fun sheetConfig(viewModel: MainViewModel, navBarHeightPx: Int): AzSheetConfig {
         val density = resources.displayMetrics.density
         val fontSize = viewModel.fontSize.value
-        // Keep in sync with the Text lineHeight used in LogBottomSheet's PeekStrip (fontSize * 1.35).
-        val lineHeightPx = fontSize.toFloat() * density * 1.4f
+        // Matches the Text lineHeight used in LogBottomSheet's PeekStrip (fontSize * 1.35). PEEK is
+        // sized for four lines and top-aligns its content, so at least three stay visible above the
+        // nav bar without needing extra per-line headroom here.
+        val lineHeightPx = fontSize.toFloat() * density * 1.35f
 
         // HIDDEN: one line + a small breathing margin → reads as a collapsed strip.
         val hiddenPx = (lineHeightPx * 1) + (8f * density) + navBarHeightPx

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/services/LogKittyOverlayService.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/services/LogKittyOverlayService.kt
@@ -197,19 +197,27 @@ class LogKittyOverlayService : Service() {
     /**
      * Build an [AzSheetConfig] from the user's current settings.
      *
-     * `hiddenStripDp` fits 1 line of text + padding + nav bar.
-     * `peekDp` fits 3 lines of text + padding + nav bar.
+     * The overlay window is resized to exactly these heights by the library, so they directly
+     * control how the HIDDEN/PEEK strips look. The nav-bar height is folded in because the
+     * sheet draws behind the system navigation bar (gravity-bottom, no-limits window).
+     *
+     * `hiddenStripDp` — a thin one-line strip so the sheet visibly *collapses* (only minimal
+     * vertical padding above the nav bar; the [LogBottomSheet] HIDDEN branch renders one line).
+     * `peekDp` — room for four lines so that at least three are always fully visible above the
+     * nav bar (the PEEK branch renders the last four lines).
      */
     private fun sheetConfig(viewModel: MainViewModel, navBarHeightPx: Int): AzSheetConfig {
         val density = resources.displayMetrics.density
         val fontSize = viewModel.fontSize.value
-        val lineHeightPx = fontSize.toFloat() * density * 1.5f
-        val paddingPx = 24f * density
+        // Keep in sync with the Text lineHeight used in LogBottomSheet's PeekStrip (fontSize * 1.35).
+        val lineHeightPx = fontSize.toFloat() * density * 1.4f
 
-        val hiddenPx = (lineHeightPx * 1) + paddingPx + navBarHeightPx
+        // HIDDEN: one line + a small breathing margin → reads as a collapsed strip.
+        val hiddenPx = (lineHeightPx * 1) + (8f * density) + navBarHeightPx
         val hiddenDp = (hiddenPx / density).dp
 
-        val peekPx = (lineHeightPx * 3) + paddingPx + navBarHeightPx
+        // PEEK: size for four lines so three are reliably visible once the nav bar is subtracted.
+        val peekPx = (lineHeightPx * 4) + (16f * density) + navBarHeightPx
         val peekDp = (peekPx / density).dp
         return AzSheetConfig(
             backgroundColor = Color(viewModel.backgroundColor.value),
@@ -240,11 +248,12 @@ class LogKittyOverlayService : Service() {
         val settingsIntent = Intent(this, LogKittyOverlayService::class.java).apply { action = ACTION_OPEN_SETTINGS }
         val settingsPending = PendingIntent.getService(this, 1, settingsIntent, PendingIntent.FLAG_IMMUTABLE)
         return NotificationCompat.Builder(this, CHANNEL_ID)
-            .setContentTitle("LogKitty Running")
-            .setContentText("Tap to Stop. Expand for Settings.")
+            .setContentTitle("LogKitty is running")
+            .setContentText("Tap to turn off. Expand for App Settings.")
             .setSmallIcon(android.R.drawable.ic_menu_view)
+            // Body tap and the prominent first action both stop the service (tears down the overlay).
             .setContentIntent(stopPending)
-            .addAction(android.R.drawable.ic_menu_close_clear_cancel, "Stop Service", stopPending)
+            .addAction(android.R.drawable.ic_menu_close_clear_cancel, "Turn Off LogKitty", stopPending)
             .addAction(android.R.drawable.ic_menu_preferences, "App Settings", settingsPending)
             .setOngoing(true)
             .setForegroundServiceBehavior(NotificationCompat.FOREGROUND_SERVICE_IMMEDIATE)

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/AppPickerDialog.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/AppPickerDialog.kt
@@ -1,0 +1,161 @@
+package com.hereliesaz.logkitty.ui
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.core.graphics.drawable.toBitmap
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/** A lightweight description of an installed application, used by [AppPickerDialog]. */
+data class InstalledApp(val packageName: String, val label: String)
+
+/**
+ * A dialog that lists installed applications (label + icon, searchable) and returns the package
+ * name of the one the user taps. Used by [SettingsScreen] to pin an app for a dedicated,
+ * UID-filtered log tab. Requires `QUERY_ALL_PACKAGES` (declared in the manifest).
+ */
+@Composable
+fun AppPickerDialog(
+    onDismiss: () -> Unit,
+    onAppSelected: (String) -> Unit,
+) {
+    val context = LocalContext.current
+    var query by remember { mutableStateOf("") }
+
+    // Load (and label-resolve) the installed apps off the main thread.
+    val apps by produceState<List<InstalledApp>?>(initialValue = null) {
+        value = withContext(Dispatchers.IO) {
+            val pm = context.packageManager
+            runCatching {
+                pm.getInstalledApplications(0)
+                    .map { InstalledApp(it.packageName, pm.getApplicationLabel(it).toString()) }
+                    .sortedBy { it.label.lowercase() }
+            }.getOrDefault(emptyList())
+        }
+    }
+
+    val filtered = remember(query, apps) {
+        val list = apps ?: emptyList()
+        if (query.isBlank()) list
+        else list.filter { it.label.contains(query, true) || it.packageName.contains(query, true) }
+    }
+
+    Dialog(onDismissRequest = onDismiss) {
+        Card(
+            shape = RoundedCornerShape(16.dp),
+            modifier = Modifier.fillMaxWidth().padding(16.dp),
+            colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)
+        ) {
+            Column(modifier = Modifier.padding(16.dp)) {
+                Text(
+                    text = "Monitor an app",
+                    style = MaterialTheme.typography.titleLarge,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+                Spacer(modifier = Modifier.size(12.dp))
+                OutlinedTextField(
+                    value = query,
+                    onValueChange = { query = it },
+                    label = { Text("Search apps") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth()
+                )
+                Spacer(modifier = Modifier.size(8.dp))
+
+                if (apps == null) {
+                    Box(modifier = Modifier.fillMaxWidth().padding(24.dp), contentAlignment = Alignment.Center) {
+                        CircularProgressIndicator()
+                    }
+                } else {
+                    LazyColumn(modifier = Modifier.fillMaxWidth().heightIn(max = 420.dp)) {
+                        items(filtered, key = { it.packageName }) { app ->
+                            AppRow(app = app, onClick = { onAppSelected(app.packageName) })
+                        }
+                    }
+                }
+
+                Spacer(modifier = Modifier.size(8.dp))
+                Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+                    TextButton(onClick = onDismiss) { Text("Cancel") }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun AppRow(app: InstalledApp, onClick: () -> Unit) {
+    val context = LocalContext.current
+    // Lazily decode the icon for the visible row only.
+    val icon by produceState<ImageBitmap?>(initialValue = null, app.packageName) {
+        value = withContext(Dispatchers.IO) {
+            runCatching {
+                context.packageManager.getApplicationIcon(app.packageName)
+                    .toBitmap(width = 96, height = 96).asImageBitmap()
+            }.getOrNull()
+        }
+    }
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Box(modifier = Modifier.size(36.dp), contentAlignment = Alignment.Center) {
+            icon?.let { Image(bitmap = it, contentDescription = null, modifier = Modifier.size(36.dp)) }
+        }
+        Spacer(modifier = Modifier.width(12.dp))
+        Column(modifier = Modifier.fillMaxWidth()) {
+            Text(
+                text = app.label,
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurface,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+            Text(
+                text = app.packageName,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
+    }
+}

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/LogBottomSheet.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/LogBottomSheet.kt
@@ -40,6 +40,7 @@ import androidx.compose.material3.TabRowDefaults
 import androidx.compose.material3.TabRowDefaults.tabIndicatorOffset
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableLongStateOf
@@ -51,6 +52,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Density
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
@@ -76,8 +79,8 @@ fun AzSheetController.hide() { snapTo(AzSheetDetent.HIDDEN) }
  * strip, and the accumulated-delta vertical drag — so this composable only renders what fills
  * each detent's body:
  *
- *   HIDDEN — nothing (the host's window is sized to a 14dp invisible strip; touches there step up).
- *   PEEK   — a one-line ticker of the latest log entry.
+ *   HIDDEN — a one-line strip showing the latest log entry; tapping it steps up.
+ *   PEEK   — the last four log lines (sized so at least three are visible above the nav bar).
  *   HALF / FULL — tabs, optional selection action bar, and the log list.
  *
  * Horizontal-drag tab switching is implemented here because the system-overlay flavor of the host
@@ -139,7 +142,7 @@ fun LogBottomSheet(
         AzSheetDetent.PEEK -> PeekStrip(
             modifier = Modifier.fillMaxSize(),
             lines = if (indexedLog.isEmpty()) listOf("LogKitty Ready")
-                    else indexedLog.takeLast(3).map { it.text },
+                    else indexedLog.takeLast(4).map { it.text },
             showTimestamp = showTimestamp,
             fontFamily = currentFontFamily,
             fontSize = fontSize,
@@ -237,6 +240,7 @@ private fun PeekStrip(
     onSwipeRight: () -> Unit,
 ) {
     val timestampRegex = remember { Regex("^\\d{2}-\\d{2}\\s\\d{2}:\\d{2}:\\d{2}\\.\\d{3}\\s+") }
+    val density = LocalDensity.current
 
     Box(
         modifier = modifier
@@ -246,25 +250,33 @@ private fun PeekStrip(
                 interactionSource = remember { MutableInteractionSource() }
             ) { onTap() }
     ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .fillMaxHeight()
-                .padding(horizontal = 12.dp),
-            verticalArrangement = Arrangement.Center
-        ) {
-            lines.forEach { line ->
-                val displayText = if (showTimestamp) line else line.replace(timestampRegex, "")
-                Text(
-                    text = displayText,
-                    fontFamily = fontFamily,
-                    fontSize = fontSize.sp,
-                    lineHeight = (fontSize * 1.35f).sp,
-                    style = MaterialTheme.typography.bodySmall,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                    color = Color.White
-                )
+        // Force fontScale = 1 so the rendered line height always equals the height the detent was
+        // sized for (sheetConfig in LogKittyOverlayService) — otherwise a user with a large system
+        // font scale would overflow the strip and only one line would fit.
+        CompositionLocalProvider(LocalDensity provides Density(density.density, fontScale = 1f)) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .fillMaxHeight()
+                    .padding(horizontal = 12.dp)
+                    .padding(top = 3.dp),
+                // Top-align so the lines pack from the top and stay clear of the system nav bar
+                // that overlays the bottom of the strip.
+                verticalArrangement = Arrangement.Top
+            ) {
+                lines.forEach { line ->
+                    val displayText = if (showTimestamp) line else line.replace(timestampRegex, "")
+                    Text(
+                        text = displayText,
+                        fontFamily = fontFamily,
+                        fontSize = fontSize.sp,
+                        lineHeight = (fontSize * 1.35f).sp,
+                        style = MaterialTheme.typography.bodySmall,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        color = Color.White
+                    )
+                }
             }
         }
     }
@@ -473,6 +485,7 @@ private fun LogRow(
     }
 
     val bg = if (isSelected) Color.White.copy(alpha = 0.10f) else Color.Transparent
+    val density = LocalDensity.current
     Box(
         modifier = Modifier
             .fillMaxWidth()
@@ -485,14 +498,18 @@ private fun LogRow(
             )
             .padding(horizontal = 4.dp, vertical = 1.dp)
     ) {
-        Text(
-            text = annotated,
-            fontFamily = fontFamily,
-            fontSize = fontSize.sp,
-            lineHeight = (fontSize * 1.35f).sp,
-            style = MaterialTheme.typography.bodySmall,
-            overflow = TextOverflow.Visible,
-        )
+        // Force fontScale = 1 so log lines always render at the user's chosen size, independent of
+        // the device's system font-size setting.
+        CompositionLocalProvider(LocalDensity provides Density(density.density, fontScale = 1f)) {
+            Text(
+                text = annotated,
+                fontFamily = fontFamily,
+                fontSize = fontSize.sp,
+                lineHeight = (fontSize * 1.35f).sp,
+                style = MaterialTheme.typography.bodySmall,
+                overflow = TextOverflow.Visible,
+            )
+        }
     }
 }
 

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/LogBottomSheet.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/LogBottomSheet.kt
@@ -58,6 +58,7 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.LineHeightStyle
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
@@ -258,8 +259,7 @@ private fun PeekStrip(
                 modifier = Modifier
                     .fillMaxWidth()
                     .fillMaxHeight()
-                    .padding(horizontal = 12.dp)
-                    .padding(top = 3.dp),
+                    .padding(horizontal = 12.dp),
                 // Top-align so the lines pack from the top and stay clear of the system nav bar
                 // that overlays the bottom of the strip.
                 verticalArrangement = Arrangement.Top
@@ -271,7 +271,14 @@ private fun PeekStrip(
                         fontFamily = fontFamily,
                         fontSize = fontSize.sp,
                         lineHeight = (fontSize * 1.35f).sp,
-                        style = MaterialTheme.typography.bodySmall,
+                        // Trim the first line's top leading so the text hugs the top edge of the
+                        // sheet instead of floating below it.
+                        style = MaterialTheme.typography.bodySmall.copy(
+                            lineHeightStyle = LineHeightStyle(
+                                alignment = LineHeightStyle.Alignment.Top,
+                                trim = LineHeightStyle.Trim.FirstLineTop
+                            )
+                        ),
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
                         color = Color.White

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/MainViewModel.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/MainViewModel.kt
@@ -33,7 +33,12 @@ data class LogTab(
     val id: String,
     val title: String,
     val type: TabType,
-    val filterValue: String? = null
+    val filterValue: String? = null,
+    /**
+     * `true` for user-pinned, app-specific tabs (from "Monitor specific apps" in settings) that
+     * persist across sessions; `false` for the transient tabs auto-created from the foreground app.
+     */
+    val pinned: Boolean = false
 )
 
 enum class TabType {
@@ -63,6 +68,30 @@ class MainViewModel(
 
     // Repositories
     private val userPreferences = UserPreferences(application)
+
+    // Cache of package name -> Android UID (-1 = resolved-but-unknown). Used to filter the log
+    // stream to a specific app reliably (UID is stable across process restarts, unlike PID).
+    private val appUidCache = java.util.concurrent.ConcurrentHashMap<String, Int>()
+
+    private fun uidFor(pkg: String): Int? {
+        appUidCache[pkg]?.let { return it.takeIf { v -> v >= 0 } }
+        val resolved = try {
+            getApplication<Application>().packageManager.getApplicationInfo(pkg, 0).uid
+        } catch (e: Exception) { -1 }
+        appUidCache[pkg] = resolved
+        return resolved.takeIf { it >= 0 }
+    }
+
+    private fun appLabel(pkg: String): String = try {
+        val pm = getApplication<Application>().packageManager
+        pm.getApplicationLabel(pm.getApplicationInfo(pkg, 0)).toString()
+    } catch (e: Exception) { pkg }
+
+    /** Packages the user has pinned for dedicated app-specific log tabs. */
+    val monitoredApps: StateFlow<Set<String>> = userPreferences.monitoredApps
+
+    fun addMonitoredApp(pkg: String) = userPreferences.addMonitoredApp(pkg)
+    fun removeMonitoredApp(pkg: String) = userPreferences.removeMonitoredApp(pkg)
 
     // Delegate to handle the heavy lifting of log buffering.
     val stateDelegate = StateDelegate(viewModelScope, bufferSizeFlow = userPreferences.bufferSize)
@@ -140,7 +169,13 @@ class MainViewModel(
                 }
                 TabType.APP -> {
                     val pkg = input.tab.filterValue
-                    if (!pkg.isNullOrBlank()) result = result.filter { it.text.contains(pkg, ignoreCase = true) }
+                    if (!pkg.isNullOrBlank()) {
+                        val targetUid = uidFor(pkg)
+                        // Prefer reliable UID matching; fall back to substring if the package's
+                        // UID can't be resolved (e.g. it isn't installed).
+                        result = if (targetUid != null) result.filter { it.uid == targetUid }
+                                 else result.filter { it.text.contains(pkg, ignoreCase = true) }
+                    }
                 }
             }
             if (input.userFilter.isNotBlank()) {
@@ -190,6 +225,11 @@ class MainViewModel(
             }
         }
 
+        // Keep pinned, app-specific tabs in sync with the user's "Monitor specific apps" choices.
+        viewModelScope.launch {
+            userPreferences.monitoredApps.collect { syncMonitoredTabs(it) }
+        }
+
         // Register the Accessibility Receiver
         val filter = IntentFilter(LogKittyAccessibilityService.ACTION_FOREGROUND_APP_CHANGED)
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
@@ -200,14 +240,38 @@ class MainViewModel(
     }
 
     /**
-     * Adds a temporary tab for a specific application package.
+     * Reconciles the pinned app tabs with the set of [packages] the user is monitoring: adds a
+     * pinned tab for each new package, promotes any matching transient (foreground) tab, and
+     * removes pinned tabs that are no longer monitored.
+     */
+    private fun syncMonitoredTabs(packages: Set<String>) {
+        _tabs.update { current ->
+            val kept = current.filterNot { it.pinned && it.filterValue !in packages }
+            val result = kept.toMutableList()
+            packages.forEach { pkg ->
+                val existingIdx = result.indexOfFirst { it.filterValue == pkg }
+                if (existingIdx < 0) {
+                    result.add(LogTab("app_$pkg", appLabel(pkg), TabType.APP, pkg, pinned = true))
+                } else if (!result[existingIdx].pinned) {
+                    result[existingIdx] = result[existingIdx].copy(pinned = true, title = appLabel(pkg))
+                }
+            }
+            result
+        }
+        if (_tabs.value.none { it.id == _selectedTab.value.id }) {
+            _selectedTab.value = _tabs.value.firstOrNull() ?: systemTab
+        }
+    }
+
+    /**
+     * Adds a transient tab for a foreground application package (auto-created via accessibility).
      */
     private fun addAppTab(pkg: String) {
         _tabs.update { currentTabs ->
             if (currentTabs.any { it.filterValue == pkg }) {
-                currentTabs // Tab already exists
+                currentTabs // Tab already exists (transient or pinned)
             } else {
-                currentTabs + LogTab("app_$pkg", pkg, TabType.APP, pkg)
+                currentTabs + LogTab("app_$pkg", appLabel(pkg), TabType.APP, pkg)
             }
         }
     }
@@ -230,9 +294,14 @@ class MainViewModel(
 
     fun closeTab(tab: LogTab) {
         if (tab.type == TabType.APP) {
-            _tabs.update { it - tab }
-            if (_selectedTab.value == tab) {
-                _selectedTab.value = _tabs.value.firstOrNull() ?: systemTab
+            if (tab.pinned) {
+                // Unpinning a monitored app removes its tab via the monitoredApps flow.
+                tab.filterValue?.let { userPreferences.removeMonitoredApp(it) }
+            } else {
+                _tabs.update { it - tab }
+                if (_selectedTab.value == tab) {
+                    _selectedTab.value = _tabs.value.firstOrNull() ?: systemTab
+                }
             }
             _tabClearMarks.update { it - tab.id }
         }

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/MainViewModel.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/MainViewModel.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.Job
 
@@ -226,7 +227,8 @@ class MainViewModel(
         }
 
         // Keep pinned, app-specific tabs in sync with the user's "Monitor specific apps" choices.
-        viewModelScope.launch {
+        // Collected on IO because syncMonitoredTabs resolves app labels/UIDs via PackageManager.
+        viewModelScope.launch(Dispatchers.IO) {
             userPreferences.monitoredApps.collect { syncMonitoredTabs(it) }
         }
 
@@ -245,15 +247,19 @@ class MainViewModel(
      * removes pinned tabs that are no longer monitored.
      */
     private fun syncMonitoredTabs(packages: Set<String>) {
+        // Resolve labels/UIDs up front (this runs off the main thread); uidFor also primes the
+        // cache so the hot filter path never touches PackageManager on the main thread.
+        val labels = packages.associateWith { pkg -> appLabel(pkg).also { uidFor(pkg) } }
         _tabs.update { current ->
             val kept = current.filterNot { it.pinned && it.filterValue !in packages }
             val result = kept.toMutableList()
             packages.forEach { pkg ->
+                val title = labels[pkg] ?: pkg
                 val existingIdx = result.indexOfFirst { it.filterValue == pkg }
                 if (existingIdx < 0) {
-                    result.add(LogTab("app_$pkg", appLabel(pkg), TabType.APP, pkg, pinned = true))
+                    result.add(LogTab("app_$pkg", title, TabType.APP, pkg, pinned = true))
                 } else if (!result[existingIdx].pinned) {
-                    result[existingIdx] = result[existingIdx].copy(pinned = true, title = appLabel(pkg))
+                    result[existingIdx] = result[existingIdx].copy(pinned = true, title = title)
                 }
             }
             result
@@ -265,13 +271,15 @@ class MainViewModel(
 
     /**
      * Adds a transient tab for a foreground application package (auto-created via accessibility).
+     * Runs on the main thread (broadcast receiver), so it intentionally uses the package name as the
+     * title rather than a blocking PackageManager label lookup.
      */
     private fun addAppTab(pkg: String) {
         _tabs.update { currentTabs ->
             if (currentTabs.any { it.filterValue == pkg }) {
                 currentTabs // Tab already exists (transient or pinned)
             } else {
-                currentTabs + LogTab("app_$pkg", appLabel(pkg), TabType.APP, pkg)
+                currentTabs + LogTab("app_$pkg", pkg, TabType.APP, pkg)
             }
         }
     }

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/SettingsScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -110,9 +111,11 @@ private fun SettingsMainScreen(
     val colorScheme by viewModel.colorScheme.collectAsState()
     val tagColoringEnabled by viewModel.tagColoringEnabled.collectAsState()
     val prohibitedCount by viewModel.prohibitedTags.collectAsState()
+    val monitoredApps by viewModel.monitoredApps.collectAsState()
 
     var showColorPicker by remember { mutableStateOf(false) }
     var showSchemeMenu by remember { mutableStateOf(false) }
+    var showAppPicker by remember { mutableStateOf(false) }
 
     if (showColorPicker) {
         ColorPickerDialog(
@@ -121,6 +124,16 @@ private fun SettingsMainScreen(
             onColorSelected = {
                 viewModel.setBackgroundColor(it.toArgb())
                 showColorPicker = false
+            }
+        )
+    }
+
+    if (showAppPicker) {
+        AppPickerDialog(
+            onDismiss = { showAppPicker = false },
+            onAppSelected = {
+                viewModel.addMonitoredApp(it)
+                showAppPicker = false
             }
         )
     }
@@ -348,6 +361,49 @@ private fun SettingsMainScreen(
             }
             HorizontalDivider(modifier = Modifier.padding(vertical = 16.dp))
 
+            SettingsSectionHeader("App Monitoring")
+            Text(
+                "Pin an app to get a dedicated tab showing only its logs, in addition to the full system log.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(bottom = 4.dp)
+            )
+            if (monitoredApps.isEmpty()) {
+                Text(
+                    "No apps pinned",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(vertical = 8.dp)
+                )
+            } else {
+                monitoredApps.forEach { pkg ->
+                    Row(
+                        modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(appLabel(context, pkg), style = MaterialTheme.typography.bodyLarge)
+                            Text(
+                                pkg,
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                        IconButton(onClick = { viewModel.removeMonitoredApp(pkg) }) {
+                            Icon(Icons.Default.Close, contentDescription = "Stop monitoring $pkg")
+                        }
+                    }
+                }
+            }
+            AzButton(
+                onClick = { showAppPicker = true },
+                text = "Add App to Monitor",
+                shape = AzButtonShape.RECTANGLE,
+                modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)
+            )
+            HorizontalDivider(modifier = Modifier.padding(vertical = 16.dp))
+
             SettingsSectionHeader("Filters")
             AzButton(
                 onClick = onOpenProhibited,
@@ -397,6 +453,12 @@ private fun SettingsMainScreen(
         }
     }
 }
+
+/** Resolves a user-facing app label for a package, falling back to the package name. */
+private fun appLabel(context: android.content.Context, pkg: String): String = try {
+    val pm = context.packageManager
+    pm.getApplicationLabel(pm.getApplicationInfo(pkg, 0)).toString()
+} catch (e: Exception) { pkg }
 
 @Composable
 fun SettingsSectionHeader(text: String) {

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/SettingsScreen.kt
@@ -41,8 +41,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -377,13 +380,17 @@ private fun SettingsMainScreen(
                 )
             } else {
                 monitoredApps.forEach { pkg ->
+                    // Resolve the app label off the main thread to avoid blocking PackageManager IPC.
+                    val label by produceState(initialValue = pkg, pkg) {
+                        value = withContext(Dispatchers.IO) { appLabel(context, pkg) }
+                    }
                     Row(
                         modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
                         horizontalArrangement = Arrangement.SpaceBetween,
                         verticalAlignment = Alignment.CenterVertically
                     ) {
                         Column(modifier = Modifier.weight(1f)) {
-                            Text(appLabel(context, pkg), style = MaterialTheme.typography.bodyLarge)
+                            Text(label, style = MaterialTheme.typography.bodyLarge)
                             Text(
                                 pkg,
                                 style = MaterialTheme.typography.bodySmall,

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/delegates/StateDelegate.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/delegates/StateDelegate.kt
@@ -16,8 +16,13 @@ import java.util.concurrent.atomic.AtomicLong
  *
  * The id is the basis for **per-tab clearing**: each tab records the highest id it has
  * "dismissed", and only lines with a larger id are rendered when that tab is selected.
+ *
+ * [uid] is the Android UID of the process that emitted the line, parsed from the `-v uid`
+ * column (see [StateDelegate.parseUidPrefix]). It powers reliable per-app filtering. It is
+ * `null` for lines without a recognizable UID prefix (e.g. reader warnings or stack-trace
+ * continuation lines).
  */
-data class IndexedLogLine(val id: Long, val text: String)
+data class IndexedLogLine(val id: Long, val text: String, val uid: Int? = null)
 
 /**
  * [StateDelegate] is the single source of truth for the raw log data.
@@ -43,6 +48,45 @@ class StateDelegate(
     companion object {
         private const val DEFAULT_maxLogSize = 5000
         private const val BATCH_INTERVAL_MS = 100L
+
+        /** Anchors the start of a standard `-v time` line: `MM-DD HH:MM:SS.mmm`. */
+        private val TIMESTAMP_ANCHOR = Regex("""\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}\.\d{3}""")
+
+        /** App-UID name form printed by some devices' `-v uid`, e.g. `u0_a123`. */
+        private val APP_UID_NAME = Regex("""^u(\d+)_a(\d+)$""")
+
+        /**
+         * Splits the optional `-v uid` prefix off a raw logcat line.
+         *
+         * The line shape is `<uid> MM-DD HH:MM:SS.mmm L/Tag( pid): msg`. We locate the timestamp
+         * and treat everything before it as the UID token, returning the remainder as the
+         * display [text] so it matches the plain `-v time` format every downstream parser expects.
+         * Lines with no timestamp (reader warnings, wrapped stack-trace lines) yield `null` UID
+         * and the full line as text.
+         */
+        internal fun parseUidPrefix(raw: String): Pair<Int?, String> {
+            val match = TIMESTAMP_ANCHOR.find(raw) ?: return null to raw
+            val start = match.range.first
+            if (start == 0) return null to raw
+            val prefix = raw.substring(0, start).trim()
+            val text = raw.substring(start)
+            return parseUid(prefix) to text
+        }
+
+        /**
+         * Converts a logcat UID token to a numeric Android UID. Handles plain numbers and the
+         * `u<user>_a<appId>` app-UID name form; returns `null` for anything else.
+         */
+        internal fun parseUid(token: String): Int? {
+            token.toIntOrNull()?.let { return it }
+            APP_UID_NAME.matchEntire(token)?.let { m ->
+                val user = m.groupValues[1].toIntOrNull() ?: return null
+                val appId = m.groupValues[2].toIntOrNull() ?: return null
+                // App UIDs for user N: N * 100000 + (10000 + appId).
+                return user * 100_000 + 10_000 + appId
+            }
+            return null
+        }
     }
 
     @Volatile
@@ -88,7 +132,8 @@ class StateDelegate(
                 is LogEvent.System -> {
                     event.msg.split('\n').forEach { raw ->
                         if (raw.isNotBlank()) {
-                            systemLines.add(IndexedLogLine(idCounter.incrementAndGet(), raw))
+                            val (uid, text) = parseUidPrefix(raw)
+                            systemLines.add(IndexedLogLine(idCounter.incrementAndGet(), text, uid))
                         }
                     }
                 }

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/delegates/StateDelegate.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/delegates/StateDelegate.kt
@@ -55,22 +55,25 @@ class StateDelegate(
         /** App-UID name form printed by some devices' `-v uid`, e.g. `u0_a123`. */
         private val APP_UID_NAME = Regex("""^u(\d+)_a(\d+)$""")
 
+        /** Result of parsing a raw logcat line into its UID prefix and display text. */
+        internal data class ParsedLogLine(val uid: Int?, val text: String, val hasTimestamp: Boolean)
+
         /**
          * Splits the optional `-v uid` prefix off a raw logcat line.
          *
          * The line shape is `<uid> MM-DD HH:MM:SS.mmm L/Tag( pid): msg`. We locate the timestamp
          * and treat everything before it as the UID token, returning the remainder as the
          * display [text] so it matches the plain `-v time` format every downstream parser expects.
-         * Lines with no timestamp (reader warnings, wrapped stack-trace lines) yield `null` UID
-         * and the full line as text.
+         * Lines with no timestamp (reader warnings, wrapped stack-trace lines) are reported with
+         * [hasTimestamp]`= false` so the caller can attribute continuation lines to the preceding
+         * entry's UID.
          */
-        internal fun parseUidPrefix(raw: String): Pair<Int?, String> {
-            val match = TIMESTAMP_ANCHOR.find(raw) ?: return null to raw
+        internal fun parseUidPrefix(raw: String): ParsedLogLine {
+            val match = TIMESTAMP_ANCHOR.find(raw) ?: return ParsedLogLine(null, raw, false)
             val start = match.range.first
-            if (start == 0) return null to raw
+            if (start == 0) return ParsedLogLine(null, raw, true)
             val prefix = raw.substring(0, start).trim()
-            val text = raw.substring(start)
-            return parseUid(prefix) to text
+            return ParsedLogLine(parseUid(prefix), raw.substring(start), true)
         }
 
         /**
@@ -98,6 +101,11 @@ class StateDelegate(
 
     private val idCounter = AtomicLong(0L)
     private val logChannel = Channel<LogEvent>(Channel.UNLIMITED)
+
+    // UID of the most recent log entry that carried a timestamp. Header-less continuation lines
+    // (e.g. stack traces) inherit it so they stay attributed to the same app. Only ever touched
+    // from the single batch-processing coroutine below, so no synchronization is needed.
+    private var lastSeenUid: Int? = null
 
     init {
         if (bufferSizeFlow != null) {
@@ -132,8 +140,17 @@ class StateDelegate(
                 is LogEvent.System -> {
                     event.msg.split('\n').forEach { raw ->
                         if (raw.isNotBlank()) {
-                            val (uid, text) = parseUidPrefix(raw)
-                            systemLines.add(IndexedLogLine(idCounter.incrementAndGet(), text, uid))
+                            val parsed = parseUidPrefix(raw)
+                            val uid = if (parsed.hasTimestamp) {
+                                // New log entry: trust its own UID (may be null) and remember it.
+                                lastSeenUid = parsed.uid
+                                parsed.uid
+                            } else {
+                                // Header-less continuation line (stack trace, wrapped message):
+                                // inherit the preceding entry's UID so it isn't dropped from the app tab.
+                                parsed.uid ?: lastSeenUid
+                            }
+                            systemLines.add(IndexedLogLine(idCounter.incrementAndGet(), parsed.text, uid))
                         }
                     }
                 }

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/utils/LogcatReader.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/utils/LogcatReader.kt
@@ -33,11 +33,15 @@ object LogcatReader {
      */
     fun observe(useRoot: Boolean): Flow<String> = flow {
         // Construct the command.
-        // "-v time" ensures we get the timestamp in a known format for parsing.
+        // "-v time" gives the timestamp in a known format for parsing; "-v uid" prepends the
+        // logged process's UID so [StateDelegate] can attribute each line to an app (used for
+        // per-app monitoring). The UID prefix is stripped back off before display, so downstream
+        // parsing still sees the familiar "-v time" line shape. Requires READ_LOGS or root to see
+        // other apps' UIDs; without either it simply reports this app's own logs.
         val cmd = if (useRoot) {
-            listOf("su", "-c", "logcat -v time")
+            listOf("su", "-c", "logcat -v uid -v time")
         } else {
-            listOf("logcat", "-v", "time")
+            listOf("logcat", "-v", "uid", "-v", "time")
         }
         
         // Endless loop: The "Resurrection Loop".

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/utils/UserPreferences.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/utils/UserPreferences.kt
@@ -34,7 +34,8 @@ data class ExportedPreferences(
     val bufferSize: Int,
     val activeLogLevels: Set<String>,
     val colorScheme: String = LogColorScheme.MATERIAL.name,
-    val tagColoringEnabled: Boolean = true
+    val tagColoringEnabled: Boolean = true,
+    val monitoredApps: List<String> = emptyList()
 )
 
 /**
@@ -108,6 +109,13 @@ class UserPreferences(context: Context) {
     // Set of tag strings to block.
     private val _prohibitedTags = MutableStateFlow(loadProhibitedTags())
     val prohibitedTags: StateFlow<Set<String>> = _prohibitedTags.asStateFlow()
+
+    // --- Preference: Monitored Apps ---
+    // Package names the user has pinned for dedicated, app-specific log tabs.
+    private val _monitoredApps = MutableStateFlow(
+        prefs.getStringSet(KEY_MONITORED_APPS, emptySet()) ?: emptySet()
+    )
+    val monitoredApps: StateFlow<Set<String>> = _monitoredApps.asStateFlow()
 
     // --- Preference: Color Scheme ---
     private val _colorScheme = MutableStateFlow(loadColorScheme())
@@ -200,6 +208,25 @@ class UserPreferences(context: Context) {
         current.remove(tag)
         _prohibitedTags.value = current
         saveProhibitedTags(current)
+    }
+
+    /** Pins a package for a dedicated app-specific log tab. */
+    fun addMonitoredApp(packageName: String) {
+        if (packageName.isBlank()) return
+        val current = _monitoredApps.value.toMutableSet()
+        if (current.add(packageName)) {
+            prefs.edit().putStringSet(KEY_MONITORED_APPS, current).apply()
+            _monitoredApps.value = current
+        }
+    }
+
+    /** Unpins a previously monitored package. */
+    fun removeMonitoredApp(packageName: String) {
+        val current = _monitoredApps.value.toMutableSet()
+        if (current.remove(packageName)) {
+            prefs.edit().putStringSet(KEY_MONITORED_APPS, current).apply()
+            _monitoredApps.value = current
+        }
     }
 
     /**
@@ -311,7 +338,8 @@ class UserPreferences(context: Context) {
             bufferSize = _bufferSize.value,
             activeLogLevels = _activeLogLevels.value,
             colorScheme = _colorScheme.value.name,
-            tagColoringEnabled = _tagColoringEnabled.value
+            tagColoringEnabled = _tagColoringEnabled.value,
+            monitoredApps = _monitoredApps.value.toList()
         )
         return try {
             Json { prettyPrint = true }.encodeToString(exported)
@@ -345,6 +373,10 @@ class UserPreferences(context: Context) {
             val tags = imported.prohibitedTags.toSet()
             _prohibitedTags.value = tags
             saveProhibitedTags(tags)
+
+            val apps = imported.monitoredApps.toSet()
+            prefs.edit().putStringSet(KEY_MONITORED_APPS, apps).apply()
+            _monitoredApps.value = apps
 
             val scheme = try { LogColorScheme.valueOf(imported.colorScheme) } catch (e: Exception) { LogColorScheme.MATERIAL }
 
@@ -385,5 +417,6 @@ class UserPreferences(context: Context) {
         private const val KEY_ACTIVE_LOG_LEVELS = "active_log_levels"
         private const val KEY_COLOR_SCHEME = "color_scheme"
         private const val KEY_TAG_COLORING = "tag_coloring_enabled"
+        private const val KEY_MONITORED_APPS = "monitored_apps"
     }
 }

--- a/docs/UI_UX.md
+++ b/docs/UI_UX.md
@@ -9,14 +9,17 @@ LogKitty is a developer tool designed to be unobtrusive yet instantly accessible
 - **Accents:** Minimal use of color; system colors used for specific log levels (Error=Red, Warn=Yellow) if implemented.
 
 ## Components
-- **Bottom Sheet:** The primary interaction point. It supports three states (heights include the system navigation bar area):
-    - **Hidden (Collapsed):** Small strip at the bottom (2% of screen height + Nav Bar).
-    - **Peek:** Small strip at the bottom, showing the last log line or status (25% of screen height + Nav Bar).
-    - **Fully-Expanded:** Covers 80% of the screen + Nav Bar for deep debugging.
+- **Bottom Sheet:** The primary interaction point. It supports four detents (heights include the system navigation bar area):
+    - **Hidden (Collapsed):** A thin one-line strip showing the latest log entry; tap to step up.
+    - **Peek:** Shows the last four log lines (sized so at least three stay visible above the nav bar).
+    - **Half / Fully-Expanded:** Tabs + the scrollable log list (50% / 90% of the screen) for deep debugging.
+    - Log line text is rendered at a forced font scale so a large system font setting can't shrink the visible line count or overflow the strips.
 - **Overlay:** A transparent touch-through layer that allows interaction with the app below when the sheet is collapsed.
+- **App Monitoring:** From Settings → "Monitor specific apps", pick an installed app to pin a dedicated tab showing only that app's logs (filtered by the app's UID), alongside the full System log.
+- **Notification:** The ongoing foreground notification offers a one-tap "Turn Off LogKitty" action (and body tap) that stops the service and removes the overlay.
 
 ## Interaction
-- **Drag:** Users can drag the sheet up/down to change states.
+- **Drag:** Users can drag the sheet up/down to change states; dragging down collapses straight to Hidden.
 - **Tap:** Tapping the peek view expands it.
 - **Copy:** A dedicated button allows copying visible logs to the clipboard.
 - **Clear:** A button to clear the current log buffer.

--- a/docs/file_descriptions.md
+++ b/docs/file_descriptions.md
@@ -22,17 +22,18 @@
 *   `LogKittyAccessibilityService.kt`: Background service that detects `TYPE_WINDOW_STATE_CHANGED` events to identify the foreground package for context-aware filtering.
 
 ### ui/
-*   `LogBottomSheet.kt`: The primary UI composable. Custom 4-detent overlay (HIDDEN/PEEK/HALF/FULL) with tab row, gesture zones, and selectable log items.
+*   `LogBottomSheet.kt`: The primary UI composable. Custom 4-detent overlay (HIDDEN shows one line, PEEK the last four, HALF/FULL the full list) with tab row, gesture zones, and selectable log items. Forces `fontScale = 1` on log lines so the rendered line height always matches the detent strip sizing regardless of the device's system font setting.
 *   `SheetController.kt`: Shared state holder for the active detent — consumed by both the Compose UI (for animation) and the hosting Service (for window sizing).
-*   `MainViewModel.kt`: The central logic controller. Bridges the `LogcatReader` data, `UserPreferences`, and the UI. Handles per-tab clearing and side-swipe tab navigation.
-*   `SettingsScreen.kt`: A dedicated screen for configuring app behavior. Hosts navigation into the prohibited-tags list, the color scheme editor, and preferences export/import.
+*   `MainViewModel.kt`: The central logic controller. Bridges the `LogcatReader` data, `UserPreferences`, and the UI. Handles per-tab clearing, side-swipe tab navigation, and pinned per-app tabs filtered reliably by the app's UID.
+*   `SettingsScreen.kt`: A dedicated screen for configuring app behavior. Hosts navigation into the prohibited-tags list, the color scheme editor, preferences export/import, and the "Monitor specific apps" picker.
+*   `AppPickerDialog.kt`: A searchable dialog listing installed apps (label + icon); returns the chosen package so it can be pinned for a dedicated, UID-filtered log tab.
 *   `ProhibitedLogsScreen.kt`: UI for managing the list of prohibited log tags/strings.
 *   `ColorSchemeEditorScreen.kt`: Per-level color customization. Selecting any swatch flips the active scheme to CUSTOM.
 *   `LogColors.kt`: Log level enum plus the built-in `LogColorScheme` palettes (Material, AOSP, Pidcat, Monochrome, Solarized, Custom) and the tag-based highlight rules.
 *   `ColorPickerDialog.kt`: A dialog composable for picking colors (used in settings).
 
 ### ui/delegates/
-*   `StateDelegate.kt`: The data holder and processor. Tags every log line with a monotonically-increasing `IndexedLogLine.id` (the basis for per-tab clearing), batches incoming lines, and caps the rolling buffer.
+*   `StateDelegate.kt`: The data holder and processor. Tags every log line with a monotonically-increasing `IndexedLogLine.id` (the basis for per-tab clearing) and the emitting process's `uid` (parsed from the `-v uid` column, for per-app filtering), batches incoming lines, and caps the rolling buffer.
 
 ### ui/theme/
 *   `Theme.kt`: Jetpack Compose theme definition.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 agp = "9.2.1"
 aetherTransportFile = "2.0.14"
-aznavrail = "9.5"
+aznavrail = "9.7"
 coreKtx = "1.18.0"
 kotlinxCoroutinesCore = "1.11.0"
 junit = "4.13.2"

--- a/version.properties
+++ b/version.properties
@@ -1,5 +1,5 @@
 #Tue May 26 17:49:02 CDT 2026
-build=5
+build=6
 major=0
 minor=6
-patch=0
+patch=1


### PR DESCRIPTION
## Summary

Updates **AzNavRail 9.5 → 9.7** (verified non-breaking — the bottom-sheet API is identical at 9.7) and fixes the four reported issues.

### 1. Collapse to the HIDDEN detent (one line)
`sheetConfig()` now sizes the HIDDEN strip to a single line with minimal vertical margin, so the sheet visibly *collapses* instead of resting as a chunky strip. The HIDDEN branch renders exactly one line.

### 2. PEEK shows at least three lines
PEEK is sized for four lines and renders the last four, and the strip is **top-aligned** so the lines pack clear of the system nav bar — at least three are always fully visible.

### 3. Quick "turn off" in the notification
The ongoing foreground notification now has a prominent one-tap **"Turn Off LogKitty"** action (body tap also stops it), which stops the service and tears down the overlay.

### 4. Monitor a specific app
- A searchable **installed-app picker** (Settings → "Monitor specific apps") pins a dedicated, persistent tab per chosen app.
- Per-app filtering is now reliable: the single logcat stream carries each line's **UID** (`logcat -v uid -v time`), parsed by anchoring on the timestamp so the displayed text is unchanged and all existing parsing/coloring is unaffected. App tabs filter by the app's resolved UID instead of brittle package-name substring matching. The full **System** ("everything") log is unchanged.

### Extra — font-scale robustness
Log-line text is rendered with a forced `fontScale = 1`, so a device with a large system font setting can't overflow the strips or reduce the visible line count. This keeps the detent heights (computed from the app's own font-size preference) in sync with what is actually drawn.

## Files
- `gradle/libs.versions.toml`, `version.properties` — version bumps
- `services/LogKittyOverlayService.kt` — detent heights + notification
- `ui/LogBottomSheet.kt` — HIDDEN one line / PEEK four lines, top-align, forced font scale
- `utils/LogcatReader.kt` — `-v uid -v time`
- `ui/delegates/StateDelegate.kt` — `IndexedLogLine.uid` + timestamp-anchored UID parse
- `ui/MainViewModel.kt` — UID resolution/cache, pinned per-app tabs, UID-based filter
- `utils/UserPreferences.kt` — `monitoredApps` preference (+ export/import)
- `ui/AppPickerDialog.kt` — new installed-app picker
- `ui/SettingsScreen.kt` — "Monitor specific apps" section
- `docs/` — updated UI/UX + file descriptions

## Verification note
The sandbox's egress proxy prevents Gradle from resolving Maven plugins/dependencies (Gradle's HTTP client connects directly to upstream IPs that the proxy drops, while curl/`HttpURLConnection` are routed through it), so `./gradlew assembleDebug` could not be run here. The changes were reviewed for compile correctness; **please let CI build this PR**. Manual on-device checks to perform: collapse to a one-line HIDDEN strip, PEEK showing ≥3 lines, the notification "Turn Off" action, and a pinned app tab showing only that app's logs while System shows everything.

---
_Generated by [Claude Code](https://claude.ai/code/session_017hRcXbYpxVLL1AhJi1t8Qk)_