### PR TITLE
Fix broken SettingsFooter (compile failure on main from #102/#103 merge)

### DIFF
--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/SettingsScreen.kt
@@ -518,31 +518,6 @@ private fun SettingsFooter(context: android.content.Context) {
         modifier = Modifier.fillMaxWidth(),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        // padding before clickable so the whole padded area is the touch target / ripple bounds.
-        Text(
-            stringResource(R.string.settings_footer_about),
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.primary,
-            modifier = Modifier
-                .padding(8.dp)
-                .clickable {
-                    open(android.content.Intent(android.content.Intent.ACTION_VIEW,
-                        Uri.parse("https://github.com/HereLiesAz/LogKitty")))
-                }
-        )
-        Text(
-            stringResource(R.string.settings_footer_feedback),
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.primary,
-            modifier = Modifier
-                .padding(8.dp)
-                .clickable {
-                    open(android.content.Intent(android.content.Intent.ACTION_SENDTO,
-                        Uri.parse("mailto:hereliesaz@gmail.com?subject=LogKitty")))
-                }
-        )
-        Text(
-            stringResource(R.string.settings_footer_handle),
         Row(
             modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
             horizontalArrangement = Arrangement.SpaceEvenly,
@@ -550,7 +525,7 @@ private fun SettingsFooter(context: android.content.Context) {
         ) {
             // clickable before padding so the whole padded area is the touch target / ripple bounds.
             Text(
-                "About",
+                stringResource(R.string.settings_footer_about),
                 style = MaterialTheme.typography.titleLarge,
                 color = MaterialTheme.colorScheme.primary,
                 modifier = Modifier
@@ -561,7 +536,7 @@ private fun SettingsFooter(context: android.content.Context) {
                     .padding(8.dp)
             )
             Text(
-                "Feedback",
+                stringResource(R.string.settings_footer_feedback),
                 style = MaterialTheme.typography.titleLarge,
                 color = MaterialTheme.colorScheme.primary,
                 modifier = Modifier
@@ -572,7 +547,7 @@ private fun SettingsFooter(context: android.content.Context) {
                     .padding(8.dp)
             )
             Text(
-                "@HereLiesAz",
+                stringResource(R.string.settings_footer_handle),
                 style = MaterialTheme.typography.titleLarge,
                 color = MaterialTheme.colorScheme.primary,
                 modifier = Modifier
@@ -584,7 +559,7 @@ private fun SettingsFooter(context: android.content.Context) {
             )
         }
         Text(
-            "LogKitty v${BuildConfig.VERSION_NAME}",
+            stringResource(R.string.settings_version, BuildConfig.VERSION_NAME),
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             modifier = Modifier.padding(top = 8.dp)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -68,6 +68,7 @@
     <string name="settings_footer_about">About</string>
     <string name="settings_footer_feedback">Feedback</string>
     <string name="settings_footer_handle">\@HereLiesAz</string>
+    <string name="settings_version">LogKitty v%1$s</string>
 
     <!-- Toasts -->
     <string name="toast_prefs_exported">Preferences exported</string>


### PR DESCRIPTION
## ⚠️ Fixes a broken build on `main`

The GitHub merge of #102 (bigger footer links + version line) and #103 (i18n) **spliced two footer variants together** in `SettingsScreen.kt → SettingsFooter`, producing invalid Kotlin:

```kotlin
Text(
    stringResource(R.string.settings_footer_handle),   // ← never closed
Row(                                                   // ← duplicate footer Row begins
    ...
```

This breaks `compileReleaseKotlin`:
```
SettingsScreen.kt:586:9 Unresolved reference 'Text'.
SettingsScreen.kt:587:52 Syntax error: Expecting ')'.
```

`main` has been failing `build-and-release` since the merge (it slipped through because `submit-gradle` only resolves dependencies — it doesn't compile Kotlin). PRs branched off main (#104, #108) inherit the breakage.

## Fix
Rebuilt `SettingsFooter` as the intended combination of both PRs:
- **i18n** labels via `stringResource` (from #103),
- **`titleLarge`** styling + **clickable-before-padding** touch target (from #102),
- version line via a new **`settings_version`** string resource (`LogKitty v%1$s`) instead of the hardcoded string.

The 240dp bottom margin from #102 is untouched.

Once this merges I'll rebase #104 and #108 onto the fixed `main`.

---
Generated by [Claude Code](https://claude.ai/code/session_017hRcXbYpxVLL1AhJi1t8Qk)

---
_Generated by [Claude Code](https://claude.ai/code/session_017hRcXbYpxVLL1AhJi1t8Qk)_