### PR TITLE
Pad peek/hidden strip by the real nav-bar inset (remove dead space below the line)

### DIFF
--- a/app/src/main/kotlin/com/hereliesaz/logkitty/services/LogKittyOverlayService.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/services/LogKittyOverlayService.kt
@@ -149,7 +149,6 @@ class LogKittyOverlayService : Service() {
                 LogBottomSheet(
                     controller = controller,
                     viewModel = viewModel,
-                    navBarHeightPx = navBarHeightPx,
                     onSaveClick = {
                         val intent = Intent(this@LogKittyOverlayService,
                             com.hereliesaz.logkitty.FileSaverActivity::class.java)

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/services/LogKittyOverlayService.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/services/LogKittyOverlayService.kt
@@ -125,9 +125,21 @@ class LogKittyOverlayService : Service() {
     private fun setupOverlay() {
         val app = applicationContext as MainApplication
         val viewModel = app.mainViewModel
+        // Use the *actual* navigation-bar inset so the overlay window is exactly content + nav bar
+        // (matching the content's navigationBarsPadding). The resource value is a fixed ~48dp even
+        // on gesture nav, which would otherwise make the window taller than the bar and leave a
+        // touch dead zone over the app below. `getInsetsIgnoringVisibility` reports the bar height
+        // even while it's temporarily hidden.
         val navBarHeightPx = run {
-            val resId = resources.getIdentifier("navigation_bar_height", "dimen", "android")
-            if (resId > 0) resources.getDimensionPixelSize(resId) else 0
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                val wm = getSystemService(Context.WINDOW_SERVICE) as android.view.WindowManager
+                wm.currentWindowMetrics.windowInsets
+                    .getInsetsIgnoringVisibility(android.view.WindowInsets.Type.navigationBars())
+                    .bottom
+            } else {
+                val resId = resources.getIdentifier("navigation_bar_height", "dimen", "android")
+                if (resId > 0) resources.getDimensionPixelSize(resId) else 0
+            }
         }
 
         val composeOwners = ComposeLifecycleHelper().also {

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/LogBottomSheet.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/LogBottomSheet.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
@@ -98,7 +99,6 @@ fun AzSheetController.hide() { snapTo(AzSheetDetent.HIDDEN) }
 fun LogBottomSheet(
     controller: AzSheetController,
     viewModel: MainViewModel,
-    navBarHeightPx: Int,
     onSaveClick: () -> Unit,
     onSettingsClick: () -> Unit,
 ) {
@@ -134,7 +134,6 @@ fun LogBottomSheet(
         AzSheetDetent.HIDDEN -> PeekStrip(
             modifier = Modifier.fillMaxSize(),
             lines = listOf(indexedLog.lastOrNull()?.text ?: "LogKitty Ready"),
-            navBarHeightPx = navBarHeightPx,
             showTimestamp = showTimestamp,
             fontFamily = currentFontFamily,
             fontSize = fontSize,
@@ -146,7 +145,6 @@ fun LogBottomSheet(
             modifier = Modifier.fillMaxSize(),
             lines = if (indexedLog.isEmpty()) listOf("LogKitty Ready")
                     else indexedLog.takeLast(3).map { it.text },
-            navBarHeightPx = navBarHeightPx,
             showTimestamp = showTimestamp,
             fontFamily = currentFontFamily,
             fontSize = fontSize,
@@ -236,7 +234,6 @@ fun LogBottomSheet(
 private fun PeekStrip(
     modifier: Modifier,
     lines: List<String>,
-    navBarHeightPx: Int,
     showTimestamp: Boolean,
     fontFamily: androidx.compose.ui.text.font.FontFamily?,
     fontSize: Int,
@@ -246,7 +243,6 @@ private fun PeekStrip(
 ) {
     val timestampRegex = remember { Regex("^\\d{2}-\\d{2}\\s\\d{2}:\\d{2}:\\d{2}\\.\\d{3}\\s+") }
     val density = LocalDensity.current
-    val navBarDp = with(density) { navBarHeightPx.toDp() }
 
     Box(
         modifier = modifier
@@ -265,9 +261,9 @@ private fun PeekStrip(
                     .fillMaxWidth()
                     .fillMaxHeight()
                     .padding(horizontal = 12.dp)
-                    // Reserve the nav-bar band at the bottom so the text sits *above* the system
-                    // nav bar instead of behind it.
-                    .padding(bottom = navBarDp),
+                    // Pad by the *actual* navigation-bar inset so the text sits right above the
+                    // system nav bar with no dead space — whatever the real bar height is.
+                    .navigationBarsPadding(),
                 // Bottom-align so the line(s) hug the nav bar with no dead space beneath them; any
                 // slack (a short log) shows above the text instead.
                 verticalArrangement = Arrangement.Bottom

--- a/version.properties
+++ b/version.properties
@@ -1,5 +1,5 @@
 #Tue May 26 17:49:02 CDT 2026
-build=7
+build=8
 major=0
 minor=6
-patch=2
+patch=3


### PR DESCRIPTION
## Problem
After #89 the HIDDEN/PEEK strips still showed a dark empty band between the last log line and the navigation buttons (see user screenshots). Cause: the strip padded its content by a **hardcoded** `navigation_bar_height` resource value, which is larger than the actual navigation-bar inset on some devices — the surplus rendered as dead space below the text.

## Fix
Pad the strip content by the **real** navigation-bar inset using `Modifier.navigationBarsPadding()` instead of the hardcoded resource height. The text now hugs the actual nav bar exactly, whatever its real size. The detent height still includes the nav-bar band so the (behind-the-bar) overlay window has room; with bottom alignment, any slack falls *above* the text, never below it. Removed the now-unused `navBarHeightPx` plumbing into `LogBottomSheet`/`PeekStrip`.

## Result
- HIDDEN: single line flush against the nav bar, no gap beneath.
- PEEK: up to three lines pinned directly above the nav bar.

## Verification
Sandbox can't run Gradle (egress proxy blocks Maven), so please let CI build. On device: collapse to HIDDEN and to PEEK and confirm the last line sits directly above the nav buttons with **no** dark band beneath it — and that the last line is not clipped behind the buttons. (This relies on the overlay window receiving navigation-bar insets, which it should on Android 11+.)

---
_Generated by [Claude Code](https://claude.ai/code/session_017hRcXbYpxVLL1AhJi1t8Qk)_