### PR TITLE
Log-source filter tabs (buckets + app categories, grouped in Settings)

### DIFF
--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/MainViewModel.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/MainViewModel.kt
@@ -206,7 +206,7 @@ class MainViewModel(
                 result = result.filter { it.text.contains(input.userFilter, ignoreCase = true) }
             }
             result
-        }.flowOn(Dispatchers.Default).stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+        }.flowOn(Dispatchers.IO).stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
     }
 
     /**

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/MainViewModel.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/MainViewModel.kt
@@ -14,11 +14,14 @@ import com.hereliesaz.logkitty.ui.delegates.IndexedLogLine
 import com.hereliesaz.logkitty.ui.delegates.StateDelegate
 import com.hereliesaz.logkitty.ui.theme.CodingFont
 import com.hereliesaz.logkitty.utils.LogcatReader
+import com.hereliesaz.logkitty.utils.LogSourceClassifier
+import com.hereliesaz.logkitty.utils.LogSources
 import com.hereliesaz.logkitty.utils.UserPreferences
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
@@ -45,7 +48,8 @@ data class LogTab(
 enum class TabType {
     SYSTEM,
     ERRORS,
-    APP
+    APP,
+    SOURCE
 }
 
 /**
@@ -94,6 +98,15 @@ class MainViewModel(
     fun addMonitoredApp(pkg: String) = userPreferences.addMonitoredApp(pkg)
     fun removeMonitoredApp(pkg: String) = userPreferences.removeMonitoredApp(pkg)
 
+    // Classifies each log line's UID into source/category buckets for the per-source tabs.
+    private val sourceClassifier = LogSourceClassifier(application)
+
+    /** Source/category filter keys (see `LogSources`) the user has enabled as dedicated tabs. */
+    val activeSourceFilters: StateFlow<Set<String>> = userPreferences.activeSourceFilters
+
+    fun setSourceFilterEnabled(key: String, enabled: Boolean) =
+        userPreferences.setSourceFilterEnabled(key, enabled)
+
     // Delegate to handle the heavy lifting of log buffering.
     val stateDelegate = StateDelegate(viewModelScope, bufferSizeFlow = userPreferences.bufferSize)
 
@@ -127,7 +140,7 @@ class MainViewModel(
     private val _tabClearMarks = MutableStateFlow<Map<String, Long>>(emptyMap())
 
     // Tab Management
-    private val systemTab = LogTab("system", "System", TabType.SYSTEM)
+    private val systemTab = LogTab("system", "All", TabType.SYSTEM)
     private val errorsTab = LogTab("errors", "Errors", TabType.ERRORS)
 
     private val _tabs = MutableStateFlow(listOf(systemTab, errorsTab))
@@ -182,12 +195,18 @@ class MainViewModel(
                         }
                     }
                 }
+                TabType.SOURCE -> {
+                    val key = input.tab.filterValue
+                    if (!key.isNullOrBlank()) {
+                        result = result.filter { sourceClassifier.classify(it.uid).contains(key) }
+                    }
+                }
             }
             if (input.userFilter.isNotBlank()) {
                 result = result.filter { it.text.contains(input.userFilter, ignoreCase = true) }
             }
             result
