### PR TITLE
Pause/resume capture + sheet header icons (play/pause, clear, close)

### DIFF
--- a/app/src/main/kotlin/com/hereliesaz/logkitty/services/LogKittyOverlayService.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/services/LogKittyOverlayService.kt
@@ -105,10 +105,15 @@ class LogKittyOverlayService : Service() {
 
         if (Settings.canDrawOverlays(this)) setupOverlay()
 
+        val viewModel = (applicationContext as MainApplication).mainViewModel
+        // Each new service session starts actively logging — the app-scoped ViewModel would
+        // otherwise retain a stale paused state from a previous session.
+        viewModel.setPaused(false)
+
         // Keep the notification's Start/Stop action in sync with the capture state, whether it's
         // toggled from the notification or the bottom sheet's play/pause control.
         serviceScope.launch {
-            (applicationContext as MainApplication).mainViewModel.isPaused.collect { updateNotification() }
+            viewModel.isPaused.collect { updateNotification() }
         }
 
         val filter = IntentFilter(LogKittyAccessibilityService.ACTION_COLLAPSE_OVERLAY)

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/services/LogKittyOverlayService.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/services/LogKittyOverlayService.kt
@@ -81,6 +81,10 @@ class LogKittyOverlayService : Service() {
                 }
                 startActivity(settingsIntent)
             }
+            ACTION_TOGGLE_PAUSE -> {
+                // The isPaused collector in onCreate refreshes the notification.
+                (applicationContext as MainApplication).mainViewModel.togglePause()
+            }
         }
         return START_STICKY
     }
@@ -100,6 +104,12 @@ class LogKittyOverlayService : Service() {
         }
 
         if (Settings.canDrawOverlays(this)) setupOverlay()
+
+        // Keep the notification's Start/Stop action in sync with the capture state, whether it's
+        // toggled from the notification or the bottom sheet's play/pause control.
+        serviceScope.launch {
+            (applicationContext as MainApplication).mainViewModel.isPaused.collect { updateNotification() }
+        }
 
         val filter = IntentFilter(LogKittyAccessibilityService.ACTION_COLLAPSE_OVERLAY)
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
@@ -250,17 +260,37 @@ class LogKittyOverlayService : Service() {
         }
     }
 
