### PR TITLE
Update AzNavRail 9.9 → 9.10

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 agp = "9.2.1"
 aetherTransportFile = "2.0.14"
-aznavrail = "9.9"
+aznavrail = "9.10"
 playServicesAds = "23.3.0"
 coreKtx = "1.18.0"
 kotlinxCoroutinesCore = "1.11.0"


### PR DESCRIPTION
Bumps AzNavRail from **9.9 → 9.10** in the version catalog.

If 9.10 includes the overlay-host `drawBehindNavBar` fix, the bottom sheet should now actually draw behind the system navigation bar on button-nav devices (the extra log lines from #101 will show through the see-through bar). No LogKitty code change is needed — the rendering was already wired in #101; this only updates the dependency.

Please test the collapsed sheet on a button-nav device and confirm the lines show through. Sandbox can't run Gradle — CI `build-and-release` verifies it compiles/links against 9.10.

---
Generated by [Claude Code](https://claude.ai/code/session_017hRcXbYpxVLL1AhJi1t8Qk)

---
_Generated by [Claude Code](https://claude.ai/code/session_017hRcXbYpxVLL1AhJi1t8Qk)_