### PR TITLE
Pin HIDDEN/PEEK strip text to the nav bar (remove dead space below the line)

### DIFF
--- a/app/src/main/kotlin/com/hereliesaz/logkitty/services/LogKittyOverlayService.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/services/LogKittyOverlayService.kt
@@ -149,6 +149,7 @@ class LogKittyOverlayService : Service() {
                 LogBottomSheet(
                     controller = controller,
                     viewModel = viewModel,
+                    navBarHeightPx = navBarHeightPx,
                     onSaveClick = {
                         val intent = Intent(this@LogKittyOverlayService,
                             com.hereliesaz.logkitty.FileSaverActivity::class.java)
@@ -201,26 +202,25 @@ class LogKittyOverlayService : Service() {
      * control how the HIDDEN/PEEK strips look. The nav-bar height is folded in because the
      * sheet draws behind the system navigation bar (gravity-bottom, no-limits window).
      *
-     * `hiddenStripDp` — a thin one-line strip so the sheet visibly *collapses* (only minimal
-     * vertical padding above the nav bar; the [LogBottomSheet] HIDDEN branch renders one line).
-     * `peekDp` — room for four lines so that at least three are always fully visible above the
-     * nav bar (the PEEK branch renders the last four lines).
+     * `hiddenStripDp` — a thin one-line strip so the sheet visibly *collapses*; the line is pinned
+     * to the bottom (just above the nav bar) by [LogBottomSheet]'s PeekStrip so there's no dead
+     * space beneath it.
+     * `peekDp` — room for three lines, likewise bottom-pinned above the nav bar.
      */
     private fun sheetConfig(viewModel: MainViewModel, navBarHeightPx: Int): AzSheetConfig {
         val density = resources.displayMetrics.density
         val fontSize = viewModel.fontSize.value
-        // Matches the Text lineHeight used in LogBottomSheet's PeekStrip (fontSize * 1.35). PEEK is
-        // sized for four lines and top-aligns its content, so at least three stay visible above the
-        // nav bar without needing extra per-line headroom here.
+        // Matches the Text lineHeight used in LogBottomSheet's PeekStrip (fontSize * 1.35). The
+        // strip content is bottom-aligned above the nav bar, so each strip is sized to exactly
+        // its text lines plus the nav-bar band the sheet draws behind — no extra padding.
         val lineHeightPx = fontSize.toFloat() * density * 1.35f
 
-        // HIDDEN: a single line sitting right under the sheet's top edge, plus the nav bar the
-        // sheet draws behind. Keep the non-line margin tiny so the strip hugs one line.
-        val hiddenPx = (lineHeightPx * 1) + (1f * density) + navBarHeightPx
+        // HIDDEN: exactly one line sitting right above the nav bar.
+        val hiddenPx = (lineHeightPx * 1) + navBarHeightPx
         val hiddenDp = (hiddenPx / density).dp
 
-        // PEEK: size for four lines so three are reliably visible once the nav bar is subtracted.
-        val peekPx = (lineHeightPx * 4) + (16f * density) + navBarHeightPx
+        // PEEK: exactly three lines above the nav bar.
+        val peekPx = (lineHeightPx * 3) + navBarHeightPx
         val peekDp = (peekPx / density).dp
         return AzSheetConfig(
             backgroundColor = Color(viewModel.backgroundColor.value),

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/LogBottomSheet.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/LogBottomSheet.kt
@@ -98,6 +98,7 @@ fun AzSheetController.hide() { snapTo(AzSheetDetent.HIDDEN) }
 fun LogBottomSheet(
     controller: AzSheetController,
     viewModel: MainViewModel,
+    navBarHeightPx: Int,
     onSaveClick: () -> Unit,
     onSettingsClick: () -> Unit,
 ) {
@@ -133,6 +134,7 @@ fun LogBottomSheet(
         AzSheetDetent.HIDDEN -> PeekStrip(
             modifier = Modifier.fillMaxSize(),
             lines = listOf(indexedLog.lastOrNull()?.text ?: "LogKitty Ready"),
+            navBarHeightPx = navBarHeightPx,
             showTimestamp = showTimestamp,
             fontFamily = currentFontFamily,
             fontSize = fontSize,
@@ -143,7 +145,8 @@ fun LogBottomSheet(
         AzSheetDetent.PEEK -> PeekStrip(
             modifier = Modifier.fillMaxSize(),
             lines = if (indexedLog.isEmpty()) listOf("LogKitty Ready")
-                    else indexedLog.takeLast(4).map { it.text },
+                    else indexedLog.takeLast(3).map { it.text },
+            navBarHeightPx = navBarHeightPx,
             showTimestamp = showTimestamp,
             fontFamily = currentFontFamily,
             fontSize = fontSize,
@@ -233,6 +236,7 @@ fun LogBottomSheet(
 private fun PeekStrip(
     modifier: Modifier,
     lines: List<String>,
+    navBarHeightPx: Int,
     showTimestamp: Boolean,
     fontFamily: androidx.compose.ui.text.font.FontFamily?,
     fontSize: Int,
@@ -242,6 +246,7 @@ private fun PeekStrip(
 ) {
     val timestampRegex = remember { Regex("^\\d{2}-\\d{2}\\s\\d{2}:\\d{2}:\\d{2}\\.\\d{3}\\s+") }
     val density = LocalDensity.current
+    val navBarDp = with(density) { navBarHeightPx.toDp() }
 
     Box(
         modifier = modifier
@@ -259,10 +264,13 @@ private fun PeekStrip(
                 modifier = Modifier
                     .fillMaxWidth()
                     .fillMaxHeight()
-                    .padding(horizontal = 12.dp),
-                // Top-align so the lines pack from the top and stay clear of the system nav bar
-                // that overlays the bottom of the strip.
-                verticalArrangement = Arrangement.Top
+                    .padding(horizontal = 12.dp)
+                    // Reserve the nav-bar band at the bottom so the text sits *above* the system
+                    // nav bar instead of behind it.
+                    .padding(bottom = navBarDp),
+                // Bottom-align so the line(s) hug the nav bar with no dead space beneath them; any
+                // slack (a short log) shows above the text instead.
+                verticalArrangement = Arrangement.Bottom
             ) {
                 lines.forEach { line ->
                     val displayText = if (showTimestamp) line else line.replace(timestampRegex, "")
@@ -271,12 +279,12 @@ private fun PeekStrip(
                         fontFamily = fontFamily,
                         fontSize = fontSize.sp,
                         lineHeight = (fontSize * 1.35f).sp,
-                        // Trim the first line's top leading so the text hugs the top edge of the
-                        // sheet instead of floating below it.
+                        // Trim the leading above the first line and below the last so the text
+                        // block hugs the bottom edge tightly.
                         style = MaterialTheme.typography.bodySmall.copy(
                             lineHeightStyle = LineHeightStyle(
-                                alignment = LineHeightStyle.Alignment.Top,
-                                trim = LineHeightStyle.Trim.FirstLineTop
+                                alignment = LineHeightStyle.Alignment.Bottom,
+                                trim = LineHeightStyle.Trim.Both
                             )
                         ),
                         maxLines = 1,

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/LogBottomSheet.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/LogBottomSheet.kt
@@ -283,7 +283,7 @@ private fun PeekStrip(
                         // block hugs the bottom edge tightly.
                         style = MaterialTheme.typography.bodySmall.copy(
                             lineHeightStyle = LineHeightStyle(
-                                alignment = LineHeightStyle.Alignment.Bottom,
+                                alignment = LineHeightStyle.Alignment.Proportional,
                                 trim = LineHeightStyle.Trim.Both
                             )
                         ),

--- a/version.properties
+++ b/version.properties
@@ -1,5 +1,5 @@
 #Tue May 26 17:49:02 CDT 2026
-build=6
+build=7
 major=0
 minor=6
-patch=1
+patch=2


### PR DESCRIPTION
## Problem
The HIDDEN/PEEK strips showed the log line(s) with too much empty space **below** them. The strip content was top-aligned, so the text sat at the top and all the leftover height — unused line slots when the log is short, plus the nav-bar band the sheet draws behind — appeared as dead space beneath the text.

## Fix
Pin the strip content to the **bottom**, just above the system nav bar:
- `PeekStrip` now uses `Arrangement.Bottom` with a bottom padding equal to the nav-bar height, so the line(s) hug the nav bar with no gap beneath. When the log is short, the slack appears *above* the text instead.
- Detent heights tightened to exactly `N lines + nav bar` (HIDDEN = 1 line, PEEK = 3 lines) — removed the extra `+1dp`/`+16dp` slack.
- Line-height leading trimmed on both edges (`Trim.Both`) so the text block sits flush; forced `fontScale = 1` retained.
- `navBarHeightPx` is threaded from the service into `LogBottomSheet`/`PeekStrip`.

## Result
- **HIDDEN:** one line tight against the nav bar, no space below.
- **PEEK:** up to three lines pinned to the bottom; with a short/empty log the visible line still hugs the nav bar.

## Verification
Sandbox can't run Gradle (egress proxy blocks Maven), so please let CI build. On device: collapse to HIDDEN and confirm the single line sits right above the nav bar with no gap beneath; step to PEEK and confirm three lines pinned to the bottom.

---
_Generated by [Claude Code](https://claude.ai/code/session_017hRcXbYpxVLL1AhJi1t8Qk)_