### PR TITLE
Lift strip text by the measured nav-bar value (fix empty band above the line)

### DIFF
--- a/app/src/main/kotlin/com/hereliesaz/logkitty/services/LogKittyOverlayService.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/services/LogKittyOverlayService.kt
@@ -125,11 +125,11 @@ class LogKittyOverlayService : Service() {
     private fun setupOverlay() {
         val app = applicationContext as MainApplication
         val viewModel = app.mainViewModel
-        // Use the *actual* navigation-bar inset so the overlay window is exactly content + nav bar
-        // (matching the content's navigationBarsPadding). The resource value is a fixed ~48dp even
-        // on gesture nav, which would otherwise make the window taller than the bar and leave a
-        // touch dead zone over the app below. `getInsetsIgnoringVisibility` reports the bar height
-        // even while it's temporarily hidden.
+        // Use the *actual* navigation-bar inset so the overlay window is exactly content + nav bar,
+        // and the PeekStrip lifts its text by this same measured value. The resource value is a
+        // fixed ~48dp even on gesture nav, which would otherwise make the window taller than the bar
+        // and leave a touch dead zone over the app below. `getInsetsIgnoringVisibility` reports the
+        // bar height even while it's temporarily hidden.
         val navBarHeightPx = run {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
                 val wm = getSystemService(Context.WINDOW_SERVICE) as android.view.WindowManager
@@ -161,6 +161,7 @@ class LogKittyOverlayService : Service() {
                 LogBottomSheet(
                     controller = controller,
                     viewModel = viewModel,
+                    navBarHeightPx = navBarHeightPx,
                     onSaveClick = {
                         val intent = Intent(this@LogKittyOverlayService,
                             com.hereliesaz.logkitty.FileSaverActivity::class.java)

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/LogBottomSheet.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/LogBottomSheet.kt
@@ -17,7 +17,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
@@ -99,6 +98,7 @@ fun AzSheetController.hide() { snapTo(AzSheetDetent.HIDDEN) }
 fun LogBottomSheet(
     controller: AzSheetController,
     viewModel: MainViewModel,
+    navBarHeightPx: Int,
     onSaveClick: () -> Unit,
     onSettingsClick: () -> Unit,
 ) {
@@ -134,6 +134,7 @@ fun LogBottomSheet(
         AzSheetDetent.HIDDEN -> PeekStrip(
             modifier = Modifier.fillMaxSize(),
             lines = listOf(indexedLog.lastOrNull()?.text ?: "LogKitty Ready"),
+            navBarHeightPx = navBarHeightPx,
             showTimestamp = showTimestamp,
             fontFamily = currentFontFamily,
             fontSize = fontSize,
@@ -145,6 +146,7 @@ fun LogBottomSheet(
             modifier = Modifier.fillMaxSize(),
             lines = if (indexedLog.isEmpty()) listOf("LogKitty Ready")
                     else indexedLog.takeLast(3).map { it.text },
+            navBarHeightPx = navBarHeightPx,
             showTimestamp = showTimestamp,
             fontFamily = currentFontFamily,
             fontSize = fontSize,
@@ -234,6 +236,7 @@ fun LogBottomSheet(
 private fun PeekStrip(
     modifier: Modifier,
     lines: List<String>,
+    navBarHeightPx: Int,
     showTimestamp: Boolean,
     fontFamily: androidx.compose.ui.text.font.FontFamily?,
     fontSize: Int,
@@ -243,6 +246,9 @@ private fun PeekStrip(
 ) {
     val timestampRegex = remember { Regex("^\\d{2}-\\d{2}\\s\\d{2}:\\d{2}:\\d{2}\\.\\d{3}\\s+") }
     val density = LocalDensity.current
+    // Convert with the real device density (before the fontScale override below) so the padding
+    // equals the measured nav-bar inset exactly.
+    val navBarDp = with(density) { navBarHeightPx.toDp() }
 
     Box(
         modifier = modifier
@@ -261,9 +267,10 @@ private fun PeekStrip(
                     .fillMaxWidth()
                     .fillMaxHeight()
                     .padding(horizontal = 12.dp)
-                    // Pad by the *actual* navigation-bar inset so the text sits right above the
-                    // system nav bar with no dead space — whatever the real bar height is.
-                    .navigationBarsPadding(),
+                    // Lift the text above the system nav bar by the measured nav-bar height. The
+                    // overlay's Compose view doesn't reliably receive window insets, so use the
+                    // explicit value rather than navigationBarsPadding().
+                    .padding(bottom = navBarDp),
                 // Bottom-align so the line(s) hug the nav bar with no dead space beneath them; any
                 // slack (a short log) shows above the text instead.
                 verticalArrangement = Arrangement.Bottom

--- a/version.properties
+++ b/version.properties
@@ -1,5 +1,5 @@
 #Tue May 26 17:49:02 CDT 2026
-build=8
+build=9
 major=0
 minor=6
-patch=3
+patch=4


### PR DESCRIPTION
## Problem
After #90 the strip looked the same height with the line moved to the bottom and an empty band above it. Cause: #90 used `Modifier.navigationBarsPadding()`, which depends on the overlay's Compose view receiving window insets — it doesn't reliably, so the padding resolved to ~0. The line dropped to the window bottom while the window kept its nav-bar-sized height, so that band became dead space *above* the line instead of shrinking.

## Fix
Lift the strip text with an explicit bottom padding equal to the **measured** nav-bar inset (read from `WindowMetrics` in the service, #90) instead of `navigationBarsPadding()`. This doesn't depend on inset delivery, so the line sits flush at the real nav-bar top: the visible strip is exactly one line (HIDDEN) / up to three (PEEK) directly above the nav bar, with no empty band.

This combines the working approach from #89 (explicit padding) with the accurate measured value from #90 (instead of the fixed `navigation_bar_height` resource that caused the original gap).

## Verification
Sandbox can't run Gradle (egress proxy blocks Maven) — please let CI build. On device: collapse to HIDDEN → the single line sits directly above the nav buttons with no empty band above or below; PEEK → up to three lines pinned above the nav bar. Confirm the line isn't clipped behind the buttons.

---
_Generated by [Claude Code](https://claude.ai/code/session_017hRcXbYpxVLL1AhJi1t8Qk)_