### PR TITLE
Draw behind the nav bar (show more log lines through a see-through bar)

### DIFF
--- a/app/src/main/kotlin/com/hereliesaz/logkitty/services/LogKittyOverlayService.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/services/LogKittyOverlayService.kt
@@ -176,6 +176,7 @@ class LogKittyOverlayService : Service() {
                 LogBottomSheet(
                     controller = controller,
                     viewModel = viewModel,
+                    navBarHeightPx = navBarHeightPx,
                     onSaveClick = {
                         val intent = Intent(this@LogKittyOverlayService,
                             com.hereliesaz.logkitty.FileSaverActivity::class.java)
@@ -235,11 +236,13 @@ class LogKittyOverlayService : Service() {
         // Matches the Text lineHeight used in LogBottomSheet's PeekStrip (fontSize * 1.35).
         val lineHeightPx = fontSize.toFloat() * density * 1.35f
 
-        // HIDDEN: exactly one line.
+        // These are the EXPOSED heights above the nav bar (one line at HIDDEN, three at PEEK). With
+        // drawBehindNavBar, AzNavRail extends the sheet behind the bar by the nav-bar inset (passed
+        // to the host) and makes the bar see-through, so the exposed height — and the top edge —
+        // stays exactly as before; the extra lines LogBottomSheet renders show through the bar.
         val hiddenPx = (lineHeightPx * 1)
         val hiddenDp = (hiddenPx / density).dp
 
-        // PEEK: exactly three lines.
         val peekPx = (lineHeightPx * 3)
         val peekDp = (peekPx / density).dp
         return AzSheetConfig(
@@ -255,6 +258,9 @@ class LogKittyOverlayService : Service() {
             horizontalSwipeEnabled = false,
             handleVisible = false,
             cornerRadiusDp = 0.dp,
+            // Draw behind the system nav bar (button-nav only; no-op on gesture nav) so the extra
+            // log lines show through it.
+            drawBehindNavBar = true,
         )
     }
 

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/LogBottomSheet.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/LogBottomSheet.kt
@@ -99,6 +99,7 @@ fun AzSheetController.hide() { snapTo(AzSheetDetent.HIDDEN) }
 fun LogBottomSheet(
     controller: AzSheetController,
     viewModel: MainViewModel,
+    navBarHeightPx: Int,
     onSaveClick: () -> Unit,
     onSettingsClick: () -> Unit,
 ) {
@@ -121,6 +122,14 @@ fun LogBottomSheet(
         getGoogleFontFamily(enumVal.fontName)
     }
 
+    // How many extra lines fit in the nav-bar band the sheet now draws behind (drawBehindNavBar).
+    // On gesture nav the inset is ~0, so this is 0 and the strips look exactly as before.
+    val density = LocalDensity.current.density
+    val extraNavBarLines = remember(navBarHeightPx, fontSize, density) {
+        val lineHeightPx = fontSize * 1.35f * density
+        if (lineHeightPx > 0f) (navBarHeightPx / lineHeightPx).toInt().coerceAtLeast(0) else 0
+    }
+
     var selectedLineIds by remember { mutableStateOf<Set<Long>>(emptySet()) }
     var isMultiSelectMode by remember { mutableStateOf(false) }
     val selectedLines = remember(selectedLineIds, indexedLog) {
@@ -131,7 +140,9 @@ fun LogBottomSheet(
     when (controller.detent) {
         AzSheetDetent.HIDDEN -> PeekStrip(
             modifier = Modifier.fillMaxSize(),
-            lines = listOf(indexedLog.lastOrNull()?.text ?: "LogKitty Ready"),
+            // Newest line stays above the bar; older lines flow down through the see-through bar.
+            lines = if (indexedLog.isEmpty()) listOf("LogKitty Ready")
+                    else indexedLog.takeLast(1 + extraNavBarLines).map { it.text }.asReversed(),
             showTimestamp = showTimestamp,
             fontFamily = currentFontFamily,
             fontSize = fontSize,
@@ -142,7 +153,7 @@ fun LogBottomSheet(
         AzSheetDetent.PEEK -> PeekStrip(
             modifier = Modifier.fillMaxSize(),
             lines = if (indexedLog.isEmpty()) listOf("LogKitty Ready")
-                    else indexedLog.takeLast(3).map { it.text },
+                    else indexedLog.takeLast(3 + extraNavBarLines).map { it.text }.asReversed(),
             showTimestamp = showTimestamp,
             fontFamily = currentFontFamily,
             fontSize = fontSize,
@@ -253,10 +264,9 @@ private fun PeekStrip(
                     .fillMaxWidth()
                     .fillMaxHeight()
                     .padding(horizontal = 12.dp),
-                // Bottom-align so the line(s) sit at the very bottom edge of the strip — right above
-                // the system nav bar, which the library's decor window tints separately. Any slack
-                // (a short log) shows above the text instead.
-                verticalArrangement = Arrangement.Bottom
+                // Top-align: the caller passes lines newest-first, so the newest sits at the top
+                // (above the nav bar) and older lines flow down through the see-through bar.
+                verticalArrangement = Arrangement.Top
             ) {
                 lines.forEach { line ->
                     val displayText = if (showTimestamp) line else line.replace(timestampRegex, "")


### PR DESCRIPTION
**PR 5 of 5** (final of the batch).

Makes the overlay **draw behind the system navigation bar** (button-nav only) so more log lines are visible, while keeping each detent's top edge and above-bar line count exactly as now.

- `AzSheetConfig.drawBehindNavBar = true` — AzNavRail extends the sheet behind the (see-through) nav bar by the measured inset and keeps the **exposed** above-bar height unchanged; no-op on gesture nav.
- The detent heights stay at the exposed values (1 line HIDDEN, 3 PEEK), so the **top edge doesn't move**.
- `LogBottomSheet` now renders `takeLast(N + navBarLines)` **newest-first, top-aligned** for HIDDEN/PEEK, so the latest line stays above the bar (as now) and older lines flow down through the transparent bar. `navBarLines` = how many text lines fit in the measured nav-bar band (0 on gesture nav → unchanged).

## ⚠️ Needs on-device verification
I can't run the overlay in the sandbox, and the exact behind-the-bar behavior depends on how AzNavRail 9.9's **overlay** host applies `drawBehindNavBar`. Per the docs it makes `AzNavBarDecorWindow` semi-transparent and keeps the exposed height unchanged — but if the overlay host doesn't actually extend the sheet window behind the bar (only the in-tree flavor does), the extra lines will be clipped and you'll just see a see-through bar without extra log lines. 

**Please test on a button-nav device** and send a screenshot. If the extra lines don't show through, the fix is a small AzNavRail change (have `AzBottomSheetWindowHost` size HIDDEN/PEEK to `heightForDetent + navBarHeightPx` when `drawBehindNavBar` is set, anchored so the exposed height stays above the bar) — I'll give you that prompt. This PR is safe either way: with no library change it won't regress the current layout (top edge and above-bar lines unchanged); it just may not yet show the extra lines.

---
_Generated by [Claude Code](https://claude.ai/code/session_017hRcXbYpxVLL1AhJi1t8Qk)_

## Summary by Sourcery

Extend the log overlay bottom sheet behind the system navigation bar while preserving existing exposed detent heights and top edge position.

New Features:
- Show additional log lines in the HIDDEN and PEEK detents by rendering content into the area behind the transparent navigation bar on button-navigation devices.

Enhancements:
- Compute the number of extra log lines that fit within the navigation bar height and adjust the HIDDEN and PEEK strips to render newest-first, top-aligned so newer entries remain above the bar.
- Pass nav bar height into LogBottomSheet and enable AzSheetConfig.drawBehindNavBar so the overlay can occupy space behind the system navigation bar.