### PR TITLE
AdMob banner at the bottom of Settings (test IDs)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -207,6 +207,9 @@ dependencies {
     implementation(libs.dokar3.sheets.m3)
     implementation(libs.aznavrail)
 
+    // Google Mobile Ads (AdMob) — banner at the bottom of Settings (test IDs for now).
+    implementation(libs.play.services.ads)
+
     // Coroutines
     implementation(libs.kotlinx.coroutines.core)
     implementation(libs.kotlinx.serialization.json)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -183,6 +183,13 @@ configurations.all {
                     useVersion("0.9.6")
                     because("Security fix: DoS via compressed JWE content")
                 }
+                // play-services-basement (via play-services-ads) drags in an old Fragment (1.x),
+                // which makes the InvalidFragmentVersionForActivityResult lint fatal for our
+                // registerForActivityResult calls. Force a version >= 1.3.0.
+                g == "androidx.fragment" && n == "fragment" -> {
+                    useVersion("1.6.2")
+                    because("registerForActivityResult lint requires androidx.fragment >= 1.3.0")
+                }
             }
         }
     }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
     <uses-permission android:name="android.permission.READ_LOGS" tools:ignore="ProtectedPermissions" />
     <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES" tools:ignore="QueryAllPackagesPermission" />
+    <uses-permission android:name="com.google.android.gms.permission.AD_ID" />
 
     <queries>
         <intent>
@@ -34,6 +35,12 @@
         <meta-data
             android:name="com.google.android.gms.fonts.API_KEY"
             android:value="${FONTS_API_KEY}" />
+
+        <!-- AdMob application ID. This is Google's official TEST app ID. TODO: replace with the
+             real AdMob app ID before shipping (and add a UMP consent flow for personalized ads). -->
+        <meta-data
+            android:name="com.google.android.gms.ads.APPLICATION_ID"
+            android:value="ca-app-pub-3940256099942544~3347511713" />
 
         <activity
             android:name=".MainActivity"

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/MainApplication.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/MainApplication.kt
@@ -1,6 +1,7 @@
 package com.hereliesaz.logkitty
 
 import android.app.Application
+import com.google.android.gms.ads.MobileAds
 import com.hereliesaz.logkitty.ui.MainViewModel
 import com.hereliesaz.logkitty.utils.CrashReporter
 import kotlinx.coroutines.CoroutineScope
