### PR TITLE
Add app-ads.txt (AdMob authorized sellers)

### DIFF
--- a/app-ads.txt
+++ b/app-ads.txt
@@ -1,0 +1,1 @@
+google.com, pub-7304740804770627, DIRECT, f08c47fec0942fa0


### PR DESCRIPTION
Adds `app-ads.txt` at the repo root declaring the AdMob publisher account:

```
google.com, pub-7304740804770627, DIRECT, f08c47fec0942fa0
```

**Important — hosting:** per the [IAB app-ads.txt spec](https://support.google.com/admob/answer/9363762), AdMob's crawler only reads this file from the **root of the developer website** listed on your app's store/AdMob listing — e.g. `https://<your-domain>/app-ads.txt`. Having it in the repo doesn't verify anything by itself; you need to serve it from that domain (GitHub Pages on a custom domain, your site, etc.). Once it's reachable there, AdMob will mark the account "authorized" within a day or so.

(Filename is `app-ads.txt` — the exact name the spec requires.)

---
Generated by [Claude Code](https://claude.ai/code/session_017hRcXbYpxVLL1AhJi1t8Qk)

---
_Generated by [Claude Code](https://claude.ai/code/session_017hRcXbYpxVLL1AhJi1t8Qk)_

## Summary by Sourcery

New Features:
- Introduce an app-ads.txt file listing the authorized AdMob seller entry for AdMob.