-        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+        }.flowOn(Dispatchers.Default).stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
     }
 
     /**
@@ -236,6 +255,11 @@ class MainViewModel(
             userPreferences.monitoredApps.collect { syncMonitoredTabs(it) }
         }
 
+        // Keep the per-source tabs in sync with the user's "Log sources" choices.
+        viewModelScope.launch {
+            userPreferences.activeSourceFilters.collect { syncSourceTabs(it) }
+        }
+
         // Register the Accessibility Receiver
         val filter = IntentFilter(LogKittyAccessibilityService.ACTION_FOREGROUND_APP_CHANGED)
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
@@ -267,6 +291,24 @@ class MainViewModel(
                 }
             }
             result
+        }
+        if (_tabs.value.none { it.id == _selectedTab.value.id }) {
+            _selectedTab.value = _tabs.value.firstOrNull() ?: systemTab
+        }
+    }
+
+    /**
+     * Reconciles the per-source tabs (id prefix `source_`) with the user's enabled source filters,
+     * preserving order: Sources first, then Categories, matching the settings layout.
+     */
+    private fun syncSourceTabs(filters: Set<String>) {
+        _tabs.update { current ->
+            val withoutSources = current.filterNot { it.id.startsWith("source_") }
+            val ordered = (LogSources.SOURCE_BUCKETS + LogSources.CATEGORY_BUCKETS).filter { it in filters }
+            val sourceTabs = ordered.map { key ->
+                LogTab("source_$key", LogSources.label(key), TabType.SOURCE, key)
+            }
+            withoutSources + sourceTabs
         }
         if (_tabs.value.none { it.id == _selectedTab.value.id }) {
             _selectedTab.value = _tabs.value.firstOrNull() ?: systemTab

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/SettingsScreen.kt
@@ -524,9 +524,11 @@ private fun SourceFilterGroup(
                 .padding(vertical = 2.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
+            // onCheckedChange = null: the Row's clickable owns the toggle, merging both into one
+            // accessible touch target.
             Checkbox(
                 checked = key in enabled,
-                onCheckedChange = { onToggle(key, it) }
+                onCheckedChange = null
             )
             Text(LogSources.label(key), style = MaterialTheme.typography.bodyLarge)
         }

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/SettingsScreen.kt
@@ -59,6 +59,7 @@ import androidx.compose.ui.unit.dp
 import com.hereliesaz.aznavrail.AzButton
 import com.hereliesaz.aznavrail.model.AzButtonShape
 import com.hereliesaz.logkitty.ui.theme.CodingFont
+import com.hereliesaz.logkitty.utils.LogSources
 
 /**
  * [SettingsScreen] provides a full-screen configuration UI with three navigation targets:
@@ -115,6 +116,7 @@ private fun SettingsMainScreen(
     val tagColoringEnabled by viewModel.tagColoringEnabled.collectAsState()
     val prohibitedCount by viewModel.prohibitedTags.collectAsState()
     val monitoredApps by viewModel.monitoredApps.collectAsState()
+    val activeSourceFilters by viewModel.activeSourceFilters.collectAsState()
 
     var showColorPicker by remember { mutableStateOf(false) }
     var showSchemeMenu by remember { mutableStateOf(false) }
@@ -411,6 +413,29 @@ private fun SettingsMainScreen(
             )
             HorizontalDivider(modifier = Modifier.padding(vertical = 16.dp))
 
+            SettingsSectionHeader("Log sources")
+            Text(
+                "Add tabs that show only logs from a chosen source. The All tab always shows " +
+                    "everything. (Source/category classification needs the UID column — root or " +
+                    "ADB READ_LOGS; lines without a UID appear only in All.)",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(bottom = 8.dp)
+            )
+            SourceFilterGroup(
+                title = "Sources",
+                keys = LogSources.SOURCE_BUCKETS,
+                enabled = activeSourceFilters,
+                onToggle = { key, on -> viewModel.setSourceFilterEnabled(key, on) }
+            )
+            SourceFilterGroup(
+                title = "Categories",
+                keys = LogSources.CATEGORY_BUCKETS,
+                enabled = activeSourceFilters,
+                onToggle = { key, on -> viewModel.setSourceFilterEnabled(key, on) }
+            )
+            HorizontalDivider(modifier = Modifier.padding(vertical = 16.dp))
+
             SettingsSectionHeader("Filters")
             AzButton(
                 onClick = onOpenProhibited,
@@ -475,4 +500,35 @@ fun SettingsSectionHeader(text: String) {
         color = MaterialTheme.colorScheme.primary,
         modifier = Modifier.padding(bottom = 8.dp)
     )
+}
+
+/** A labelled sub-group of source-filter checkboxes (e.g. "Sources" or "Categories"). */
+@Composable
+private fun SourceFilterGroup(
+    title: String,
+    keys: List<String>,
+    enabled: Set<String>,
+    onToggle: (String, Boolean) -> Unit,
+) {
+    Text(
+        title,
+        style = MaterialTheme.typography.bodyMedium,
+        color = MaterialTheme.colorScheme.primary,
+        modifier = Modifier.padding(top = 4.dp, bottom = 2.dp)
+    )
+    keys.forEach { key ->
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable { onToggle(key, key !in enabled) }
+                .padding(vertical = 2.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Checkbox(
+                checked = key in enabled,
+                onCheckedChange = { onToggle(key, it) }
+            )
+            Text(LogSources.label(key), style = MaterialTheme.typography.bodyLarge)
+        }
+    }
 }

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/utils/LogSourceClassifier.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/utils/LogSourceClassifier.kt
@@ -1,0 +1,124 @@
+package com.hereliesaz.logkitty.utils
+
+import android.content.Context
+import android.content.pm.ApplicationInfo
+import android.content.pm.PackageManager
+import android.os.Build
+import android.os.Process
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Catalog of log-source filter keys plus their display labels and grouping, shared by the settings
+ * UI and the ViewModel. A "source" is derived from the UID that emitted a log line.
+ */
+object LogSources {
+    // Source buckets.
+    const val USER = "USER"
+    const val SYSTEM = "SYSTEM"
+    const val PLAY_STORE = "PLAY_STORE"
+    const val NON_PLAY_STORE = "NON_PLAY_STORE"
+
+    // App-category buckets (from ApplicationInfo.category).
+    const val CAT_GAME = "CAT_GAME"
+    const val CAT_AUDIO = "CAT_AUDIO"
+    const val CAT_VIDEO = "CAT_VIDEO"
+    const val CAT_IMAGE = "CAT_IMAGE"
+    const val CAT_SOCIAL = "CAT_SOCIAL"
+    const val CAT_NEWS = "CAT_NEWS"
+    const val CAT_MAPS = "CAT_MAPS"
+    const val CAT_PRODUCTIVITY = "CAT_PRODUCTIVITY"
+    const val CAT_ACCESSIBILITY = "CAT_ACCESSIBILITY"
+    const val CAT_OTHER = "CAT_OTHER"
+
+    /** Ordered bucket keys shown under the "Sources" header in settings. */
+    val SOURCE_BUCKETS = listOf(USER, SYSTEM, PLAY_STORE, NON_PLAY_STORE)
+
+    /** Ordered category keys shown under the "Categories" header in settings. */
+    val CATEGORY_BUCKETS = listOf(
+        CAT_GAME, CAT_AUDIO, CAT_VIDEO, CAT_IMAGE, CAT_SOCIAL,
+        CAT_NEWS, CAT_MAPS, CAT_PRODUCTIVITY, CAT_ACCESSIBILITY, CAT_OTHER,
+    )
+
+    /** Human-readable label for a filter key (also used as the tab title). */
+    fun label(key: String): String = when (key) {
+        USER -> "User apps"
+        SYSTEM -> "System"
+        PLAY_STORE -> "Play Store"
+        NON_PLAY_STORE -> "Non-Play Store"
+        CAT_GAME -> "Games"
+        CAT_AUDIO -> "Audio"
+        CAT_VIDEO -> "Video"
+        CAT_IMAGE -> "Images"
+        CAT_SOCIAL -> "Social"
+        CAT_NEWS -> "News"
+        CAT_MAPS -> "Maps & Navigation"
+        CAT_PRODUCTIVITY -> "Productivity"
+        CAT_ACCESSIBILITY -> "Accessibility"
+        CAT_OTHER -> "Uncategorized"
+        else -> key
+    }
+}
+
+/**
+ * Classifies a log line's emitting UID into a set of [LogSources] keys (system/user, install
+ * source, app category). Used to power the per-source log tabs.
+ *
+ * Results are cached per UID. Resolution requires the UID column on the log stream
+ * (root / ADB `READ_LOGS`); lines without a UID can't be classified and only appear in the All tab.
+ */
+class LogSourceClassifier(context: Context) {
+
+    private val pm: PackageManager = context.applicationContext.packageManager
+    private val cache = ConcurrentHashMap<Int, Set<String>>()
+
+    /** Returns the set of source/category keys the [uid] belongs to (empty if unknown/null). */
+    fun classify(uid: Int?): Set<String> {
+        if (uid == null) return emptySet()
+        cache[uid]?.let { return it }
+        val result = compute(uid)
+        cache[uid] = result
+        return result
+    }
+
+    private fun compute(uid: Int): Set<String> {
+        val out = mutableSetOf<String>()
+        if (uid < Process.FIRST_APPLICATION_UID) out += LogSources.SYSTEM else out += LogSources.USER
+
+        val pkgs = runCatching { pm.getPackagesForUid(uid) }.getOrNull()?.filterNotNull() ?: emptyList()
+        for (pkg in pkgs) {
+            val ai = runCatching { pm.getApplicationInfo(pkg, 0) }.getOrNull() ?: continue
+            if (ai.flags and ApplicationInfo.FLAG_SYSTEM != 0 ||
+                ai.flags and ApplicationInfo.FLAG_UPDATED_SYSTEM_APP != 0
+            ) out += LogSources.SYSTEM
+
+            val installer = runCatching {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                    pm.getInstallSourceInfo(pkg).installingPackageName
+                } else {
+                    @Suppress("DEPRECATION") pm.getInstallerPackageName(pkg)
+                }
+            }.getOrNull()
+            if (installer == PLAY_STORE_PACKAGE) out += LogSources.PLAY_STORE else out += LogSources.NON_PLAY_STORE
+
+            out += categoryKey(ai.category)
+        }
+        return out
+    }
+
+    private fun categoryKey(category: Int): String = when (category) {
+        ApplicationInfo.CATEGORY_GAME -> LogSources.CAT_GAME
+        ApplicationInfo.CATEGORY_AUDIO -> LogSources.CAT_AUDIO
+        ApplicationInfo.CATEGORY_VIDEO -> LogSources.CAT_VIDEO
+        ApplicationInfo.CATEGORY_IMAGE -> LogSources.CAT_IMAGE
+        ApplicationInfo.CATEGORY_SOCIAL -> LogSources.CAT_SOCIAL
+        ApplicationInfo.CATEGORY_NEWS -> LogSources.CAT_NEWS
+        ApplicationInfo.CATEGORY_MAPS -> LogSources.CAT_MAPS
+        ApplicationInfo.CATEGORY_PRODUCTIVITY -> LogSources.CAT_PRODUCTIVITY
+        ApplicationInfo.CATEGORY_ACCESSIBILITY -> LogSources.CAT_ACCESSIBILITY
+        else -> LogSources.CAT_OTHER
+    }
+
+    companion object {
+        private const val PLAY_STORE_PACKAGE = "com.android.vending"
+    }
+}

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/utils/UserPreferences.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/utils/UserPreferences.kt
@@ -35,7 +35,8 @@ data class ExportedPreferences(
     val activeLogLevels: Set<String>,
     val colorScheme: String = LogColorScheme.MATERIAL.name,
     val tagColoringEnabled: Boolean = true,
-    val monitoredApps: List<String> = emptyList()
+    val monitoredApps: List<String> = emptyList(),
+    val activeSourceFilters: List<String> = emptyList()
 )
 
 /**
@@ -116,6 +117,13 @@ class UserPreferences(context: Context) {
         prefs.getStringSet(KEY_MONITORED_APPS, emptySet()) ?: emptySet()
     )
     val monitoredApps: StateFlow<Set<String>> = _monitoredApps.asStateFlow()
+
+    // --- Preference: Active Log-Source Filters ---
+    // Source/category keys (see LogSources) the user has enabled as dedicated log tabs.
+    private val _activeSourceFilters = MutableStateFlow(
+        prefs.getStringSet(KEY_ACTIVE_SOURCE_FILTERS, emptySet()) ?: emptySet()
+    )
+    val activeSourceFilters: StateFlow<Set<String>> = _activeSourceFilters.asStateFlow()
 
     // --- Preference: Color Scheme ---
     private val _colorScheme = MutableStateFlow(loadColorScheme())
@@ -229,6 +237,14 @@ class UserPreferences(context: Context) {
         }
     }
 
+    /** Enables/disables a log-source filter tab (key from `LogSources`). */
+    fun setSourceFilterEnabled(key: String, enabled: Boolean) {
+        val current = _activeSourceFilters.value.toMutableSet()
+        if (enabled) current.add(key) else current.remove(key)
+        prefs.edit().putStringSet(KEY_ACTIVE_SOURCE_FILTERS, current).apply()
+        _activeSourceFilters.value = current
+    }
+
     /**
      * Customizes the color for a specific log level. Switches the scheme to CUSTOM so further
      * scheme changes don't silently overwrite the user's overrides.
@@ -339,7 +355,8 @@ class UserPreferences(context: Context) {
             activeLogLevels = _activeLogLevels.value,
             colorScheme = _colorScheme.value.name,
             tagColoringEnabled = _tagColoringEnabled.value,
-            monitoredApps = _monitoredApps.value.toList()
+            monitoredApps = _monitoredApps.value.toList(),
+            activeSourceFilters = _activeSourceFilters.value.toList()
         )
         return try {
             Json { prettyPrint = true }.encodeToString(exported)
@@ -377,6 +394,10 @@ class UserPreferences(context: Context) {
             val apps = imported.monitoredApps.toSet()
             prefs.edit().putStringSet(KEY_MONITORED_APPS, apps).apply()
             _monitoredApps.value = apps
+
+            val sources = imported.activeSourceFilters.toSet()
+            prefs.edit().putStringSet(KEY_ACTIVE_SOURCE_FILTERS, sources).apply()
+            _activeSourceFilters.value = sources
 
             val scheme = try { LogColorScheme.valueOf(imported.colorScheme) } catch (e: Exception) { LogColorScheme.MATERIAL }
 
@@ -418,5 +439,6 @@ class UserPreferences(context: Context) {
         private const val KEY_COLOR_SCHEME = "color_scheme"
         private const val KEY_TAG_COLORING = "tag_coloring_enabled"
         private const val KEY_MONITORED_APPS = "monitored_apps"
+        private const val KEY_ACTIVE_SOURCE_FILTERS = "active_source_filters"
     }
 }


### PR DESCRIPTION
**PR 2 of 5.**

## What
Adds **per-source log tabs**, selectable in Settings, classified from each log line's UID.

- **`LogSourceClassifier`** (new) maps a UID → a set of source/category keys: **User/System** (UID range + `FLAG_SYSTEM`), **Play Store / Non-Play Store** (via `getInstallSourceInfo`), and the app's **category** (Games, Audio, Video, Image, Social, News, Maps, Productivity, Accessibility, Uncategorized). Cached per-UID.
- **`UserPreferences.activeSourceFilters`** stores which source tabs are enabled (+ export/import).
- **`MainViewModel`**: new `TabType.SOURCE`; `syncSourceTabs` builds tabs from the enabled filters; the filter pipeline gains a `SOURCE` branch and now runs on `Dispatchers.Default`, so per-line classification IPC never touches the main thread. The built-in **System** tab is renamed **All** (still shows everything — this is the "show logs for all" option).
- **`SettingsScreen`**: a **"Log sources"** section, grouped under **Sources** (User, System, Play Store, Non-Play Store) and **Categories** (Games, Audio, …) checkboxes; each enabled bucket becomes a tab.

## Limitation
Classification needs the UID column on the stream (root / ADB `READ_LOGS`). Lines without a UID can't be classified and appear only in the **All** tab. Noted in the settings copy.

## Verification
CI build. On device (root/READ_LOGS): enable e.g. "Play Store" and "Games" → new tabs appear showing only logs from apps in those buckets; "System" shows system-UID logs; "All" shows everything.

(Independent of PR #95; both touch `MainViewModel` in different sections.)

---
_Generated by [Claude Code](https://claude.ai/code/session_017hRcXbYpxVLL1AhJi1t8Qk)_