@@ -39,5 +40,11 @@ class MainApplication : Application() {
         // Initialize the shared ViewModel.
         // We pass 'this' (Application Context) to it.
         mainViewModel = MainViewModel(this)
+
+        // Initialize the Google Mobile Ads SDK (off the main thread per Google's guidance) for the
+        // banner shown at the bottom of Settings. Uses test IDs for now (see AndroidManifest).
+        CoroutineScope(Dispatchers.IO).launch {
+            runCatching { MobileAds.initialize(this@MainApplication) }
+        }
     }
 }

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/SettingsScreen.kt
@@ -558,16 +558,38 @@ private fun SettingsFooter(context: android.content.Context) {
  */
 @Composable
 private fun SettingsAdBanner() {
-    androidx.compose.ui.viewinterop.AndroidView(
-        modifier = Modifier.fillMaxWidth(),
-        factory = { ctx ->
-            com.google.android.gms.ads.AdView(ctx).apply {
-                setAdSize(com.google.android.gms.ads.AdSize.BANNER)
-                adUnitId = TEST_BANNER_AD_UNIT
-                loadAd(com.google.android.gms.ads.AdRequest.Builder().build())
+    val context = LocalContext.current
+    val lifecycleOwner = androidx.compose.ui.platform.LocalLifecycleOwner.current
+
+    val adView = remember {
+        com.google.android.gms.ads.AdView(context).apply {
+            setAdSize(com.google.android.gms.ads.AdSize.BANNER)
+            adUnitId = TEST_BANNER_AD_UNIT
+            loadAd(com.google.android.gms.ads.AdRequest.Builder().build())
+        }
+    }
+
+    // Pause/resume/destroy with the host lifecycle (AdMob policy + battery/memory).
+    androidx.compose.runtime.DisposableEffect(lifecycleOwner) {
+        val observer = androidx.lifecycle.LifecycleEventObserver { _, event ->
+            when (event) {
+                androidx.lifecycle.Lifecycle.Event.ON_RESUME -> adView.resume()
+                androidx.lifecycle.Lifecycle.Event.ON_PAUSE -> adView.pause()
+                androidx.lifecycle.Lifecycle.Event.ON_DESTROY -> adView.destroy()
+                else -> {}
             }
-        },
-        onRelease = { it.destroy() }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose {
+            lifecycleOwner.lifecycle.removeObserver(observer)
+            adView.destroy()
+        }
+    }
+
+    // Fixed banner height avoids a layout shift (and accidental taps) when the ad loads.
+    androidx.compose.ui.viewinterop.AndroidView(
+        modifier = Modifier.fillMaxWidth().height(50.dp),
+        factory = { adView }
     )
 }
 

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/SettingsScreen.kt
@@ -485,6 +485,9 @@ private fun SettingsMainScreen(
             HorizontalDivider(modifier = Modifier.padding(vertical = 16.dp))
             SettingsFooter(context)
 
+            Spacer(modifier = Modifier.height(16.dp))
+            SettingsAdBanner()
+
             Spacer(modifier = Modifier.height(32.dp))
         }
     }
@@ -547,6 +550,28 @@ private fun SettingsFooter(context: android.content.Context) {
         )
     }
 }
+
+/**
+ * AdMob banner shown at the bottom of Settings. Uses Google's official TEST ad unit for now.
+ * TODO: replace [TEST_BANNER_AD_UNIT] with the real ad-unit ID and add a UMP consent flow
+ * (the app ID lives in AndroidManifest; SDK init is in MainApplication).
+ */
+@Composable
+private fun SettingsAdBanner() {
+    androidx.compose.ui.viewinterop.AndroidView(
+        modifier = Modifier.fillMaxWidth(),
+        factory = { ctx ->
+            com.google.android.gms.ads.AdView(ctx).apply {
+                setAdSize(com.google.android.gms.ads.AdSize.BANNER)
+                adUnitId = TEST_BANNER_AD_UNIT
+                loadAd(com.google.android.gms.ads.AdRequest.Builder().build())
+            }
+        },
+        onRelease = { it.destroy() }
+    )
+}
+
+private const val TEST_BANNER_AD_UNIT = "ca-app-pub-3940256099942544/6300978111"
 
 @Composable
 fun SettingsSectionHeader(text: String) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,6 +2,7 @@
 agp = "9.2.1"
 aetherTransportFile = "2.0.14"
 aznavrail = "9.9"
+playServicesAds = "23.3.0"
 coreKtx = "1.18.0"
 kotlinxCoroutinesCore = "1.11.0"
 junit = "4.13.2"
@@ -30,6 +31,7 @@ androidx-lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-
 androidx-localbroadcastmanager = { module = "androidx.localbroadcastmanager:localbroadcastmanager", version.ref = "localbroadcastmanager" }
 androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "navigationCompose" }
 aznavrail = { module = "com.github.HereLiesAz:AzNavRail", version.ref = "aznavrail" }
+play-services-ads = { module = "com.google.android.gms:play-services-ads", version.ref = "playServicesAds" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }


### PR DESCRIPTION
**PR 4 of 5.**

Adds a Google Mobile Ads (AdMob) **banner at the bottom of Settings**, wired with Google's official **test** IDs.

- `play-services-ads` dependency (version catalog).
- `AndroidManifest.xml`: AdMob `APPLICATION_ID` meta-data (test app ID `…~3347511713`) + `com.google.android.gms.permission.AD_ID`.
- `MainApplication`: `MobileAds.initialize(...)` off the main thread.
- `SettingsScreen`: a `BANNER` `AdView` (test unit `…/6300978111`) at the bottom, destroyed on release to avoid leaks.

**Before shipping (TODO in code):** replace the test app ID + ad-unit ID with the real ones, and add a UMP consent flow for personalized ads (EU/UK). Test ads don't require consent, so it's deferred.

**Heads-up:** AdMob in a logging/overlay utility may have AdMob/Play policy considerations — test IDs avoid any live-policy risk for now.

Verify on device: a "Test Ad" banner renders at the bottom of Settings.

---
_Generated by [Claude Code](https://claude.ai/code/session_017hRcXbYpxVLL1AhJi1t8Qk)_

## Summary by Sourcery

Integrate a test AdMob banner at the bottom of the Settings screen and initialize the Google Mobile Ads SDK.

New Features:
- Display a Google Mobile Ads banner at the bottom of the Settings screen using official AdMob test IDs.

Enhancements:
- Initialize the Google Mobile Ads SDK in the application startup on a background coroutine.
- Add the Google Mobile Ads dependency via the version catalog and request the Google AD_ID permission in the manifest.