+    /** Rebuilds and re-posts the notification (e.g. to flip the Start/Stop action on pause toggle). */
+    private fun updateNotification() {
+        runCatching {
+            getSystemService(NotificationManager::class.java)?.notify(SERVICE_ID, createNotification())
+        }
+    }
+
     private fun createNotification(): Notification {
+        val isPaused = (applicationContext as MainApplication).mainViewModel.isPaused.value
+
         val stopIntent = Intent(this, LogKittyOverlayService::class.java).apply { action = ACTION_STOP_SERVICE }
         val stopPending = PendingIntent.getService(this, 0, stopIntent, PendingIntent.FLAG_IMMUTABLE)
         val settingsIntent = Intent(this, LogKittyOverlayService::class.java).apply { action = ACTION_OPEN_SETTINGS }
         val settingsPending = PendingIntent.getService(this, 1, settingsIntent, PendingIntent.FLAG_IMMUTABLE)
+        val pauseIntent = Intent(this, LogKittyOverlayService::class.java).apply { action = ACTION_TOGGLE_PAUSE }
+        val pausePending = PendingIntent.getService(this, 2, pauseIntent, PendingIntent.FLAG_IMMUTABLE)
+
         return NotificationCompat.Builder(this, CHANNEL_ID)
             .setContentTitle("LogKitty is running")
-            .setContentText("Tap to turn off. Expand for App Settings.")
+            .setContentText(
+                if (isPaused) "Logging paused. Tap to turn off." else "Logging. Tap to turn off."
+            )
             .setSmallIcon(android.R.drawable.ic_menu_view)
-            // Body tap and the prominent first action both stop the service (tears down the overlay).
+            // Body tap and the "Turn Off" action both stop the service (tears down the overlay).
             .setContentIntent(stopPending)
+            // Start/Stop toggles log capture (mirrors the sheet's play/pause).
+            .addAction(
+                if (isPaused) android.R.drawable.ic_media_play else android.R.drawable.ic_media_pause,
+                if (isPaused) "Start" else "Stop",
+                pausePending
+            )
             .addAction(android.R.drawable.ic_menu_close_clear_cancel, "Turn Off LogKitty", stopPending)
             .addAction(android.R.drawable.ic_menu_preferences, "App Settings", settingsPending)
             .setOngoing(true)
@@ -273,5 +303,6 @@ class LogKittyOverlayService : Service() {
         private const val SERVICE_ID = 1001
         private const val ACTION_STOP_SERVICE = "com.hereliesaz.logkitty.STOP_SERVICE"
         private const val ACTION_OPEN_SETTINGS = "com.hereliesaz.logkitty.OPEN_SETTINGS"
+        private const val ACTION_TOGGLE_PAUSE = "com.hereliesaz.logkitty.TOGGLE_PAUSE"
     }
 }

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/LogBottomSheet.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/LogBottomSheet.kt
@@ -24,9 +24,11 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Block
-import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material.icons.filled.DeleteSweep
+import androidx.compose.material.icons.filled.Pause
+import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Save
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Settings
@@ -43,7 +45,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -113,14 +114,12 @@ fun LogBottomSheet(
     val logColors by viewModel.logColors.collectAsState()
     val isLogReversed by viewModel.isLogReversed.collectAsState()
     val tagColoringEnabled by viewModel.tagColoringEnabled.collectAsState()
+    val isPaused by viewModel.isPaused.collectAsState()
 
     val currentFontFamily = remember(fontFamilyName) {
         val enumVal = try { CodingFont.valueOf(fontFamilyName) } catch (e: Exception) { CodingFont.SYSTEM }
         getGoogleFontFamily(enumVal.fontName)
     }
-
-    // X-button double-press tracking (clear → hide).
-    var lastClearAt by remember { mutableLongStateOf(0L) }
 
     var selectedLineIds by remember { mutableStateOf<Set<Long>>(emptySet()) }
     var isMultiSelectMode by remember { mutableStateOf(false) }
@@ -161,6 +160,7 @@ fun LogBottomSheet(
             fontSize = fontSize,
             showTimestamp = showTimestamp,
             isLogReversed = isLogReversed,
+            isPaused = isPaused,
             selectedLineIds = selectedLineIds,
             selectedLines = selectedLines,
             onTapLine = { id ->
@@ -192,16 +192,9 @@ fun LogBottomSheet(
                 controller.hide()
                 onSettingsClick()
             },
-            onClearClick = {
-                val now = System.currentTimeMillis()
-                if (now - lastClearAt < 3000L) {
-                    controller.hide()
-                    lastClearAt = 0L
-                } else {
-                    viewModel.clearActiveTab()
-                    lastClearAt = now
-                }
-            },
+            onTogglePause = { viewModel.togglePause() },
+            onClearClick = { viewModel.clearActiveTab() },
+            onCloseClick = { controller.hide() },
             onCopySelected = {
                 val joined = selectedLines.joinToString("\n") { it.text }
                 clipboardManager.setText(AnnotatedString(joined))
@@ -301,6 +294,7 @@ private fun ExpandedView(
     fontSize: Int,
     showTimestamp: Boolean,
     isLogReversed: Boolean,
+    isPaused: Boolean,
     selectedLineIds: Set<Long>,
     selectedLines: List<IndexedLogLine>,
     onTapLine: (Long) -> Unit,
@@ -312,7 +306,9 @@ private fun ExpandedView(
     onSwipeRight: () -> Unit,
     onSaveClick: () -> Unit,
     onSettingsClick: () -> Unit,
+    onTogglePause: () -> Unit,
     onClearClick: () -> Unit,
+    onCloseClick: () -> Unit,
     onCopySelected: () -> Unit,
     onSearchLine: (IndexedLogLine) -> Unit,
     onProhibitLine: (IndexedLogLine) -> Unit,
@@ -375,8 +371,18 @@ private fun ExpandedView(
                     IconButton(onClick = onSettingsClick, modifier = Modifier.size(36.dp)) {
                         Icon(Icons.Default.Settings, "Settings", tint = MaterialTheme.colorScheme.onSurface)
                     }
+                    IconButton(onClick = onTogglePause, modifier = Modifier.size(36.dp)) {
+                        Icon(
+                            if (isPaused) Icons.Default.PlayArrow else Icons.Default.Pause,
+                            contentDescription = if (isPaused) "Resume logging" else "Pause logging",
+                            tint = MaterialTheme.colorScheme.onSurface
+                        )
+                    }
                     IconButton(onClick = onClearClick, modifier = Modifier.size(36.dp)) {
-                        Icon(Icons.Default.Clear, "Clear / Hide", tint = MaterialTheme.colorScheme.onSurface)
+                        Icon(Icons.Default.DeleteSweep, "Clear logs", tint = MaterialTheme.colorScheme.onSurface)
+                    }
+                    IconButton(onClick = onCloseClick, modifier = Modifier.size(36.dp)) {
+                        Icon(Icons.Default.Close, "Close", tint = MaterialTheme.colorScheme.onSurface)
                     }
                 }
             }

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/MainViewModel.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/MainViewModel.kt
@@ -103,6 +103,15 @@ class MainViewModel(
     private val _currentForegroundApp = MutableStateFlow<String?>(null)
     val currentForegroundApp: StateFlow<String?> = _currentForegroundApp
 
+    // Whether log capture is paused (frozen). Runtime-only: the logcat stream keeps running but new
+    // lines are dropped while paused so the view holds still. Toggled from the sheet's play/pause
+    // control and the notification's Start/Stop action.
+    private val _isPaused = MutableStateFlow(false)
+    val isPaused: StateFlow<Boolean> = _isPaused
+
+    fun togglePause() { _isPaused.value = !_isPaused.value }
+    fun setPaused(paused: Boolean) { _isPaused.value = paused }
+
     // Preference Flows (Directly exposed from UserPreferences)
     val isContextModeEnabled: StateFlow<Boolean> = userPreferences.isContextModeEnabled
     val customFilter: StateFlow<String> = userPreferences.customFilter
@@ -224,7 +233,7 @@ class MainViewModel(
                 stateDelegate.clearLog() // Clear old logs (optional, but cleaner)
                 logJob = launch {
                     LogcatReader.observe(useRoot).collect {
-                        stateDelegate.appendSystemLog(it)
+                        if (!_isPaused.value) stateDelegate.appendSystemLog(it)
                     }
                 }
             }

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/MainViewModel.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/MainViewModel.kt
@@ -109,7 +109,7 @@ class MainViewModel(
     private val _isPaused = MutableStateFlow(false)
     val isPaused: StateFlow<Boolean> = _isPaused
 
-    fun togglePause() { _isPaused.value = !_isPaused.value }
+    fun togglePause() { _isPaused.update { !it } }
     fun setPaused(paused: Boolean) { _isPaused.value = paused }
 
     // Preference Flows (Directly exposed from UserPreferences)


### PR DESCRIPTION
**PR 1 of 5** from the batch of seven requested features.

## What
- **Pause/resume log capture** — a new freeze toggle (`MainViewModel.isPaused`) gates the logcat collector; the stream keeps running but new lines are dropped while paused so the view holds still.
- **Sheet header icons reworked** (Save · Settings · **Play/Pause** · **Clear** · **Close**):
  - New **Play/Pause** button (`PlayArrow`/`Pause`) → toggles capture.
  - **Clear logs** now uses a proper icon (`DeleteSweep`), single-press → clears the active tab. (Was an X with a confusing double-press-to-hide.)
  - New **Close (X)** button → collapses the sheet to HIDDEN.
- **Notification Start/Stop** — a new action toggles capture, mirroring the sheet's play/pause and staying in sync both ways. "Turn Off LogKitty" and "App Settings" are kept.

## Verification
Sandbox can't run Gradle — please let CI build. On device: tap Pause → list freezes and the notification action flips to "Start"; tap the DeleteSweep icon → active tab clears; tap X → sheet collapses to hidden; toggling capture from the notification updates the sheet icon and vice-versa.

(First of five small PRs; the others — log-source filters, settings footer links, AdMob test banner, and draw-behind-nav-bar — follow.)

---
_Generated by [Claude Code](https://claude.ai/code/session_017hRcXbYpxVLL1AhJi1t8Qk)_