### PR TITLE
Prominent-disclosure consent before enabling Context Mode (accessibility)

### DIFF
--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/SettingsScreen.kt
@@ -132,6 +132,24 @@ private fun SettingsMainScreen(
     var showColorPicker by remember { mutableStateOf(false) }
     var showSchemeMenu by remember { mutableStateOf(false) }
     var showAppPicker by remember { mutableStateOf(false) }
+    var showAccessibilityDisclosure by remember { mutableStateOf(false) }
+
+    if (showAccessibilityDisclosure) {
+        AccessibilityDisclosureDialog(
+            onDismiss = { showAccessibilityDisclosure = false },
+            onAgree = {
+                showAccessibilityDisclosure = false
+                viewModel.toggleContextMode() // enable
+                runCatching {
+                    context.startActivity(
+                        android.content.Intent(android.provider.Settings.ACTION_ACCESSIBILITY_SETTINGS)
+                    )
+                }.onFailure {
+                    Toast.makeText(context, context.getString(R.string.toast_no_app_to_handle), Toast.LENGTH_SHORT).show()
+                }
+            }
+        )
+    }
 
     if (showColorPicker) {
         ColorPickerDialog(
@@ -361,7 +379,14 @@ private fun SettingsMainScreen(
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 Text(stringResource(R.string.settings_context_mode), style = MaterialTheme.typography.bodyLarge)
-                Switch(checked = isContextMode, onCheckedChange = { viewModel.toggleContextMode() })
+                Switch(
+                    checked = isContextMode,
+                    onCheckedChange = { enable ->
+                        // Enabling Context Mode relies on the accessibility service, so show the
+                        // prominent disclosure + consent first; disabling needs no gate.
+                        if (enable) showAccessibilityDisclosure = true else viewModel.toggleContextMode()
+                    }
+                )
             }
 
             Row(
@@ -829,6 +854,26 @@ private fun PermissionsSection(context: android.content.Context) {
             )
         }
     }
+}
+
+/**
+ * Prominent disclosure shown before Context Mode is enabled, since that feature relies on the
+ * accessibility service. Explains what is accessed (foreground app, home/recents transitions), why,
+ * and that no screen content / personal data is read — required by Google Play's User Data policy.
+ */
+@Composable
+private fun AccessibilityDisclosureDialog(onDismiss: () -> Unit, onAgree: () -> Unit) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.accessibility_disclosure_title)) },
+        text = { Text(stringResource(R.string.accessibility_disclosure_body)) },
+        confirmButton = {
+            TextButton(onClick = onAgree) { Text(stringResource(R.string.accessibility_disclosure_agree)) }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text(stringResource(R.string.cancel)) }
+        }
+    )
 }
 
 @Composable

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/SettingsScreen.kt
@@ -134,6 +134,20 @@ private fun SettingsMainScreen(
     var showAppPicker by remember { mutableStateOf(false) }
     var showAccessibilityDisclosure by remember { mutableStateOf(false) }
 
+    // Track whether the accessibility service is actually enabled, refreshed on resume so the
+    // Context Mode warning and toggle behavior stay accurate after the user returns from settings.
+    var isAccessibilityEnabled by remember { mutableStateOf(isAccessibilityServiceEnabled(context)) }
+    val accessibilityLifecycleOwner = LocalLifecycleOwner.current
+    DisposableEffect(accessibilityLifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) {
+                isAccessibilityEnabled = isAccessibilityServiceEnabled(context)
+            }
+        }
+        accessibilityLifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { accessibilityLifecycleOwner.lifecycle.removeObserver(observer) }
+    }
+
     if (showAccessibilityDisclosure) {
         AccessibilityDisclosureDialog(
             onDismiss = { showAccessibilityDisclosure = false },
@@ -378,13 +392,28 @@ private fun SettingsMainScreen(
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                Text(stringResource(R.string.settings_context_mode), style = MaterialTheme.typography.bodyLarge)
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(stringResource(R.string.settings_context_mode), style = MaterialTheme.typography.bodyLarge)
+                    // Warn if Context Mode is on but the accessibility service isn't actually enabled,
+                    // so the user knows the feature won't work until they turn it on in settings.
+                    if (isContextMode && !isAccessibilityEnabled) {
+                        Text(
+                            stringResource(R.string.accessibility_service_disabled_warning),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.error
+                        )
+                    }
+                }
                 Switch(
                     checked = isContextMode,
                     onCheckedChange = { enable ->
-                        // Enabling Context Mode relies on the accessibility service, so show the
-                        // prominent disclosure + consent first; disabling needs no gate.
-                        if (enable) showAccessibilityDisclosure = true else viewModel.toggleContextMode()
+                        // Enabling relies on the accessibility service: if it's already enabled just
+                        // toggle; otherwise show the prominent disclosure + consent first. Disabling
+                        // needs no gate.
+                        if (enable) {
+                            if (isAccessibilityEnabled) viewModel.toggleContextMode()
+                            else showAccessibilityDisclosure = true
+                        } else viewModel.toggleContextMode()
                     }
                 )
             }
@@ -861,6 +890,18 @@ private fun PermissionsSection(context: android.content.Context) {
  * accessibility service. Explains what is accessed (foreground app, home/recents transitions), why,
  * and that no screen content / personal data is read — required by Google Play's User Data policy.
  */
+/** True if LogKitty's accessibility service is currently enabled in system settings. */
+private fun isAccessibilityServiceEnabled(context: android.content.Context): Boolean = runCatching {
+    val am = context.getSystemService(android.content.Context.ACCESSIBILITY_SERVICE)
+        as android.view.accessibility.AccessibilityManager
+    am.getEnabledAccessibilityServiceList(
+        android.accessibilityservice.AccessibilityServiceInfo.FEEDBACK_ALL_MASK
+    ).any {
+        it.resolveInfo.serviceInfo.packageName == context.packageName &&
+            it.resolveInfo.serviceInfo.name == com.hereliesaz.logkitty.services.LogKittyAccessibilityService::class.java.name
+    }
+}.getOrDefault(false)
+
 @Composable
 private fun AccessibilityDisclosureDialog(onDismiss: () -> Unit, onAgree: () -> Unit) {
     AlertDialog(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -46,6 +46,9 @@
     <string name="settings_buffer_size">Buffer Size</string>
     <string name="settings_buffer_lines">%1$d lines</string>
     <string name="settings_context_mode">Context Mode (Auto-Filter)</string>
+    <string name="accessibility_disclosure_title">Enable Context Mode</string>
+    <string name="accessibility_disclosure_body">Context Mode uses Android\'s Accessibility Service so LogKitty can detect which app is currently in the foreground and when you switch to Home or Recents. LogKitty uses this only to (1) automatically filter the log to the app you\'re using and (2) collapse the overlay when you leave an app.\n\nIt does not read screen contents, the text you type, passwords, or any personal data, and this information never leaves your device. To turn Context Mode on, you\'ll be taken to Accessibility settings to enable LogKitty.</string>
+    <string name="accessibility_disclosure_agree">Agree &amp; open settings</string>
     <string name="settings_root_access">Root Access</string>
     <string name="settings_reverse_log_order">Reverse Log Order</string>
     <string name="settings_section_app_monitoring">App Monitoring</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -49,6 +49,7 @@
     <string name="accessibility_disclosure_title">Enable Context Mode</string>
     <string name="accessibility_disclosure_body">Context Mode uses Android\'s Accessibility Service so LogKitty can detect which app is currently in the foreground and when you switch to Home or Recents. LogKitty uses this only to (1) automatically filter the log to the app you\'re using and (2) collapse the overlay when you leave an app.\n\nIt does not read screen contents, the text you type, passwords, or any personal data, and this information never leaves your device. To turn Context Mode on, you\'ll be taken to Accessibility settings to enable LogKitty.</string>
     <string name="accessibility_disclosure_agree">Agree &amp; open settings</string>
+    <string name="accessibility_service_disabled_warning">Accessibility service is off — Context Mode won\'t work until you enable it.</string>
     <string name="settings_root_access">Root Access</string>
     <string name="settings_reverse_log_order">Reverse Log Order</string>
     <string name="settings_section_app_monitoring">App Monitoring</string>


### PR DESCRIPTION
Adds an in-app **prominent disclosure + consent** popup before Context Mode is enabled, since that feature relies on the accessibility service (Google Play User Data policy requirement).

- Toggling **Context Mode (Auto-Filter)** ON now shows a dialog explaining: it uses the Accessibility Service to detect the foreground app and Home/Recents transitions; it's used only to auto-filter logs to the current app and collapse the overlay; and it does **not** read screen contents, typed text, passwords, or personal data, and nothing leaves the device.
- On **Agree**, the preference is enabled and the user is taken to Accessibility settings to turn the service on. **Cancel** leaves it off. Disabling needs no gate.

This is the in-app disclosure you can screen-record for the Play declaration. (`isAccessibilityTool` stays unset/false — LogKitty isn't an assistive tool; this disclosure is the compliance path.)

---
Generated by [Claude Code](https://claude.ai/code/session_017hRcXbYpxVLL1AhJi1t8Qk)

---
_Generated by [Claude Code](https://claude.ai/code/session_017hRcXbYpxVLL1AhJi1t8Qk)_

## Summary by Sourcery

Gate enabling of Context Mode behind an in-app accessibility disclosure and consent dialog required by Google Play policy.

New Features:
- Display a prominent disclosure dialog explaining Context Mode's use of the Accessibility Service before it can be enabled.

Enhancements:
- Update the Context Mode settings toggle to require user consent before enabling and deep-link users to Accessibility settings on agreement.
- Add localized strings describing the accessibility disclosure, including title, body, and confirmation action label.