### PR TITLE
i18n: extract user-facing strings to strings.xml

### DIFF
--- a/app/src/main/kotlin/com/hereliesaz/logkitty/FileSaverActivity.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/FileSaverActivity.kt
@@ -30,13 +30,13 @@ class FileSaverActivity : ComponentActivity() {
                         output.write(logs.toByteArray())
                     }
                     withContext(Dispatchers.Main) {
-                        Toast.makeText(this@FileSaverActivity, "Logs saved successfully", Toast.LENGTH_SHORT).show()
+                        Toast.makeText(this@FileSaverActivity, getString(R.string.toast_logs_saved), Toast.LENGTH_SHORT).show()
                         finish()
                     }
                 } catch (e: Exception) {
                     e.printStackTrace()
                     withContext(Dispatchers.Main) {
-                        Toast.makeText(this@FileSaverActivity, "Failed to save logs: ${e.message}", Toast.LENGTH_LONG).show()
+                        Toast.makeText(this@FileSaverActivity, getString(R.string.toast_save_logs_failed, e.message), Toast.LENGTH_LONG).show()
                         finish()
                     }
                 }

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/MainActivity.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/MainActivity.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -230,18 +231,18 @@ fun MainScreenContent(
         ) {
             androidx.compose.foundation.Image(
                 painter = androidx.compose.ui.res.painterResource(id = R.drawable.logkitty),
-                contentDescription = "LogKitty Logo",
+                contentDescription = stringResource(R.string.cd_app_logo),
                 modifier = Modifier.size(120.dp).padding(bottom = 16.dp)
             )
-            Text(text = "LogKitty", style = MaterialTheme.typography.displayMedium, color = MaterialTheme.colorScheme.primary)
+            Text(text = stringResource(R.string.app_name), style = MaterialTheme.typography.displayMedium, color = MaterialTheme.colorScheme.primary)
             Spacer(modifier = Modifier.height(32.dp))
 
             // Step 1: Overlay Permission
             if (!isOverlayGranted) {
                 PermissionCard(
-                    title = "Overlay Permission Required",
-                    description = "LogKitty needs to draw over other apps.",
-                    buttonText = "Grant Overlay",
+                    title = stringResource(R.string.main_overlay_permission_title),
+                    description = stringResource(R.string.main_overlay_permission_desc),
+                    buttonText = stringResource(R.string.main_grant_overlay),
                     onClick = onGrantOverlay
                 )
                 Spacer(modifier = Modifier.height(16.dp))
@@ -251,16 +252,16 @@ fun MainScreenContent(
             if (!isReadLogsGranted && !isRootEnabled) {
                 Card(modifier = Modifier.fillMaxWidth(), elevation = CardDefaults.cardElevation(4.dp)) {
                     Column(modifier = Modifier.padding(16.dp), horizontalAlignment = Alignment.CenterHorizontally) {
-                        Text("Standard Permission Required", style = MaterialTheme.typography.titleMedium, color = MaterialTheme.colorScheme.error)
+                        Text(stringResource(R.string.main_standard_permission_title), style = MaterialTheme.typography.titleMedium, color = MaterialTheme.colorScheme.error)
                         Spacer(modifier = Modifier.height(8.dp))
-                        Text("Run this ADB command:", style = MaterialTheme.typography.bodyMedium)
+                        Text(stringResource(R.string.main_run_adb_command), style = MaterialTheme.typography.bodyMedium)
                         Spacer(modifier = Modifier.height(8.dp))
                         val command = "adb shell pm grant ${BuildConfig.APPLICATION_ID} android.permission.READ_LOGS"
                         Card(colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.05f)), modifier = Modifier.fillMaxWidth()) {
                             Text(command, style = MaterialTheme.typography.bodySmall, modifier = Modifier.padding(8.dp), fontFamily = androidx.compose.ui.text.font.FontFamily.Monospace)
                         }
                         Spacer(modifier = Modifier.height(8.dp))
-                        AzButton(onClick = { clipboardManager.setText(AnnotatedString(command)) }, text = "Copy Command", shape = AzButtonShape.RECTANGLE, modifier = Modifier.fillMaxWidth())
+                        AzButton(onClick = { clipboardManager.setText(AnnotatedString(command)) }, text = stringResource(R.string.main_copy_command), shape = AzButtonShape.RECTANGLE, modifier = Modifier.fillMaxWidth())
                     }
                 }
                 Spacer(modifier = Modifier.height(16.dp))
@@ -268,18 +269,18 @@ fun MainScreenContent(
 
             // Step 3: Start Button
             if (canStart) {
-                Text("Ready to Purr", style = MaterialTheme.typography.headlineSmall, color = MaterialTheme.colorScheme.tertiary)
+                Text(stringResource(R.string.main_ready_to_purr), style = MaterialTheme.typography.headlineSmall, color = MaterialTheme.colorScheme.tertiary)
                 Spacer(modifier = Modifier.height(16.dp))
                 AzButton(
                     onClick = onToggleService,
-                    text = if (isServiceRunning) "Stop Service" else "Start Service",
+                    text = if (isServiceRunning) stringResource(R.string.main_stop_service) else stringResource(R.string.main_start_service),
                     modifier = Modifier.fillMaxWidth().height(56.dp),
                     shape = AzButtonShape.RECTANGLE,
                     colors = if (isServiceRunning) ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.error) else ButtonDefaults.buttonColors()
                 )
             }
             Spacer(modifier = Modifier.height(16.dp))
-            AzButton(onClick = onOpenSettings, text = "Settings", modifier = Modifier.fillMaxWidth().height(56.dp), shape = AzButtonShape.RECTANGLE)
+            AzButton(onClick = onOpenSettings, text = stringResource(R.string.settings), modifier = Modifier.fillMaxWidth().height(56.dp), shape = AzButtonShape.RECTANGLE)
         }
     }
 }

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/services/LogKittyOverlayService.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/services/LogKittyOverlayService.kt
@@ -22,6 +22,7 @@ import com.hereliesaz.aznavrail.model.AzSheetConfig
 import com.hereliesaz.aznavrail.model.AzSheetDetent
 import com.hereliesaz.logkitty.MainActivity
 import com.hereliesaz.logkitty.MainApplication
+import com.hereliesaz.logkitty.R
 import com.hereliesaz.logkitty.ui.LogBottomSheet
 import com.hereliesaz.logkitty.ui.MainViewModel
 import com.hereliesaz.logkitty.ui.hide
@@ -266,7 +267,7 @@ class LogKittyOverlayService : Service() {
 
     private fun createNotificationChannel() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            val channel = NotificationChannel(CHANNEL_ID, "Overlay Service", NotificationManager.IMPORTANCE_LOW)
+            val channel = NotificationChannel(CHANNEL_ID, getString(R.string.notif_channel_name), NotificationManager.IMPORTANCE_LOW)
             getSystemService(NotificationManager::class.java).createNotificationChannel(channel)
         }
     }
