### PR TITLE
Restore clean HIDDEN=1 / PEEK=3 lines above the nav bar

### DIFF
--- a/app/src/main/kotlin/com/hereliesaz/logkitty/services/LogKittyOverlayService.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/services/LogKittyOverlayService.kt
@@ -177,7 +177,6 @@ class LogKittyOverlayService : Service() {
                 LogBottomSheet(
                     controller = controller,
                     viewModel = viewModel,
-                    navBarHeightPx = navBarHeightPx,
                     onSaveClick = {
                         val intent = Intent(this@LogKittyOverlayService,
                             com.hereliesaz.logkitty.FileSaverActivity::class.java)
@@ -237,10 +236,9 @@ class LogKittyOverlayService : Service() {
         // Matches the Text lineHeight used in LogBottomSheet's PeekStrip (fontSize * 1.35).
         val lineHeightPx = fontSize.toFloat() * density * 1.35f
 
-        // These are the EXPOSED heights above the nav bar (one line at HIDDEN, three at PEEK). With
-        // drawBehindNavBar, AzNavRail extends the sheet behind the bar by the nav-bar inset (passed
-        // to the host) and makes the bar see-through, so the exposed height — and the top edge —
-        // stays exactly as before; the extra lines LogBottomSheet renders show through the bar.
+        // Heights above the nav bar: one line at HIDDEN, three at PEEK. The host is given the
+        // measured nav-bar inset so the window sits cleanly above the bar (drawBehindNavBar is off
+        // because the overlay nav bar isn't actually see-through, which only cluttered the strips).
         val hiddenPx = (lineHeightPx * 1)
         val hiddenDp = (hiddenPx / density).dp
 
@@ -259,9 +257,9 @@ class LogKittyOverlayService : Service() {
             horizontalSwipeEnabled = false,
             handleVisible = false,
             cornerRadiusDp = 0.dp,
-            // Draw behind the system nav bar (button-nav only; no-op on gesture nav) so the extra
-            // log lines show through it.
-            drawBehindNavBar = true,
+            // Keep the sheet above the system nav bar. (Drawing behind a see-through bar needs an
+            // AzNavRail host change; until then this just cluttered HIDDEN with extra lines.)
+            drawBehindNavBar = false,
         )
     }
 

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/LogBottomSheet.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/LogBottomSheet.kt
@@ -101,7 +101,6 @@ fun AzSheetController.hide() { snapTo(AzSheetDetent.HIDDEN) }
 fun LogBottomSheet(
     controller: AzSheetController,
     viewModel: MainViewModel,
-    navBarHeightPx: Int,
     onSaveClick: () -> Unit,
     onSettingsClick: () -> Unit,
 ) {
@@ -124,14 +123,6 @@ fun LogBottomSheet(
         getGoogleFontFamily(enumVal.fontName)
     }
 
-    // How many extra lines fit in the nav-bar band the sheet now draws behind (drawBehindNavBar).
-    // On gesture nav the inset is ~0, so this is 0 and the strips look exactly as before.
-    val density = LocalDensity.current.density
-    val extraNavBarLines = remember(navBarHeightPx, fontSize, density) {
-        val lineHeightPx = fontSize * 1.35f * density
-        if (lineHeightPx > 0f) (navBarHeightPx / lineHeightPx).toInt().coerceAtLeast(0) else 0
-    }
-
     var selectedLineIds by remember { mutableStateOf<Set<Long>>(emptySet()) }
     var isMultiSelectMode by remember { mutableStateOf(false) }
     val selectedLines = remember(selectedLineIds, indexedLog) {
@@ -142,9 +133,9 @@ fun LogBottomSheet(
     when (controller.detent) {
         AzSheetDetent.HIDDEN -> PeekStrip(
             modifier = Modifier.fillMaxSize(),
-            // Newest line stays above the bar; older lines flow down through the see-through bar.
+            // One line: the latest entry, sitting just above the nav bar.
             lines = if (indexedLog.isEmpty()) listOf(stringResource(R.string.sheet_ready))
-                    else indexedLog.takeLast(1 + extraNavBarLines).map { it.text }.asReversed(),
+                    else indexedLog.takeLast(1).map { it.text },
             showTimestamp = showTimestamp,
             fontFamily = currentFontFamily,
             fontSize = fontSize,
@@ -154,8 +145,9 @@ fun LogBottomSheet(
         )
         AzSheetDetent.PEEK -> PeekStrip(
             modifier = Modifier.fillMaxSize(),
+            // The last three entries, oldest-to-newest, pinned above the nav bar.
             lines = if (indexedLog.isEmpty()) listOf(stringResource(R.string.sheet_ready))
-                    else indexedLog.takeLast(3 + extraNavBarLines).map { it.text }.asReversed(),
+                    else indexedLog.takeLast(3).map { it.text },
             showTimestamp = showTimestamp,
             fontFamily = currentFontFamily,
             fontSize = fontSize,
@@ -266,9 +258,9 @@ private fun PeekStrip(
                     .fillMaxWidth()
                     .fillMaxHeight()
                     .padding(horizontal = 12.dp),
-                // Top-align: the caller passes lines newest-first, so the newest sits at the top
-                // (above the nav bar) and older lines flow down through the see-through bar.
-                verticalArrangement = Arrangement.Top
+                // Bottom-align so the line(s) hug the bottom edge (just above the nav bar); when
+                // the log is shorter than the strip, the slack appears above the text, not below.
+                verticalArrangement = Arrangement.Bottom
             ) {
                 lines.forEach { line ->
                     val displayText = if (showTimestamp) line else line.replace(timestampRegex, "")


### PR DESCRIPTION
Restores the clean collapsed-sheet look. Your screenshots showed HIDDEN rendering a whole block of lines (not one) and PEEK looking nearly identical, with nothing actually behind the (opaque) nav bar.

**Cause:** AzNavRail 9.10's `drawBehindNavBar` grew the sheet window by the nav-bar inset, but the overlay nav bar isn't truly see-through, so the "extra" lines my earlier change rendered (`takeLast(1 + extraNavBarLines)`) piled up **above** the opaque bar instead of showing **through** it.

**Fix:**
- `LogBottomSheet`: dropped `navBarHeightPx`/`extraNavBarLines`. HIDDEN renders the latest **1** line, PEEK the last **3** (chronological), bottom-aligned so they sit just above the nav bar with no gap below.
- `sheetConfig`: `drawBehindNavBar = false`, so AzNavRail sizes the window to exactly the detent height and places it cleanly above the bar (the host still gets `navBarHeightPx` for that offset).

Result on a button-nav device: HIDDEN = one line above the bar, PEEK = three, no clutter.

Behind-bar is parked, not abandoned — see the next message for the AzNavRail prompt to make the bar genuinely see-through; once that ships I'll re-enable the extra lines.

---
Generated by [Claude Code](https://claude.ai/code/session_017hRcXbYpxVLL1AhJi1t8Qk)

---
_Generated by [Claude Code](https://claude.ai/code/session_017hRcXbYpxVLL1AhJi1t8Qk)_

## Summary by Sourcery

Restore the bottom sheet’s HIDDEN and PEEK detents to show a clean 1-line and 3-line strip positioned directly above the nav bar instead of rendering extra lines behind it.

Bug Fixes:
- Fix misaligned and cluttered HIDDEN/PEEK log strips caused by rendering extra lines behind an opaque nav bar.

Enhancements:
- Simplify LogBottomSheet by removing nav bar height–dependent extra-line calculations and always using a fixed 1-line (HIDDEN) and 3-line (PEEK) display.
- Adjust PeekStrip layout to bottom-align preview lines so they consistently hug the bottom edge above the nav bar.
- Update AzNavRail sheet configuration to stop drawing behind the nav bar and instead size the window exactly above it.