### PR TITLE
Increment build number on every build, in any environment

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -30,22 +30,20 @@ val minor = versionProps.getProperty("minor")?.toIntOrNull() ?: 0
 val patch = versionProps.getProperty("patch")?.toIntOrNull() ?: 0
 var buildNumber = versionProps.getProperty("build")?.toIntOrNull() ?: 0
 
-// Automatic build number increment logic: increments only for actual build tasks
-val taskNames = gradle.startParameter.taskNames
-val isBuildTask = taskNames.any {
-    it.contains("assemble") || it.contains("bundle") || it.contains("install")
+// Automatic build-number increment: bump on every build that produces an artifact, regardless of
+// environment (CLI, Android Studio, CI) or which build task is invoked. This runs at configuration
+// time so the new number flows into versionCode/versionName below. Writing version.properties also
+// invalidates the configuration cache, so the next build re-runs this block and increments again.
+val isBuildTask = gradle.startParameter.taskNames.any { taskName ->
+    val name = taskName.substringAfterLast(':').lowercase()
+    name.startsWith("assemble") || name.startsWith("bundle") ||
+        name.startsWith("install") || name.startsWith("package") || name == "build"
 }
 
-if (isBuildTask && System.getProperty("version.incremented") != "true") {
+if (isBuildTask) {
     buildNumber++
     versionProps.setProperty("build", buildNumber.toString())
-    val writer = versionPropsFile.writer()
-    try {
-        versionProps.store(writer, null)
-    } finally {
-        writer.close()
-    }
-    System.setProperty("version.incremented", "true")
+    versionPropsFile.writer().use { versionProps.store(it, null) }
 }
 
 android {


### PR DESCRIPTION
## Problem
Building the app wasn't reliably incrementing the version. The auto-increment in `app/build.gradle.kts` guarded with `System.setProperty("version.incremented", "true")` — but that JVM system property lives for the **whole Gradle daemon lifetime**. So only the *first* build in a daemon session bumped the number; every build after that (Android Studio, repeated `./gradlew` runs — all reuse the daemon) saw the flag still set and skipped the increment.

## Fix
- **Drop the daemon-leaking guard.** The `:app` script is configured once per build invocation, so each build now increments exactly once.
- **Broaden build-task detection** to any artifact-producing task by leaf name: `assemble*`, `bundle*`, `install*`, `package*`, or `build` — so it fires no matter how the app is built (IDE, CLI, CI).
- Increment still runs at configuration time so the new number flows into `versionCode`/`versionName`. Writing `version.properties` invalidates the configuration cache, so the next build re-runs the block and increments again. (Non-build tasks like sync/`test` still don't bump.)

## Note
With this in place, the build owns the version number — manual bumps to `version.properties` are no longer needed (I'll stop adding them). One follow-up to consider: CI builds increment the number for the artifact but don't commit `version.properties` back, so the repo's stored number only advances when a local build's change is committed. If you want CI builds to be monotonic too, I can either have the release workflow commit the bump or derive the build number from the git commit count — your call.

## Verification
Sandbox can't run Gradle (egress proxy blocks Maven). To verify locally: run `./gradlew assembleDebug` twice **with the daemon running** and confirm `build=` in `version.properties` increases both times (previously it only bumped on the first run per daemon).

---
_Generated by [Claude Code](https://claude.ai/code/session_017hRcXbYpxVLL1AhJi1t8Qk)_