### PR TITLE
Don't reserve nav-bar space in the peek/hidden strips (remove the gap below the line)

### DIFF
--- a/app/src/main/kotlin/com/hereliesaz/logkitty/services/LogKittyOverlayService.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/services/LogKittyOverlayService.kt
@@ -151,7 +151,7 @@ class LogKittyOverlayService : Service() {
         val host = AzBottomSheetWindowHost(
             context = this,
             controller = controller,
-            config = sheetConfig(viewModel, navBarHeightPx),
+            config = sheetConfig(viewModel),
             lifecycleOwner = composeOwners,
             viewModelStoreOwner = composeOwners,
             savedStateRegistryOwner = composeOwners,
@@ -161,7 +161,6 @@ class LogKittyOverlayService : Service() {
                 LogBottomSheet(
                     controller = controller,
                     viewModel = viewModel,
-                    navBarHeightPx = navBarHeightPx,
                     onSaveClick = {
                         val intent = Intent(this@LogKittyOverlayService,
                             com.hereliesaz.logkitty.FileSaverActivity::class.java)
@@ -194,7 +193,7 @@ class LogKittyOverlayService : Service() {
                 viewModel.backgroundColor,
             ) { fs, op, bg -> Triple(fs, op, bg) }
                 .collect { (_, _, _) ->
-                    host.updateConfig(sheetConfig(viewModel, navBarHeightPx))
+                    host.updateConfig(sheetConfig(viewModel))
                 }
         }
 
@@ -211,28 +210,22 @@ class LogKittyOverlayService : Service() {
      * Build an [AzSheetConfig] from the user's current settings.
      *
      * The overlay window is resized to exactly these heights by the library, so they directly
-     * control how the HIDDEN/PEEK strips look. The nav-bar height is folded in because the
-     * sheet draws behind the system navigation bar (gravity-bottom, no-limits window).
-     *
-     * `hiddenStripDp` — a thin one-line strip so the sheet visibly *collapses*; the line is pinned
-     * to the bottom (just above the nav bar) by [LogBottomSheet]'s PeekStrip so there's no dead
-     * space beneath it.
-     * `peekDp` — room for three lines, likewise bottom-pinned above the nav bar.
+     * control how the HIDDEN/PEEK strips look. The nav bar is NOT folded in: the library's
+     * nav-bar decor window tints the system nav bar separately, so the sheet sits above it — each
+     * strip is sized to exactly its text lines, and the bottom line sits right above the nav bar.
      */
-    private fun sheetConfig(viewModel: MainViewModel, navBarHeightPx: Int): AzSheetConfig {
+    private fun sheetConfig(viewModel: MainViewModel): AzSheetConfig {
         val density = resources.displayMetrics.density
         val fontSize = viewModel.fontSize.value
-        // Matches the Text lineHeight used in LogBottomSheet's PeekStrip (fontSize * 1.35). The
-        // strip content is bottom-aligned above the nav bar, so each strip is sized to exactly
-        // its text lines plus the nav-bar band the sheet draws behind — no extra padding.
+        // Matches the Text lineHeight used in LogBottomSheet's PeekStrip (fontSize * 1.35).
         val lineHeightPx = fontSize.toFloat() * density * 1.35f
 
-        // HIDDEN: exactly one line sitting right above the nav bar.
-        val hiddenPx = (lineHeightPx * 1) + navBarHeightPx
+        // HIDDEN: exactly one line.
+        val hiddenPx = (lineHeightPx * 1)
         val hiddenDp = (hiddenPx / density).dp
 
-        // PEEK: exactly three lines above the nav bar.
-        val peekPx = (lineHeightPx * 3) + navBarHeightPx
+        // PEEK: exactly three lines.
+        val peekPx = (lineHeightPx * 3)
         val peekDp = (peekPx / density).dp
         return AzSheetConfig(
             backgroundColor = Color(viewModel.backgroundColor.value),

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/LogBottomSheet.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/LogBottomSheet.kt
@@ -98,7 +98,6 @@ fun AzSheetController.hide() { snapTo(AzSheetDetent.HIDDEN) }
 fun LogBottomSheet(
     controller: AzSheetController,
     viewModel: MainViewModel,
-    navBarHeightPx: Int,
     onSaveClick: () -> Unit,
     onSettingsClick: () -> Unit,
 ) {
@@ -134,7 +133,6 @@ fun LogBottomSheet(
         AzSheetDetent.HIDDEN -> PeekStrip(
             modifier = Modifier.fillMaxSize(),
             lines = listOf(indexedLog.lastOrNull()?.text ?: "LogKitty Ready"),
-            navBarHeightPx = navBarHeightPx,
             showTimestamp = showTimestamp,
             fontFamily = currentFontFamily,
             fontSize = fontSize,
@@ -146,7 +144,6 @@ fun LogBottomSheet(
             modifier = Modifier.fillMaxSize(),
             lines = if (indexedLog.isEmpty()) listOf("LogKitty Ready")
                     else indexedLog.takeLast(3).map { it.text },
-            navBarHeightPx = navBarHeightPx,
             showTimestamp = showTimestamp,
             fontFamily = currentFontFamily,
             fontSize = fontSize,
@@ -236,7 +233,6 @@ fun LogBottomSheet(
 private fun PeekStrip(
     modifier: Modifier,
     lines: List<String>,
-    navBarHeightPx: Int,
     showTimestamp: Boolean,
     fontFamily: androidx.compose.ui.text.font.FontFamily?,
     fontSize: Int,
@@ -246,9 +242,6 @@ private fun PeekStrip(
 ) {
     val timestampRegex = remember { Regex("^\\d{2}-\\d{2}\\s\\d{2}:\\d{2}:\\d{2}\\.\\d{3}\\s+") }
     val density = LocalDensity.current
-    // Convert with the real device density (before the fontScale override below) so the padding
-    // equals the measured nav-bar inset exactly.
-    val navBarDp = with(density) { navBarHeightPx.toDp() }
 
     Box(
         modifier = modifier
@@ -266,13 +259,10 @@ private fun PeekStrip(
                 modifier = Modifier
                     .fillMaxWidth()
                     .fillMaxHeight()
-                    .padding(horizontal = 12.dp)
-                    // Lift the text above the system nav bar by the measured nav-bar height. The
-                    // overlay's Compose view doesn't reliably receive window insets, so use the
-                    // explicit value rather than navigationBarsPadding().
-                    .padding(bottom = navBarDp),
-                // Bottom-align so the line(s) hug the nav bar with no dead space beneath them; any
-                // slack (a short log) shows above the text instead.
+                    .padding(horizontal = 12.dp),
+                // Bottom-align so the line(s) sit at the very bottom edge of the strip — right above
+                // the system nav bar, which the library's decor window tints separately. Any slack
+                // (a short log) shows above the text instead.
                 verticalArrangement = Arrangement.Bottom
             ) {
                 lines.forEach { line ->


### PR DESCRIPTION
## Problem
The HIDDEN/PEEK strips left a gap between the last log line and the nav buttons (user screenshots). I was reserving the nav-bar height in **both** the detent height and the text's bottom padding. But AzNavRail's nav-bar **decor window** tints the system nav bar separately and the sheet sits *above* it — so that reserved height was pure dead space, appearing as the gap.

## Fix
- Size each strip to exactly its text lines: HIDDEN = 1 line, PEEK = 3 lines (no `+ navBarHeightPx`).
- Drop the strip's bottom padding entirely.
- Keep the content bottom-aligned, so the last line sits right at the strip's bottom edge — directly above the nav bar.
- Removed the now-unused `navBarHeightPx` plumbing into `LogBottomSheet`/`PeekStrip` (it's still measured for the decor window).

## Result
HIDDEN is one line directly above the nav buttons; PEEK is three lines, last one directly above the buttons — no dead band beneath.

## Verification
Sandbox can't run Gradle (egress proxy blocks Maven) — please let CI build. On device: collapse to HIDDEN and PEEK and confirm the last line sits right above the nav buttons with no gap. If instead the last line is now *clipped behind* the buttons, the strip window does extend behind the nav bar after all and I'll re-add a small clearance — but per the screenshots the gap is the dead space to remove.

---
_Generated by [Claude Code](https://claude.ai/code/session_017hRcXbYpxVLL1AhJi1t8Qk)_