@@ -289,9 +290,9 @@ class LogKittyOverlayService : Service() {
         val pausePending = PendingIntent.getService(this, 2, pauseIntent, PendingIntent.FLAG_IMMUTABLE)
 
         return NotificationCompat.Builder(this, CHANNEL_ID)
-            .setContentTitle("LogKitty is running")
+            .setContentTitle(getString(R.string.notif_title))
             .setContentText(
-                if (isPaused) "Logging paused. Tap to turn off." else "Logging. Tap to turn off."
+                if (isPaused) getString(R.string.notif_text_paused) else getString(R.string.notif_text_running)
             )
             .setSmallIcon(android.R.drawable.ic_menu_view)
             // Body tap and the "Turn Off" action both stop the service (tears down the overlay).
@@ -299,11 +300,11 @@ class LogKittyOverlayService : Service() {
             // Start/Stop toggles log capture (mirrors the sheet's play/pause).
             .addAction(
                 if (isPaused) android.R.drawable.ic_media_play else android.R.drawable.ic_media_pause,
-                if (isPaused) "Start" else "Stop",
+                if (isPaused) getString(R.string.notif_action_start) else getString(R.string.notif_action_stop),
                 pausePending
             )
-            .addAction(android.R.drawable.ic_menu_close_clear_cancel, "Turn Off LogKitty", stopPending)
-            .addAction(android.R.drawable.ic_menu_preferences, "App Settings", settingsPending)
+            .addAction(android.R.drawable.ic_menu_close_clear_cancel, getString(R.string.notif_action_turn_off), stopPending)
+            .addAction(android.R.drawable.ic_menu_preferences, getString(R.string.notif_action_app_settings), settingsPending)
             .setOngoing(true)
             .setForegroundServiceBehavior(NotificationCompat.FOREGROUND_SERVICE_IMMEDIATE)
             .build()

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/AppPickerDialog.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/AppPickerDialog.kt
@@ -33,10 +33,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.core.graphics.drawable.toBitmap
+import com.hereliesaz.logkitty.R
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
@@ -82,7 +84,7 @@ fun AppPickerDialog(
         ) {
             Column(modifier = Modifier.padding(16.dp)) {
                 Text(
-                    text = "Monitor an app",
+                    text = stringResource(R.string.app_picker_title),
                     style = MaterialTheme.typography.titleLarge,
                     color = MaterialTheme.colorScheme.onSurface
                 )
@@ -90,7 +92,7 @@ fun AppPickerDialog(
                 OutlinedTextField(
                     value = query,
                     onValueChange = { query = it },
-                    label = { Text("Search apps") },
+                    label = { Text(stringResource(R.string.app_picker_search)) },
                     singleLine = true,
                     modifier = Modifier.fillMaxWidth()
                 )
@@ -110,7 +112,7 @@ fun AppPickerDialog(
 
                 Spacer(modifier = Modifier.size(8.dp))
                 Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
-                    TextButton(onClick = onDismiss) { Text("Cancel") }
+                    TextButton(onClick = onDismiss) { Text(stringResource(R.string.cancel)) }
                 }
             }
         }

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/ColorPickerDialog.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/ColorPickerDialog.kt
@@ -11,8 +11,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
+import com.hereliesaz.logkitty.R
 
 /**
  * A simple RGB color picker dialog.
@@ -43,7 +45,7 @@ fun ColorPickerDialog(
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
                 Text(
-                    text = "Pick Background Color",
+                    text = stringResource(R.string.color_picker_title),
                     style = MaterialTheme.typography.titleLarge,
                     color = MaterialTheme.colorScheme.onSurface
                 )
@@ -62,9 +64,9 @@ fun ColorPickerDialog(
                 Spacer(modifier = Modifier.height(24.dp))
 
                 // RGB Sliders
-                ColorSlider(value = red, onValueChange = { red = it }, label = "R", color = Color.Red)
-                ColorSlider(value = green, onValueChange = { green = it }, label = "G", color = Color.Green)
-                ColorSlider(value = blue, onValueChange = { blue = it }, label = "B", color = Color.Blue)
+                ColorSlider(value = red, onValueChange = { red = it }, label = stringResource(R.string.color_picker_channel_red), color = Color.Red)
+                ColorSlider(value = green, onValueChange = { green = it }, label = stringResource(R.string.color_picker_channel_green), color = Color.Green)
+                ColorSlider(value = blue, onValueChange = { blue = it }, label = stringResource(R.string.color_picker_channel_blue), color = Color.Blue)
 
                 Spacer(modifier = Modifier.height(24.dp))
 
@@ -74,11 +76,11 @@ fun ColorPickerDialog(
                     horizontalArrangement = Arrangement.End
                 ) {
                     TextButton(onClick = onDismiss) {
-                        Text("Cancel")
+                        Text(stringResource(R.string.cancel))
                     }
                     Spacer(modifier = Modifier.width(8.dp))
                     Button(onClick = { onColorSelected(currentColor) }) {
-                        Text("Select")
+                        Text(stringResource(R.string.select))
                     }
                 }
             }

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/ColorSchemeEditorScreen.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/ColorSchemeEditorScreen.kt
@@ -31,7 +31,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import com.hereliesaz.logkitty.R
 
 /**
  * Per-level color customization. Selecting a swatch opens the [ColorPickerDialog] for that
@@ -62,10 +64,10 @@ fun ColorSchemeEditorScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Log Colors — ${scheme.displayName}") },
+                title = { Text(stringResource(R.string.colors_title, stringResource(scheme.displayNameRes))) },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, "Back")
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, stringResource(R.string.cd_back))
                     }
                 }
             )
@@ -78,7 +80,7 @@ fun ColorSchemeEditorScreen(
                 .padding(16.dp)
         ) {
             Text(
-                "Tap a swatch to customize. Editing any color switches the active scheme to Custom.",
+                stringResource(R.string.colors_editor_hint),
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
@@ -96,7 +98,7 @@ fun ColorSchemeEditorScreen(
                     Column {
                         Text(level.name, style = MaterialTheme.typography.bodyLarge)
                         Text(
-                            "Letter: ${level.letter}",
+                            stringResource(R.string.colors_letter, level.letter),
                             style = MaterialTheme.typography.bodySmall,
                             color = MaterialTheme.colorScheme.onSurfaceVariant
                         )

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/LogBottomSheet.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/LogBottomSheet.kt
@@ -54,6 +54,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
@@ -66,6 +67,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.hereliesaz.aznavrail.bottomsheet.AzSheetController
 import com.hereliesaz.aznavrail.model.AzSheetDetent
+import com.hereliesaz.logkitty.R
 import com.hereliesaz.logkitty.ui.delegates.IndexedLogLine
 import com.hereliesaz.logkitty.ui.theme.CodingFont
 import com.hereliesaz.logkitty.ui.theme.getGoogleFontFamily
@@ -141,7 +143,7 @@ fun LogBottomSheet(
         AzSheetDetent.HIDDEN -> PeekStrip(
             modifier = Modifier.fillMaxSize(),
             // Newest line stays above the bar; older lines flow down through the see-through bar.
-            lines = if (indexedLog.isEmpty()) listOf("LogKitty Ready")
+            lines = if (indexedLog.isEmpty()) listOf(stringResource(R.string.sheet_ready))
                     else indexedLog.takeLast(1 + extraNavBarLines).map { it.text }.asReversed(),
             showTimestamp = showTimestamp,
             fontFamily = currentFontFamily,
@@ -152,7 +154,7 @@ fun LogBottomSheet(
         )
         AzSheetDetent.PEEK -> PeekStrip(
             modifier = Modifier.fillMaxSize(),
-            lines = if (indexedLog.isEmpty()) listOf("LogKitty Ready")
+            lines = if (indexedLog.isEmpty()) listOf(stringResource(R.string.sheet_ready))
                     else indexedLog.takeLast(3 + extraNavBarLines).map { it.text }.asReversed(),
             showTimestamp = showTimestamp,
             fontFamily = currentFontFamily,
@@ -363,7 +365,7 @@ private fun ExpandedView(
                                         ) {
                                             Icon(
                                                 Icons.Default.Close,
-                                                contentDescription = "Close tab",
+                                                contentDescription = stringResource(R.string.cd_close_tab),
                                                 modifier = Modifier.size(14.dp)
                                             )
                                         }
@@ -376,23 +378,23 @@ private fun ExpandedView(
 
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     IconButton(onClick = onSaveClick, modifier = Modifier.size(36.dp)) {
-                        Icon(Icons.Default.Save, "Save", tint = MaterialTheme.colorScheme.onSurface)
+                        Icon(Icons.Default.Save, stringResource(R.string.cd_save), tint = MaterialTheme.colorScheme.onSurface)
                     }
                     IconButton(onClick = onSettingsClick, modifier = Modifier.size(36.dp)) {
-                        Icon(Icons.Default.Settings, "Settings", tint = MaterialTheme.colorScheme.onSurface)
+                        Icon(Icons.Default.Settings, stringResource(R.string.settings), tint = MaterialTheme.colorScheme.onSurface)
                     }
                     IconButton(onClick = onTogglePause, modifier = Modifier.size(36.dp)) {
                         Icon(
                             if (isPaused) Icons.Default.PlayArrow else Icons.Default.Pause,
-                            contentDescription = if (isPaused) "Resume logging" else "Pause logging",
+                            contentDescription = if (isPaused) stringResource(R.string.cd_resume_logging) else stringResource(R.string.cd_pause_logging),
                             tint = MaterialTheme.colorScheme.onSurface
                         )
                     }
                     IconButton(onClick = onClearClick, modifier = Modifier.size(36.dp)) {
-                        Icon(Icons.Default.DeleteSweep, "Clear logs", tint = MaterialTheme.colorScheme.onSurface)
+                        Icon(Icons.Default.DeleteSweep, stringResource(R.string.cd_clear_logs), tint = MaterialTheme.colorScheme.onSurface)
                     }
                     IconButton(onClick = onCloseClick, modifier = Modifier.size(36.dp)) {
-                        Icon(Icons.Default.Close, "Close", tint = MaterialTheme.colorScheme.onSurface)
+                        Icon(Icons.Default.Close, stringResource(R.string.cd_close), tint = MaterialTheme.colorScheme.onSurface)
                     }
                 }
             }
@@ -412,25 +414,25 @@ private fun ExpandedView(
                 horizontalArrangement = Arrangement.End
             ) {
                 Text(
-                    text = if (count <= 1) "Selected entry" else "$count selected",
+                    text = if (count <= 1) stringResource(R.string.sheet_selected_entry) else stringResource(R.string.sheet_count_selected, count),
                     style = MaterialTheme.typography.labelMedium,
                     color = Color.White.copy(alpha = 0.75f),
                     modifier = Modifier.weight(1f)
                 )
                 IconButton(onClick = onCopySelected, modifier = Modifier.size(32.dp)) {
-                    Icon(Icons.Default.ContentCopy, "Copy selected", tint = MaterialTheme.colorScheme.onSurface)
+                    Icon(Icons.Default.ContentCopy, stringResource(R.string.cd_copy_selected), tint = MaterialTheme.colorScheme.onSurface)
                 }
                 if (count == 1) {
                     val only = selectedLines.first()
                     IconButton(onClick = { onSearchLine(only) }, modifier = Modifier.size(32.dp)) {
-                        Icon(Icons.Default.Search, "Search Google", tint = MaterialTheme.colorScheme.onSurface)
+                        Icon(Icons.Default.Search, stringResource(R.string.cd_search_google), tint = MaterialTheme.colorScheme.onSurface)
                     }
                     IconButton(onClick = { onProhibitLine(only) }, modifier = Modifier.size(32.dp)) {
-                        Icon(Icons.Default.Block, "Prohibit this tag", tint = MaterialTheme.colorScheme.onSurface)
+                        Icon(Icons.Default.Block, stringResource(R.string.cd_prohibit_tag), tint = MaterialTheme.colorScheme.onSurface)
                     }
                 }
                 IconButton(onClick = onClearSelection, modifier = Modifier.size(32.dp)) {
-                    Icon(Icons.Default.Close, "Deselect", tint = MaterialTheme.colorScheme.onSurface)
+                    Icon(Icons.Default.Close, stringResource(R.string.cd_deselect), tint = MaterialTheme.colorScheme.onSurface)
                 }
             }
         }
@@ -445,7 +447,7 @@ private fun ExpandedView(
         ) {
             if (indexedLog.isEmpty()) {
                 Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                    Text("No logs", color = Color.Gray)
+                    Text(stringResource(R.string.sheet_no_logs), color = Color.Gray)
                 }
             } else {
                 LazyColumn(

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/LogColors.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/LogColors.kt
@@ -1,6 +1,7 @@
 package com.hereliesaz.logkitty.ui
 
 import androidx.compose.ui.graphics.Color
+import com.hereliesaz.logkitty.R
 
 /**
  * [LogLevel] mirrors the canonical Android Logcat priorities.
@@ -52,8 +53,8 @@ enum class LogLevel(val letter: String, val defaultColor: Color) {
  * - [SOLARIZED]: Solarized Dark palette for prolonged sessions.
  * - [CUSTOM]: User-defined per-level colors stored via [com.hereliesaz.logkitty.utils.UserPreferences].
  */
-enum class LogColorScheme(val displayName: String, val palette: Map<LogLevel, Color>) {
-    MATERIAL("Material", mapOf(
+enum class LogColorScheme(val displayNameRes: Int, val palette: Map<LogLevel, Color>) {
+    MATERIAL(R.string.scheme_material, mapOf(
         LogLevel.VERBOSE to Color(0xFFBDBDBD),
         LogLevel.DEBUG to Color(0xFF2196F3),
         LogLevel.INFO to Color(0xFF4CAF50),
@@ -61,7 +62,7 @@ enum class LogColorScheme(val displayName: String, val palette: Map<LogLevel, Co
         LogLevel.ERROR to Color(0xFFF44336),
         LogLevel.ASSERT to Color(0xFF9C27B0),
     )),
-    AOSP("Android Studio", mapOf(
+    AOSP(R.string.scheme_aosp, mapOf(
         LogLevel.VERBOSE to Color(0xFFBBBBBB),
         LogLevel.DEBUG to Color(0xFF6897BB),
         LogLevel.INFO to Color(0xFF6A8759),
@@ -69,7 +70,7 @@ enum class LogColorScheme(val displayName: String, val palette: Map<LogLevel, Co
         LogLevel.ERROR to Color(0xFFFF6B68),
         LogLevel.ASSERT to Color(0xFFCC7832),
     )),
-    PIDCAT("Pidcat", mapOf(
+    PIDCAT(R.string.scheme_pidcat, mapOf(
         LogLevel.VERBOSE to Color(0xFFAAAAAA),
         LogLevel.DEBUG to Color(0xFF00FFFF),
         LogLevel.INFO to Color(0xFF00FF00),
@@ -77,7 +78,7 @@ enum class LogColorScheme(val displayName: String, val palette: Map<LogLevel, Co
         LogLevel.ERROR to Color(0xFFFF0033),
         LogLevel.ASSERT to Color(0xFFFF66FF),
     )),
-    MONOCHROME("Monochrome", mapOf(
+    MONOCHROME(R.string.scheme_monochrome, mapOf(
         LogLevel.VERBOSE to Color(0xFF666666),
         LogLevel.DEBUG to Color(0xFF888888),
         LogLevel.INFO to Color(0xFFAAAAAA),
@@ -85,7 +86,7 @@ enum class LogColorScheme(val displayName: String, val palette: Map<LogLevel, Co
         LogLevel.ERROR to Color(0xFFFFFFFF),
         LogLevel.ASSERT to Color(0xFFFFFFFF),
     )),
-    SOLARIZED("Solarized Dark", mapOf(
+    SOLARIZED(R.string.scheme_solarized, mapOf(
         LogLevel.VERBOSE to Color(0xFF93A1A1),
         LogLevel.DEBUG to Color(0xFF268BD2),
         LogLevel.INFO to Color(0xFF859900),
@@ -93,7 +94,7 @@ enum class LogColorScheme(val displayName: String, val palette: Map<LogLevel, Co
         LogLevel.ERROR to Color(0xFFDC322F),
         LogLevel.ASSERT to Color(0xFFD33682),
     )),
-    CUSTOM("Custom", MATERIAL.palette);
+    CUSTOM(R.string.scheme_custom, MATERIAL.palette);
 
     fun colorFor(level: LogLevel): Color = palette[level] ?: Color.White
 }

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/MainViewModel.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/MainViewModel.kt
@@ -149,8 +149,8 @@ class MainViewModel(
     private val _tabClearMarks = MutableStateFlow<Map<String, Long>>(emptyMap())
 
     // Tab Management
-    private val systemTab = LogTab("system", getApplication<Application>().getString(com.hereliesaz.logkitty.R.string.tab_all), TabType.SYSTEM)
-    private val errorsTab = LogTab("errors", getApplication<Application>().getString(com.hereliesaz.logkitty.R.string.tab_errors), TabType.ERRORS)
+    private val systemTab = LogTab("system", application.getString(com.hereliesaz.logkitty.R.string.tab_all), TabType.SYSTEM)
+    private val errorsTab = LogTab("errors", application.getString(com.hereliesaz.logkitty.R.string.tab_errors), TabType.ERRORS)
 
     private val _tabs = MutableStateFlow(listOf(systemTab, errorsTab))
     val tabs: StateFlow<List<LogTab>> = _tabs

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/MainViewModel.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/MainViewModel.kt
@@ -149,8 +149,8 @@ class MainViewModel(
     private val _tabClearMarks = MutableStateFlow<Map<String, Long>>(emptyMap())
 
     // Tab Management
-    private val systemTab = LogTab("system", "All", TabType.SYSTEM)
-    private val errorsTab = LogTab("errors", "Errors", TabType.ERRORS)
+    private val systemTab = LogTab("system", getApplication<Application>().getString(com.hereliesaz.logkitty.R.string.tab_all), TabType.SYSTEM)
+    private val errorsTab = LogTab("errors", getApplication<Application>().getString(com.hereliesaz.logkitty.R.string.tab_errors), TabType.ERRORS)
 
     private val _tabs = MutableStateFlow(listOf(systemTab, errorsTab))
     val tabs: StateFlow<List<LogTab>> = _tabs

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/ProhibitedLogsScreen.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/ProhibitedLogsScreen.kt
@@ -11,9 +11,11 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.hereliesaz.aznavrail.AzButton
 import com.hereliesaz.aznavrail.model.AzButtonShape
+import com.hereliesaz.logkitty.R
 
 /**
  * [ProhibitedLogsScreen] allows the user to manage the list of "Blacklisted" tags.
@@ -32,10 +34,10 @@ fun ProhibitedLogsScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Prohibited Logs") },
+                title = { Text(stringResource(R.string.prohibited_title)) },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.cd_back))
                     }
                 }
             )
@@ -49,7 +51,7 @@ fun ProhibitedLogsScreen(
                 contentAlignment = Alignment.Center
             ) {
                 Text(
-                    text = "No prohibited logs.",
+                    text = stringResource(R.string.prohibited_empty),
                     style = MaterialTheme.typography.bodyLarge,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
@@ -99,7 +101,7 @@ fun ProhibitedTagItem(
             // Remove Button
             AzButton(
                 onClick = onDelete,
-                text = "Remove",
+                text = stringResource(R.string.remove),
                 shape = AzButtonShape.RECTANGLE,
                 contentPadding = PaddingValues(horizontal = 8.dp, vertical = 4.dp)
             )

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/SettingsScreen.kt
@@ -274,7 +274,10 @@ private fun SettingsMainScreen(
                     modifier = Modifier.fillMaxWidth(),
                     shape = RectangleShape
                 ) {
-                    Text(stringResource(R.string.settings_font, fontFamilyName))
+                    val currentFont = remember(fontFamilyName) {
+                        try { CodingFont.valueOf(fontFamilyName) } catch (e: Exception) { CodingFont.SYSTEM }
+                    }
+                    Text(stringResource(R.string.settings_font, stringResource(currentFont.displayNameRes)))
                 }
                 DropdownMenu(expanded = fontExpanded, onDismissRequest = { fontExpanded = false }) {
                     CodingFont.values().forEach { font ->

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/SettingsScreen.kt
@@ -54,10 +54,12 @@ import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.unit.dp
 import com.hereliesaz.aznavrail.AzButton
 import com.hereliesaz.aznavrail.model.AzButtonShape
+import com.hereliesaz.logkitty.R
 import com.hereliesaz.logkitty.ui.theme.CodingFont
 import com.hereliesaz.logkitty.utils.LogSources
 
@@ -150,8 +152,8 @@ private fun SettingsMainScreen(
             context.contentResolver.openOutputStream(uri)?.use { out ->
                 out.write(viewModel.exportPreferences().toByteArray())
             }
-            Toast.makeText(context, "Preferences exported", Toast.LENGTH_SHORT).show()
-        }.onFailure { Toast.makeText(context, "Export failed: ${it.message}", Toast.LENGTH_LONG).show() }
+            Toast.makeText(context, context.getString(R.string.toast_prefs_exported), Toast.LENGTH_SHORT).show()
+        }.onFailure { Toast.makeText(context, context.getString(R.string.toast_export_failed, it.message), Toast.LENGTH_LONG).show() }
     }
 
     val importLauncher = rememberLauncherForActivityResult(
@@ -160,17 +162,17 @@ private fun SettingsMainScreen(
         if (uri != null) runCatching {
             val text = context.contentResolver.openInputStream(uri)?.bufferedReader()?.use { it.readText() } ?: ""
             val ok = viewModel.importPreferences(text)
-            Toast.makeText(context, if (ok) "Preferences imported" else "Invalid file", Toast.LENGTH_SHORT).show()
-        }.onFailure { Toast.makeText(context, "Import failed: ${it.message}", Toast.LENGTH_LONG).show() }
+            Toast.makeText(context, context.getString(if (ok) R.string.toast_prefs_imported else R.string.toast_invalid_file), Toast.LENGTH_SHORT).show()
+        }.onFailure { Toast.makeText(context, context.getString(R.string.toast_import_failed, it.message), Toast.LENGTH_LONG).show() }
     }
 
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Settings") },
+                title = { Text(stringResource(R.string.settings_title)) },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, "Back")
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, stringResource(R.string.cd_back))
                     }
                 }
             )
@@ -183,7 +185,7 @@ private fun SettingsMainScreen(
                 .verticalScroll(scrollState)
                 .padding(16.dp)
         ) {
-            SettingsSectionHeader("Appearance")
+            SettingsSectionHeader(stringResource(R.string.settings_section_appearance))
 
             Row(
                 modifier = Modifier
@@ -193,7 +195,7 @@ private fun SettingsMainScreen(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.SpaceBetween
             ) {
-                Text("Background Color", style = MaterialTheme.typography.bodyLarge)
+                Text(stringResource(R.string.settings_background_color), style = MaterialTheme.typography.bodyLarge)
                 Box(
                     modifier = Modifier
                         .size(32.dp)
@@ -205,7 +207,7 @@ private fun SettingsMainScreen(
             HorizontalDivider()
 
             Text(
-                "Background Opacity: ${(overlayOpacity * 100).toInt()}%",
+                stringResource(R.string.settings_background_opacity, (overlayOpacity * 100).toInt()),
                 style = MaterialTheme.typography.bodyLarge,
                 modifier = Modifier.padding(top = 12.dp)
             )
@@ -217,19 +219,19 @@ private fun SettingsMainScreen(
             )
             HorizontalDivider(modifier = Modifier.padding(vertical = 16.dp))
 
-            SettingsSectionHeader("Log Colors")
+            SettingsSectionHeader(stringResource(R.string.settings_section_log_colors))
             Row(
                 modifier = Modifier.fillMaxWidth().padding(vertical = 6.dp),
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.SpaceBetween
             ) {
-                Text("Color Scheme", style = MaterialTheme.typography.bodyLarge)
+                Text(stringResource(R.string.settings_color_scheme), style = MaterialTheme.typography.bodyLarge)
                 Box {
-                    OutlinedButton(onClick = { showSchemeMenu = true }) { Text(colorScheme.displayName) }
+                    OutlinedButton(onClick = { showSchemeMenu = true }) { Text(stringResource(colorScheme.displayNameRes)) }
                     DropdownMenu(expanded = showSchemeMenu, onDismissRequest = { showSchemeMenu = false }) {
                         LogColorScheme.values().forEach { scheme ->
                             DropdownMenuItem(
-                                text = { Text(scheme.displayName) },
+                                text = { Text(stringResource(scheme.displayNameRes)) },
                                 onClick = {
                                     viewModel.setColorScheme(scheme)
                                     showSchemeMenu = false
@@ -244,20 +246,20 @@ private fun SettingsMainScreen(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.SpaceBetween
             ) {
-                Text("Tag-Based Coloring", style = MaterialTheme.typography.bodyLarge)
+                Text(stringResource(R.string.settings_tag_based_coloring), style = MaterialTheme.typography.bodyLarge)
                 Switch(checked = tagColoringEnabled, onCheckedChange = { viewModel.setTagColoringEnabled(it) })
             }
             AzButton(
                 onClick = onOpenColorEditor,
-                text = "Customize Per-Level Colors",
+                text = stringResource(R.string.settings_customize_per_level_colors),
                 shape = AzButtonShape.RECTANGLE,
                 modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)
             )
 
             HorizontalDivider(modifier = Modifier.padding(vertical = 16.dp))
 
-            SettingsSectionHeader("Typography")
-            Text("Font Size: ${fontSize}sp", style = MaterialTheme.typography.bodyLarge)
+            SettingsSectionHeader(stringResource(R.string.settings_section_typography))
+            Text(stringResource(R.string.settings_font_size, fontSize), style = MaterialTheme.typography.bodyLarge)
             Slider(
                 value = fontSize.toFloat(),
                 onValueChange = { viewModel.setFontSize(it.toInt()) },
@@ -272,12 +274,12 @@ private fun SettingsMainScreen(
                     modifier = Modifier.fillMaxWidth(),
                     shape = RectangleShape
                 ) {
-                    Text("Font: $fontFamilyName")
+                    Text(stringResource(R.string.settings_font, fontFamilyName))
                 }
                 DropdownMenu(expanded = fontExpanded, onDismissRequest = { fontExpanded = false }) {
                     CodingFont.values().forEach { font ->
                         DropdownMenuItem(
-                            text = { Text(font.displayName) },
+                            text = { Text(stringResource(font.displayNameRes)) },
                             onClick = {
                                 viewModel.setFontFamily(font)
                                 fontExpanded = false
@@ -292,14 +294,14 @@ private fun SettingsMainScreen(
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                Text("Show Timestamps", style = MaterialTheme.typography.bodyLarge)
+                Text(stringResource(R.string.settings_show_timestamps), style = MaterialTheme.typography.bodyLarge)
                 Switch(checked = showTimestamp, onCheckedChange = { viewModel.setShowTimestamp(it) })
             }
             HorizontalDivider(modifier = Modifier.padding(vertical = 16.dp))
 
-            SettingsSectionHeader("Behavior")
+            SettingsSectionHeader(stringResource(R.string.settings_section_behavior))
 
-            Text("Active Log Levels", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.primary)
+            Text(stringResource(R.string.settings_active_log_levels), style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.primary)
             Row(
                 modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
                 horizontalArrangement = Arrangement.SpaceBetween
@@ -321,13 +323,13 @@ private fun SettingsMainScreen(
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                Text("Buffer Size", style = MaterialTheme.typography.bodyLarge)
+                Text(stringResource(R.string.settings_buffer_size), style = MaterialTheme.typography.bodyLarge)
                 Box {
                     OutlinedButton(onClick = { bufferExpanded = true }) { Text(bufferSize.toString()) }
                     DropdownMenu(expanded = bufferExpanded, onDismissRequest = { bufferExpanded = false }) {
                         listOf(1000, 2000, 5000, 10000).forEach { size ->
                             DropdownMenuItem(
-                                text = { Text("$size lines") },
+                                text = { Text(stringResource(R.string.settings_buffer_lines, size)) },
                                 onClick = {
                                     viewModel.setBufferSize(size)
                                     bufferExpanded = false
@@ -343,7 +345,7 @@ private fun SettingsMainScreen(
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                Text("Context Mode (Auto-Filter)", style = MaterialTheme.typography.bodyLarge)
+                Text(stringResource(R.string.settings_context_mode), style = MaterialTheme.typography.bodyLarge)
                 Switch(checked = isContextMode, onCheckedChange = { viewModel.toggleContextMode() })
             }
 
@@ -352,7 +354,7 @@ private fun SettingsMainScreen(
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                Text("Root Access", style = MaterialTheme.typography.bodyLarge)
+                Text(stringResource(R.string.settings_root_access), style = MaterialTheme.typography.bodyLarge)
                 Switch(checked = isRootEnabled, onCheckedChange = { viewModel.setRootEnabled(it) })
             }
 
@@ -361,21 +363,21 @@ private fun SettingsMainScreen(
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                Text("Reverse Log Order", style = MaterialTheme.typography.bodyLarge)
+                Text(stringResource(R.string.settings_reverse_log_order), style = MaterialTheme.typography.bodyLarge)
                 Switch(checked = isLogReversed, onCheckedChange = { viewModel.setLogReversed(it) })
             }
             HorizontalDivider(modifier = Modifier.padding(vertical = 16.dp))
 
-            SettingsSectionHeader("App Monitoring")
+            SettingsSectionHeader(stringResource(R.string.settings_section_app_monitoring))
             Text(
-                "Pin an app to get a dedicated tab showing only its logs, in addition to the full system log.",
+                stringResource(R.string.settings_app_monitoring_desc),
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier.padding(bottom = 4.dp)
             )
             if (monitoredApps.isEmpty()) {
                 Text(
-                    "No apps pinned",
+                    stringResource(R.string.settings_no_apps_pinned),
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     modifier = Modifier.padding(vertical = 8.dp)
@@ -400,70 +402,68 @@ private fun SettingsMainScreen(
                             )
                         }
                         IconButton(onClick = { viewModel.removeMonitoredApp(pkg) }) {
-                            Icon(Icons.Default.Close, contentDescription = "Stop monitoring $pkg")
+                            Icon(Icons.Default.Close, contentDescription = stringResource(R.string.cd_stop_monitoring, pkg))
                         }
                     }
                 }
             }
             AzButton(
                 onClick = { showAppPicker = true },
-                text = "Add App to Monitor",
+                text = stringResource(R.string.settings_add_app_to_monitor),
                 shape = AzButtonShape.RECTANGLE,
                 modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)
             )
             HorizontalDivider(modifier = Modifier.padding(vertical = 16.dp))
 
-            SettingsSectionHeader("Log sources")
+            SettingsSectionHeader(stringResource(R.string.settings_section_log_sources))
             Text(
-                "Add tabs that show only logs from a chosen source. The All tab always shows " +
-                    "everything. (Source/category classification needs the UID column — root or " +
-                    "ADB READ_LOGS; lines without a UID appear only in All.)",
+                stringResource(R.string.settings_log_sources_desc),
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier.padding(bottom = 8.dp)
             )
             SourceFilterGroup(
-                title = "Sources",
+                title = stringResource(R.string.settings_sources),
                 keys = LogSources.SOURCE_BUCKETS,
                 enabled = activeSourceFilters,
                 onToggle = { key, on -> viewModel.setSourceFilterEnabled(key, on) }
             )
             SourceFilterGroup(
-                title = "Categories",
+                title = stringResource(R.string.settings_categories),
                 keys = LogSources.CATEGORY_BUCKETS,
                 enabled = activeSourceFilters,
                 onToggle = { key, on -> viewModel.setSourceFilterEnabled(key, on) }
             )
             HorizontalDivider(modifier = Modifier.padding(vertical = 16.dp))
 
-            SettingsSectionHeader("Filters")
+            SettingsSectionHeader(stringResource(R.string.settings_section_filters))
             AzButton(
                 onClick = onOpenProhibited,
-                text = "Prohibited Tags (${prohibitedCount.size})",
+                text = stringResource(R.string.settings_prohibited_tags, prohibitedCount.size),
                 shape = AzButtonShape.RECTANGLE,
                 modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)
             )
             HorizontalDivider(modifier = Modifier.padding(vertical = 16.dp))
 
-            SettingsSectionHeader("Backup")
+            SettingsSectionHeader(stringResource(R.string.settings_section_backup))
             AzButton(
                 onClick = { exportLauncher.launch("logkitty_prefs.json") },
-                text = "Export Preferences",
+                text = stringResource(R.string.settings_export_preferences),
                 shape = AzButtonShape.RECTANGLE,
                 modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)
             )
             AzButton(
                 onClick = { importLauncher.launch(arrayOf("application/json", "text/plain", "*/*")) },
-                text = "Import Preferences",
+                text = stringResource(R.string.settings_import_preferences),
                 shape = AzButtonShape.RECTANGLE,
                 modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)
             )
             AzButton(
                 onClick = {
                     clipboardManager.setText(AnnotatedString(viewModel.exportPreferences()))
-                    Toast.makeText(context, "Copied to clipboard", Toast.LENGTH_SHORT).show()
+                    Toast.makeText(context, context.getString(R.string.toast_copied_to_clipboard), Toast.LENGTH_SHORT).show()
                 },
-                text = "Copy Preferences JSON",
+                text = stringResource(R.string.settings_copy_preferences_json),
                 shape = AzButtonShape.RECTANGLE,
                 modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)
             )
@@ -471,13 +471,13 @@ private fun SettingsMainScreen(
 
             AzButton(
                 onClick = { viewModel.clearLog() },
-                text = "Clear Log",
+                text = stringResource(R.string.settings_clear_log),
                 shape = AzButtonShape.RECTANGLE,
                 modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)
             )
             AzButton(
                 onClick = { viewModel.resetLogColors() },
-                text = "Reset Colors",
+                text = stringResource(R.string.settings_reset_colors),
                 shape = AzButtonShape.RECTANGLE,
                 modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)
             )
@@ -507,7 +507,7 @@ private fun appLabel(context: android.content.Context, pkg: String): String = tr
 private fun SettingsFooter(context: android.content.Context) {
     fun open(intent: android.content.Intent) {
         runCatching { context.startActivity(intent) }
-            .onFailure { Toast.makeText(context, "No app found to handle this", Toast.LENGTH_SHORT).show() }
+            .onFailure { Toast.makeText(context, context.getString(R.string.toast_no_app_to_handle), Toast.LENGTH_SHORT).show() }
     }
     Row(
         modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
@@ -516,7 +516,7 @@ private fun SettingsFooter(context: android.content.Context) {
     ) {
         // padding before clickable so the whole padded area is the touch target / ripple bounds.
         Text(
-            "About",
+            stringResource(R.string.settings_footer_about),
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.primary,
             modifier = Modifier
@@ -527,7 +527,7 @@ private fun SettingsFooter(context: android.content.Context) {
                 }
         )
         Text(
-            "Feedback",
+            stringResource(R.string.settings_footer_feedback),
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.primary,
             modifier = Modifier
@@ -538,7 +538,7 @@ private fun SettingsFooter(context: android.content.Context) {
                 }
         )
         Text(
-            "@HereLiesAz",
+            stringResource(R.string.settings_footer_handle),
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.primary,
             modifier = Modifier

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/theme/Type.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/theme/Type.kt
@@ -21,15 +21,15 @@ val provider = GoogleFont.Provider(
  * Enumeration of supported Monospace fonts for code rendering.
  * These map to Google Fonts available via the provider.
  */
-enum class CodingFont(val fontName: String, val displayName: String) {
-    SYSTEM("System", "System Default"),
-    ROBOTO_MONO("Roboto Mono", "Roboto Mono"),
-    SOURCE_CODE_PRO("Source Code Pro", "Source Code Pro"),
-    JETBRAINS_MONO("JetBrains Mono", "JetBrains Mono"),
-    FIRA_CODE("Fira Code", "Fira Code"),
-    INCONSOLATA("Inconsolata", "Inconsolata"),
-    SPACE_MONO("Space Mono", "Space Mono"),
-    UBUNTU_MONO("Ubuntu Mono", "Ubuntu Mono")
+enum class CodingFont(val fontName: String, val displayNameRes: Int) {
+    SYSTEM("System", R.string.font_system),
+    ROBOTO_MONO("Roboto Mono", R.string.font_roboto_mono),
+    SOURCE_CODE_PRO("Source Code Pro", R.string.font_source_code_pro),
+    JETBRAINS_MONO("JetBrains Mono", R.string.font_jetbrains_mono),
+    FIRA_CODE("Fira Code", R.string.font_fira_code),
+    INCONSOLATA("Inconsolata", R.string.font_inconsolata),
+    SPACE_MONO("Space Mono", R.string.font_space_mono),
+    UBUNTU_MONO("Ubuntu Mono", R.string.font_ubuntu_mono)
 }
 
 /**

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,4 +9,141 @@
     <string name="error_app_not_installed">App not installed. Please build first.</string>
     <string name="error_launch_failed">Failed to launch app: %1$s</string>
     <string name="deploy_instruction_gh_pages">Deployed! Enable GitHub Pages in repo settings.</string>
+
+    <!-- Common -->
+    <string name="select">Select</string>
+    <string name="remove">Remove</string>
+    <string name="settings">Settings</string>
+    <string name="cd_back">Back</string>
+
+    <!-- Main dashboard (MainActivity) -->
+    <string name="cd_app_logo">LogKitty Logo</string>
+    <string name="main_overlay_permission_title">Overlay Permission Required</string>
+    <string name="main_overlay_permission_desc">LogKitty needs to draw over other apps.</string>
+    <string name="main_grant_overlay">Grant Overlay</string>
+    <string name="main_standard_permission_title">Standard Permission Required</string>
+    <string name="main_run_adb_command">Run this ADB command:</string>
+    <string name="main_copy_command">Copy Command</string>
+    <string name="main_ready_to_purr">Ready to Purr</string>
+    <string name="main_stop_service">Stop Service</string>
+    <string name="main_start_service">Start Service</string>
+
+    <!-- Settings screen -->
+    <string name="settings_title">Settings</string>
+    <string name="settings_section_appearance">Appearance</string>
+    <string name="settings_background_color">Background Color</string>
+    <string name="settings_background_opacity">Background Opacity: %1$d%%</string>
+    <string name="settings_section_log_colors">Log Colors</string>
+    <string name="settings_color_scheme">Color Scheme</string>
+    <string name="settings_tag_based_coloring">Tag-Based Coloring</string>
+    <string name="settings_customize_per_level_colors">Customize Per-Level Colors</string>
+    <string name="settings_section_typography">Typography</string>
+    <string name="settings_font_size">Font Size: %1$dsp</string>
+    <string name="settings_font">Font: %1$s</string>
+    <string name="settings_show_timestamps">Show Timestamps</string>
+    <string name="settings_section_behavior">Behavior</string>
+    <string name="settings_active_log_levels">Active Log Levels</string>
+    <string name="settings_buffer_size">Buffer Size</string>
+    <string name="settings_buffer_lines">%1$d lines</string>
+    <string name="settings_context_mode">Context Mode (Auto-Filter)</string>
+    <string name="settings_root_access">Root Access</string>
+    <string name="settings_reverse_log_order">Reverse Log Order</string>
+    <string name="settings_section_app_monitoring">App Monitoring</string>
+    <string name="settings_app_monitoring_desc">Pin an app to get a dedicated tab showing only its logs, in addition to the full system log.</string>
+    <string name="settings_no_apps_pinned">No apps pinned</string>
+    <string name="cd_stop_monitoring">Stop monitoring %1$s</string>
+    <string name="settings_add_app_to_monitor">Add App to Monitor</string>
+    <string name="settings_section_log_sources">Log sources</string>
+    <string name="settings_log_sources_desc">Add tabs that show only logs from a chosen source. The All tab always shows everything. (Source/category classification needs the UID column — root or ADB READ_LOGS; lines without a UID appear only in All.)</string>
+    <string name="settings_sources">Sources</string>
+    <string name="settings_categories">Categories</string>
+    <string name="settings_section_filters">Filters</string>
+    <string name="settings_prohibited_tags">Prohibited Tags (%1$d)</string>
+    <string name="settings_section_backup">Backup</string>
+    <string name="settings_export_preferences">Export Preferences</string>
+    <string name="settings_import_preferences">Import Preferences</string>
+    <string name="settings_copy_preferences_json">Copy Preferences JSON</string>
+    <string name="settings_clear_log">Clear Log</string>
+    <string name="settings_reset_colors">Reset Colors</string>
+    <string name="settings_footer_about">About</string>
+    <string name="settings_footer_feedback">Feedback</string>
+    <string name="settings_footer_handle">\@HereLiesAz</string>
+
+    <!-- Toasts -->
+    <string name="toast_prefs_exported">Preferences exported</string>
+    <string name="toast_export_failed">Export failed: %1$s</string>
+    <string name="toast_prefs_imported">Preferences imported</string>
+    <string name="toast_invalid_file">Invalid file</string>
+    <string name="toast_import_failed">Import failed: %1$s</string>
+    <string name="toast_copied_to_clipboard">Copied to clipboard</string>
+    <string name="toast_no_app_to_handle">No app found to handle this</string>
+    <string name="toast_logs_saved">Logs saved successfully</string>
+    <string name="toast_save_logs_failed">Failed to save logs: %1$s</string>
+
+    <!-- Prohibited logs screen -->
+    <string name="prohibited_title">Prohibited Logs</string>
+    <string name="prohibited_empty">No prohibited logs.</string>
+
+    <!-- Color scheme editor -->
+    <string name="colors_title">Log Colors — %1$s</string>
+    <string name="colors_editor_hint">Tap a swatch to customize. Editing any color switches the active scheme to Custom.</string>
+    <string name="colors_letter">Letter: %1$s</string>
+
+    <!-- Color picker dialog -->
+    <string name="color_picker_title">Pick Background Color</string>
+    <string name="color_picker_channel_red">R</string>
+    <string name="color_picker_channel_green">G</string>
+    <string name="color_picker_channel_blue">B</string>
+
+    <!-- App picker dialog -->
+    <string name="app_picker_title">Monitor an app</string>
+    <string name="app_picker_search">Search apps</string>
+
+    <!-- Log bottom sheet -->
+    <string name="sheet_ready">LogKitty Ready</string>
+    <string name="sheet_no_logs">No logs</string>
+    <string name="sheet_selected_entry">Selected entry</string>
+    <string name="sheet_count_selected">%1$d selected</string>
+    <string name="cd_close_tab">Close tab</string>
+    <string name="cd_save">Save</string>
+    <string name="cd_resume_logging">Resume logging</string>
+    <string name="cd_pause_logging">Pause logging</string>
+    <string name="cd_clear_logs">Clear logs</string>
+    <string name="cd_close">Close</string>
+    <string name="cd_copy_selected">Copy selected</string>
+    <string name="cd_search_google">Search Google</string>
+    <string name="cd_prohibit_tag">Prohibit this tag</string>
+    <string name="cd_deselect">Deselect</string>
+
+    <!-- Tabs -->
+    <string name="tab_all">All</string>
+    <string name="tab_errors">Errors</string>
+
+    <!-- Color scheme names -->
+    <string name="scheme_material">Material</string>
+    <string name="scheme_aosp">Android Studio</string>
+    <string name="scheme_pidcat">Pidcat</string>
+    <string name="scheme_monochrome">Monochrome</string>
+    <string name="scheme_solarized">Solarized Dark</string>
+    <string name="scheme_custom">Custom</string>
+
+    <!-- Font names -->
+    <string name="font_system">System Default</string>
+    <string name="font_roboto_mono">Roboto Mono</string>
+    <string name="font_source_code_pro">Source Code Pro</string>
+    <string name="font_jetbrains_mono">JetBrains Mono</string>
+    <string name="font_fira_code">Fira Code</string>
+    <string name="font_inconsolata">Inconsolata</string>
+    <string name="font_space_mono">Space Mono</string>
+    <string name="font_ubuntu_mono">Ubuntu Mono</string>
+
+    <!-- Notifications (overlay service) -->
+    <string name="notif_channel_name">Overlay Service</string>
+    <string name="notif_title">LogKitty is running</string>
+    <string name="notif_text_paused">Logging paused. Tap to turn off.</string>
+    <string name="notif_text_running">Logging. Tap to turn off.</string>
+    <string name="notif_action_start">Start</string>
+    <string name="notif_action_stop">Stop</string>
+    <string name="notif_action_turn_off">Turn Off LogKitty</string>
+    <string name="notif_action_app_settings">App Settings</string>
 </resources>


### PR DESCRIPTION
Full internationalization pass — moves hardcoded **user-facing** strings out of Kotlin into `res/values/strings.xml`, referenced via `stringResource()` in Composables and `getString()` in Activities/Service/ViewModel.

## What changed
- **Screens/dialogs:** Settings, Prohibited Logs, Color Scheme Editor, App Picker, Color Picker, and the log bottom sheet (including all icon `contentDescription`s).
- **MainActivity:** logo CD, app name, permission cards, ADB instruction labels, Start/Stop/Settings buttons.
- **Overlay service:** notification channel name, title/text, and all action labels.
- **Toasts:** export/import/copy (Settings) and save (FileSaver).
- **Enums:** `LogColorScheme.displayName` and `CodingFont.displayName` `String` fields are now `displayNameRes: Int`, resolved at their (Composable) call sites. *(This is the one structural change — verified no `.displayName` references remain.)*
- **Tabs:** `All` / `Errors` titles resolved via the ViewModel's `Application` context.
- `strings.xml`: ~80 entries added (existing ones kept; reused where identical).

## Deliberately left inline
- `LogSources.label()` — `LogSources` is a plain `object` with no `Context`; adding one would break its Composable + ViewModel call sites.
- `LogcatReader` stream warnings — plain `object`, no `Context`.
- `CrashReporter` — GitHub-issue payloads / log-only, not shown to users.
- Log-level identifiers (V/D/I/W/E/A — also used as pref keys), the ADB command, and all intent actions/URLs/mime types.

## Notes
- Sandbox can't run Gradle — verified by inspection (imports present, `stringResource` only in Composables, format args/escaping checked). Needs CI `build-and-release` to confirm.
- The footer here is the pre-#102 version; if #102 merges first I'll rebase and fold its bigger-font/version/margin changes into the resource-backed footer.

---
Generated by [Claude Code](https://claude.ai/code/session_017hRcXbYpxVLL1AhJi1t8Qk)

---
_Generated by [Claude Code](https://claude.ai/code/session_017hRcXbYpxVLL1AhJi1t8Qk)_