### PR TITLE
Settings footer links (About / Feedback / @HereLiesAz)

### DIFF
--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/SettingsScreen.kt
@@ -456,6 +456,10 @@ private fun SettingsMainScreen(
                 shape = AzButtonShape.RECTANGLE,
                 modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)
             )
+
+            HorizontalDivider(modifier = Modifier.padding(vertical = 16.dp))
+            SettingsFooter(context)
+
             Spacer(modifier = Modifier.height(32.dp))
         }
     }
@@ -466,6 +470,56 @@ private fun appLabel(context: android.content.Context, pkg: String): String = tr
     val pm = context.packageManager
     pm.getApplicationLabel(pm.getApplicationInfo(pkg, 0)).toString()
 } catch (e: Exception) { pkg }
+
+/**
+ * Bottom-of-settings footer mirroring AzNavRail's footer: About (repo), Feedback (email),
+ * and the author's handle (Instagram).
+ */
+@Composable
+private fun SettingsFooter(context: android.content.Context) {
+    fun open(intent: android.content.Intent) {
+        runCatching { context.startActivity(intent) }
+    }
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
+        horizontalArrangement = Arrangement.SpaceEvenly,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            "About",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.primary,
+            modifier = Modifier
+                .clickable {
+                    open(android.content.Intent(android.content.Intent.ACTION_VIEW,
+                        Uri.parse("https://github.com/HereLiesAz/LogKitty")))
+                }
+                .padding(8.dp)
+        )
+        Text(
+            "Feedback",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.primary,
+            modifier = Modifier
+                .clickable {
+                    open(android.content.Intent(android.content.Intent.ACTION_SENDTO,
+                        Uri.parse("mailto:hereliesaz@gmail.com?subject=LogKitty")))
+                }
+                .padding(8.dp)
+        )
+        Text(
+            "@HereLiesAz",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.primary,
+            modifier = Modifier
+                .clickable {
+                    open(android.content.Intent(android.content.Intent.ACTION_VIEW,
+                        Uri.parse("https://instagram.com/HereLiesAz")))
+                }
+                .padding(8.dp)
+        )
+    }
+}
 
 @Composable
 fun SettingsSectionHeader(text: String) {

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/SettingsScreen.kt
@@ -479,44 +479,46 @@ private fun appLabel(context: android.content.Context, pkg: String): String = tr
 private fun SettingsFooter(context: android.content.Context) {
     fun open(intent: android.content.Intent) {
         runCatching { context.startActivity(intent) }
+            .onFailure { Toast.makeText(context, "No app found to handle this", Toast.LENGTH_SHORT).show() }
     }
     Row(
         modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
         horizontalArrangement = Arrangement.SpaceEvenly,
         verticalAlignment = Alignment.CenterVertically
     ) {
+        // padding before clickable so the whole padded area is the touch target / ripple bounds.
         Text(
             "About",
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.primary,
             modifier = Modifier
+                .padding(8.dp)
                 .clickable {
                     open(android.content.Intent(android.content.Intent.ACTION_VIEW,
                         Uri.parse("https://github.com/HereLiesAz/LogKitty")))
                 }
-                .padding(8.dp)
         )
         Text(
             "Feedback",
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.primary,
             modifier = Modifier
+                .padding(8.dp)
                 .clickable {
                     open(android.content.Intent(android.content.Intent.ACTION_SENDTO,
                         Uri.parse("mailto:hereliesaz@gmail.com?subject=LogKitty")))
                 }
-                .padding(8.dp)
         )
         Text(
             "@HereLiesAz",
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.primary,
             modifier = Modifier
+                .padding(8.dp)
                 .clickable {
                     open(android.content.Intent(android.content.Intent.ACTION_VIEW,
                         Uri.parse("https://instagram.com/HereLiesAz")))
                 }
-                .padding(8.dp)
         )
     }
 }


### PR DESCRIPTION
**PR 3 of 5.**

Adds a footer at the bottom of the Settings screen, mirroring AzNavRail's footer links:
- **About** → `https://github.com/HereLiesAz/LogKitty`
- **Feedback** → `mailto:hereliesaz@gmail.com?subject=LogKitty`
- **@HereLiesAz** → `https://instagram.com/HereLiesAz`

Each opens via an `Intent` wrapped in `runCatching`. Small, self-contained change to `SettingsScreen.kt`.

Verify on device: each link opens the right destination.

---
_Generated by [Claude Code](https://claude.ai/code/session_017hRcXbYpxVLL1AhJi1t8Qk)_

## Summary by Sourcery

New Features:
- Introduce a Settings footer with About, Feedback, and author handle links that open external destinations via intents.