### PR TITLE
Upgrade AzNavRail 9.7 → 9.9 + patch all Dependabot security alerts

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -146,33 +146,43 @@ configurations.all {
     exclude(group = "com.intellij", module = "annotations")
     resolutionStrategy {
         eachDependency {
-            if (requested.group == "commons-logging" && requested.name == "commons-logging") {
-                useTarget("org.slf4j:jcl-over-slf4j:1.7.30")
-                because("Avoids duplicate classes with jcl-over-slf4j")
-            }
-            if (requested.group == "com.google.protobuf" && requested.name == "protobuf-kotlin") {
-                useVersion("3.25.5")
-                because("Security fix")
-            }
-            if (requested.group == "org.jdom" && requested.name == "jdom2") {
-                useVersion("2.0.6.1")
-                because("Security fix")
-            }
-            if (requested.group == "io.netty" && requested.name == "netty-codec-http2") {
-                useVersion("4.1.124.Final")
-                because("Security fix")
-            }
-            if (requested.group == "io.netty" && requested.name == "netty-handler") {
-                useVersion("4.1.118.Final")
-                because("Security fix")
-            }
-            if (requested.group == "org.bitbucket.b_c" && requested.name == "jose4j") {
-                useVersion("0.9.6")
-                because("Security fix")
-            }
-            if (requested.group == "io.netty" && requested.name == "netty-codec-http") {
-                useVersion("4.1.129.Final")
-                because("Security fix")
+            val g = requested.group
+            val n = requested.name
+            when {
+                g == "commons-logging" && n == "commons-logging" -> {
+                    useTarget("org.slf4j:jcl-over-slf4j:1.7.30")
+                    because("Avoids duplicate classes with jcl-over-slf4j")
+                }
+                g == "com.google.protobuf" && n == "protobuf-kotlin" -> {
+                    useVersion("3.25.5")
+                    because("Security fix")
+                }
+                // Netty artifacts are versioned together; force the whole family (except the
+                // separately-versioned tcnative natives) to the latest 4.1 security release.
+                g == "io.netty" && !n.startsWith("netty-tcnative") -> {
+                    useVersion("4.1.133.Final")
+                    because("Security fixes: CVE-2025-67735, CVE-2026-42583, CVE-2026-42587, et al.")
+                }
+                g == "org.bouncycastle" && n.endsWith("-jdk18on") -> {
+                    useVersion("1.84")
+                    because("Security fixes: CVE-2026-0636 (LDAP), covert timing channel, broken crypto")
+                }
+                g == "org.apache.commons" && n == "commons-lang3" -> {
+                    useVersion("3.18.0")
+                    because("Security fix: CVE-2025-48924 uncontrolled recursion")
+                }
+                g == "org.apache.httpcomponents" && n == "httpclient" -> {
+                    useVersion("4.5.14")
+                    because("Security fix: cross-site scripting (CVE-2020-13956)")
+                }
+                g == "org.jdom" && n == "jdom2" -> {
+                    useVersion("2.0.6.1")
+                    because("Security fix: XXE injection")
+                }
+                g == "org.bitbucket.b_c" && n == "jose4j" -> {
+                    useVersion("0.9.6")
+                    because("Security fix: DoS via compressed JWE content")
+                }
             }
         }
     }

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/services/LogKittyOverlayService.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/services/LogKittyOverlayService.kt
@@ -35,7 +35,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 
 /**
- * [LogKittyOverlayService] hosts the always-on Compose overlay using AzNavRail 8.13's
+ * [LogKittyOverlayService] hosts the always-on Compose overlay using AzNavRail's
  * [AzBottomSheetWindowHost]. The library owns:
  *
  *   - The `TYPE_APPLICATION_OVERLAY` window and the per-detent `WindowManager` resize bridge.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,43 @@
+// Force secure versions of transitive dependencies that ride in on the build / plugin classpath
+// (AGP's apksigner pulls BouncyCastle; other build tooling pulls Netty / jose4j / jdom2 /
+// httpclient / commons-lang3). These are what Dependabot flags against settings.gradle.kts.
+// `eachDependency` only rewrites dependencies that are actually present, so any force that doesn't
+// apply is a harmless no-op. Mirrored in app/build.gradle.kts for the app's own configurations.
+buildscript {
+    configurations.classpath {
+        resolutionStrategy.eachDependency {
+            val g = requested.group
+            val n = requested.name
+            when {
+                g == "io.netty" && !n.startsWith("netty-tcnative") -> {
+                    useVersion("4.1.133.Final")
+                    because("Security fixes: CVE-2025-67735, CVE-2026-42583, CVE-2026-42587, et al.")
+                }
+                g == "org.bouncycastle" && n.endsWith("-jdk18on") -> {
+                    useVersion("1.84")
+                    because("Security fixes: CVE-2026-0636 (LDAP), covert timing channel, broken crypto")
+                }
+                g == "org.apache.commons" && n == "commons-lang3" -> {
+                    useVersion("3.18.0")
+                    because("Security fix: CVE-2025-48924 uncontrolled recursion")
+                }
+                g == "org.apache.httpcomponents" && n == "httpclient" -> {
+                    useVersion("4.5.14")
+                    because("Security fix: cross-site scripting (CVE-2020-13956)")
+                }
+                g == "org.jdom" && n == "jdom2" -> {
+                    useVersion("2.0.6.1")
+                    because("Security fix: XXE injection")
+                }
+                g == "org.bitbucket.b_c" && n == "jose4j" -> {
+                    useVersion("0.9.6")
+                    because("Security fix: DoS via compressed JWE content")
+                }
+            }
+        }
+    }
+}
+
 plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.kotlin.compose) apply false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 agp = "9.2.1"
 aetherTransportFile = "2.0.14"
-aznavrail = "9.7"
+aznavrail = "9.9"
 coreKtx = "1.18.0"
 kotlinxCoroutinesCore = "1.11.0"
 junit = "4.13.2"


### PR DESCRIPTION
Two related dependency changes on the same branch (per the single-branch workflow).

## 1. AzNavRail 9.7 → 9.9
Non-breaking (all `AzSheetConfig` fields and the `AzBottomSheetWindowHost` constructor LogKitty uses are unchanged). LogKitty gains: live `updateConfig()` resize of the collapsed strip, real window-inset delivery, and one-detent-at-a-time drag. (Details unchanged from the original PR.)

## 2. Fix all 18 Dependabot security alerts
Every alert is a **Maven transitive dependency on the build / plugin classpath** (Dependabot attributes them to `settings.gradle.kts`), not LogKitty app code — AGP's apksigner pulls BouncyCastle, and other build tooling pulls Netty / jose4j / jdom2 / httpclient / commons-lang3. The pre-existing `resolutionStrategy` forces lived in `app/build.gradle.kts` and only covered the app's own configurations, so the build classpath stayed vulnerable and the alerts persisted.

Added a **buildscript-classpath** `resolutionStrategy` in the root `build.gradle.kts` and consolidated the app-side one to the same secure set:

| Dependency | Forced version | Alerts |
|---|---|---|
| `io.netty:*` (except tcnative) | **4.1.133.Final** | #17 #18 #23 #24 #25 #26 #27 #28 #29 #30 #31 (CVE-2025-67735, CVE-2026-42583 Lz4 DoS, CVE-2026-42587 decompression bomb, smuggling/desync/injection) |
| `org.bouncycastle:*-jdk18on` | **1.84** | #19 #20 #22 (CVE-2026-0636 LDAP, covert timing channel, broken crypto) |
| `org.apache.commons:commons-lang3` | **3.18.0** | #10 (CVE-2025-48924 uncontrolled recursion) |
| `org.apache.httpcomponents:httpclient` | **4.5.14** | #1 (XSS, CVE-2020-13956) |
| `org.jdom:jdom2` | **2.0.6.1** | #14 (XXE) |
| `org.bitbucket.b_c:jose4j` | **0.9.6** | #16 (DoS via compressed JWE) |

`eachDependency` only rewrites dependencies that are actually present, so any force that doesn't apply is a no-op.

## Verification
Sandbox can't run Gradle (egress proxy blocks Maven) — **please let CI build** (`build-and-release` + `submit-gradle`). After merge, the next `submit-gradle` run re-submits the dependency graph with the bumped versions, which should clear all 18 alerts. If CI surfaces an incompatibility from forcing a build-tooling dependency, I'll adjust the specific version.

> Note: these two changes are bundled because the workflow keeps all work on one branch. Happy to split them into separate PRs if you'd prefer — just grant a second branch.