### PR TITLE
Hotfix: restore logs — fall back from `-v uid` logcat format when unsupported

### DIFF
--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/MainViewModel.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/MainViewModel.kt
@@ -172,10 +172,14 @@ class MainViewModel(
                     val pkg = input.tab.filterValue
                     if (!pkg.isNullOrBlank()) {
                         val targetUid = uidFor(pkg)
-                        // Prefer reliable UID matching; fall back to substring if the package's
-                        // UID can't be resolved (e.g. it isn't installed).
-                        result = if (targetUid != null) result.filter { it.uid == targetUid }
-                                 else result.filter { it.text.contains(pkg, ignoreCase = true) }
+                        result = result.filter { line ->
+                            // Use reliable UID matching when both the target UID and the line's UID
+                            // are known (uid-annotated stream); otherwise fall back to package-name
+                            // substring matching — e.g. when logcat is running in the plain
+                            // `-v time` fallback format and lines carry no UID.
+                            if (targetUid != null && line.uid != null) line.uid == targetUid
+                            else line.text.contains(pkg, ignoreCase = true)
+                        }
                     }
                 }
             }

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/utils/LogcatReader.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/utils/LogcatReader.kt
@@ -21,6 +21,9 @@ import java.io.IOException
  */
 object LogcatReader {
 
+    /** Matches a standard logcat timestamp (`MM-DD HH:MM:SS.mmm`); used to detect real log output. */
+    private val TIMESTAMP_PATTERN = Regex("""\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}\.\d{3}""")
+
     /**
      * Starts observing the logcat stream.
      *
@@ -32,23 +35,25 @@ object LogcatReader {
      *                to the app's own logs unless READ_LOGS is granted via ADB).
      */
     fun observe(useRoot: Boolean): Flow<String> = flow {
-        // Construct the command.
-        // "-v time" gives the timestamp in a known format for parsing; "-v uid" prepends the
-        // logged process's UID so [StateDelegate] can attribute each line to an app (used for
-        // per-app monitoring). The UID prefix is stripped back off before display, so downstream
-        // parsing still sees the familiar "-v time" line shape. Requires READ_LOGS or root to see
-        // other apps' UIDs; without either it simply reports this app's own logs.
-        val cmd = if (useRoot) {
-            listOf("su", "-c", "logcat -v uid -v time")
-        } else {
-            listOf("logcat", "-v", "uid", "-v", "time")
-        }
-        
+        // Prefer the uid-annotated format ("-v uid -v time") so per-app tabs can filter reliably by
+        // UID. Some devices' logcat reject the `uid` modifier and emit nothing; if the uid attempt
+        // exits without ever producing a real (timestamped) log line, permanently downgrade to the
+        // plain "-v time" format so logs always appear.
+        var useUidFormat = true
+
         // Endless loop: The "Resurrection Loop".
         // If the process dies (e.g., log buffer cleared, system kills it), we want to restart it
         // automatically so the user doesn't have to toggle the service.
         while (currentCoroutineContext().isActive) {
+            val formatArgs = if (useUidFormat) listOf("-v", "uid", "-v", "time") else listOf("-v", "time")
+            val cmd = if (useRoot) {
+                listOf("su", "-c", "logcat " + formatArgs.joinToString(" "))
+            } else {
+                listOf("logcat") + formatArgs
+            }
+
             var process: Process? = null
+            var sawValidLog = false
             try {
                 // Use ProcessBuilder for better control over streams than Runtime.exec()
                 val pb = ProcessBuilder(cmd)
@@ -66,6 +71,7 @@ object LogcatReader {
 
                     // Inner loop: Stream data while the process is alive.
                     while (currentCoroutineContext().isActive && line != null) {
+                        if (!sawValidLog && TIMESTAMP_PATTERN.containsMatchIn(line)) sawValidLog = true
                         emit(line)
                         line = reader.readLine()
                     }
@@ -83,7 +89,14 @@ object LogcatReader {
                 // Ensure the zombie process is cleaned up before we loop around.
                 process?.destroyForcibly()
             }
-            
+
+            // The uid format exited without ever emitting a real log line — this device likely
+            // rejects `-v uid`. Downgrade to plain `-v time` and retry immediately so logs appear.
+            if (useUidFormat && !sawValidLog) {
+                useUidFormat = false
+                continue
+            }
+
             // If the coroutine is still active but the loop exited, wait a bit before restarting.
             if (currentCoroutineContext().isActive) {
                 delay(1000)


### PR DESCRIPTION
## Regression hotfix: LogKitty showed no logs

PR #87 switched the logcat stream to `logcat -v uid -v time` (to enable reliable per-app UID filtering). On devices whose `logcat` rejects the `-v uid` modifier, that command emits nothing — which dropped **all** logs, since the System tab shows every line regardless of UID.

### Fix
- **`LogcatReader`** now starts with the uid-annotated format, but if that attempt exits without ever producing a real (timestamped) log line, it **permanently downgrades to the original `logcat -v time`** command and retries immediately. So logs always appear; UID annotation is used only when the device actually supports it.
- **`MainViewModel`** per-app tab filter now falls back to package-name substring matching **per line** when a line has no UID (i.e. while running in the `-v time` fallback), and keeps exact UID matching when the uid format is active. So app tabs work in both modes.

No behavior change for devices where `-v uid` works; on devices where it doesn't, the app behaves exactly as it did before #87 (plain `-v time` + substring per-app matching).

## Verification
The sandbox can't run Gradle (egress proxy blocks Maven resolution), so please let CI build. On-device check: confirm the System tab streams logs again on a device/setup that previously went blank, and that a pinned app tab still shows that app's logs.

---
_Generated by [Claude Code](https://claude.ai/code/session_017hRcXbYpxVLL1AhJi1t8Qk)_