### PR TITLE
Add per-app developer Stats view to the bottom sheet

### DIFF
--- a/app/src/main/kotlin/com/hereliesaz/logkitty/model/AppStats.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/model/AppStats.kt
@@ -1,0 +1,109 @@
+package com.hereliesaz.logkitty.model
+
+/**
+ * A single immutable snapshot of everything LogKitty could measure about one targeted app at one
+ * point in time. Every section is nullable: on a non-rooted device (or when a particular metric
+ * isn't exposed by the kernel/ROM) the section is simply `null` and the UI renders a graceful
+ * "unavailable" placeholder instead of a fake zero.
+ *
+ * Snapshots are produced by [com.hereliesaz.logkitty.utils.AppStatsCollector] and streamed to the
+ * UI by [com.hereliesaz.logkitty.ui.delegates.StatsDelegate].
+ */
+data class AppStats(
+    val packageName: String,
+    val label: String,
+    /** True when this snapshot was gathered through a root shell (full fidelity). */
+    val rootUsed: Boolean,
+    /** True when the process was found and at least the proc-based sections were populated. */
+    val processFound: Boolean,
+    /** Process ids backing the app (multi-process apps report several). */
+    val pids: List<Int>,
+    val collectedAtMs: Long,
+    val cpu: CpuStats? = null,
+    val memory: MemoryStats? = null,
+    val gpu: GpuStats? = null,
+    val network: NetworkStats? = null,
+    val power: PowerStats? = null,
+    val health: HealthStats? = null,
+    /** Human-readable caveats, e.g. "Root required for CPU, memory, GPU and I/O stats". */
+    val notes: List<String> = emptyList(),
+)
+
+/**
+ * CPU usage expressed as a percentage of the whole device's capacity (0..100, summed across all
+ * cores). The per-thread breakdown is the closest thing to "which library is taxing the device"
+ * that can be measured from outside the process — most libraries name their threads.
+ */
+data class CpuStats(
+    val appPercent: Float,
+    val userPercent: Float,
+    val kernelPercent: Float,
+    val numCores: Int,
+    val deviceBusyPercent: Float,
+    /** Top threads by CPU, descending. Each carries the library it most likely belongs to. */
+    val threads: List<ThreadCpu>,
+    val threadCount: Int,
+)
+
+data class ThreadCpu(
+    val tid: Int,
+    val name: String,
+    val percent: Float,
+    /** Best-effort library/subsystem the thread belongs to (e.g. "OkHttp", "ART GC"); null if unknown. */
+    val library: String?,
+)
+
+data class MemoryStats(
+    val totalPssKb: Long?,
+    val javaHeapKb: Long?,
+    val nativeHeapKb: Long?,
+    val graphicsKb: Long?,
+    val codeKb: Long?,
+    val stackKb: Long?,
+    val rssKb: Long?,
+    val deviceTotalRamKb: Long?,
+    val deviceAvailRamKb: Long?,
+)
+
+data class GpuStats(
+    val totalFrames: Long?,
+    val jankyFrames: Long?,
+    val jankPercent: Float?,
+    val p50Ms: Float?,
+    val p90Ms: Float?,
+    val p95Ms: Float?,
+    val p99Ms: Float?,
+    val missedVsync: Long?,
+    val slowUiThread: Long?,
+    val slowDrawCommands: Long?,
+    /** System-wide GPU busy %, device-specific (Adreno/KGSL). Not per-app. */
+    val gpuBusyPercent: Float?,
+)
+
+data class NetworkStats(
+    val rxBytesPerSec: Long?,
+    val txBytesPerSec: Long?,
+    val totalRxBytes: Long?,
+    val totalTxBytes: Long?,
+    val mobileBytes: Long?,
+    val wifiBytes: Long?,
+)
+
+data class PowerStats(
+    val wakelockCount: Int?,
+    val partialWakelockMs: Long?,
+    val jobsRegistered: Int?,
+    val alarmsRegistered: Int?,
+    val batteryLevelPercent: Int?,
+    val batteryTempC: Float?,
+    val charging: Boolean?,
+)
+
+data class HealthStats(
+    val threadCount: Int?,
+    val fdCount: Int?,
+    val ioReadBytesPerSec: Long?,
+    val ioWriteBytesPerSec: Long?,
+    val totalIoReadBytes: Long?,
+    val totalIoWriteBytes: Long?,
+)

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/LogBottomSheet.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/LogBottomSheet.kt
@@ -22,6 +22,8 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.ui.draw.clip
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Block
 import androidx.compose.material.icons.filled.Close
@@ -43,6 +45,7 @@ import androidx.compose.material3.TabRowDefaults.tabIndicatorOffset
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -117,6 +120,7 @@ fun LogBottomSheet(
     val isLogReversed by viewModel.isLogReversed.collectAsState()
     val tagColoringEnabled by viewModel.tagColoringEnabled.collectAsState()
     val isPaused by viewModel.isPaused.collectAsState()
+    val appStats by viewModel.appStats.collectAsState()
 
     val currentFontFamily = remember(fontFamilyName) {
         val enumVal = try { CodingFont.valueOf(fontFamilyName) } catch (e: Exception) { CodingFont.SYSTEM }
@@ -128,6 +132,20 @@ fun LogBottomSheet(
     val selectedLines = remember(selectedLineIds, indexedLog) {
         if (selectedLineIds.isEmpty()) emptyList()
         else indexedLog.filter { it.id in selectedLineIds }.sortedBy { it.id }
+    }
+
+    // Which app tabs are currently flipped from Logs to the developer-stats view. Tracked per tab id
+    // so each monitored app remembers its own Logs/Stats choice while the sheet is open.
+    var statsModeTabs by remember { mutableStateOf<Set<String>>(emptySet()) }
+    val statsActive = selectedTab.type == TabType.APP && selectedTab.id in statsModeTabs
+
+    // Drive the stats poller from the active selection: only collect while an app tab is showing its
+    // Stats view *and* the sheet is expanded, so it costs nothing when collapsed or showing logs.
+    val expanded = controller.detent == AzSheetDetent.HALF || controller.detent == AzSheetDetent.FULL
+    val collectStats = statsActive && expanded
+    LaunchedEffect(collectStats, selectedTab.id, selectedTab.filterValue) {
+        if (collectStats) viewModel.setStatsTarget(selectedTab.filterValue, selectedTab.title)
+        else viewModel.setStatsTarget(null)
     }
 
     when (controller.detent) {
@@ -166,6 +184,13 @@ fun LogBottomSheet(
             showTimestamp = showTimestamp,
             isLogReversed = isLogReversed,
             isPaused = isPaused,
+            showStatsToggle = selectedTab.type == TabType.APP,
+            statsActive = statsActive,
+            appStats = appStats,
+            onToggleStats = {
+                statsModeTabs = if (selectedTab.id in statsModeTabs) statsModeTabs - selectedTab.id
+                                else statsModeTabs + selectedTab.id
+            },
             selectedLineIds = selectedLineIds,
             selectedLines = selectedLines,
             onTapLine = { id ->
@@ -299,6 +324,10 @@ private fun ExpandedView(
     showTimestamp: Boolean,
     isLogReversed: Boolean,
     isPaused: Boolean,
+    showStatsToggle: Boolean,
+    statsActive: Boolean,
+    appStats: com.hereliesaz.logkitty.model.AppStats?,
+    onToggleStats: () -> Unit,
     selectedLineIds: Set<Long>,
     selectedLines: List<IndexedLogLine>,
     onTapLine: (Long) -> Unit,
@@ -369,6 +398,9 @@ private fun ExpandedView(
                 }
 
                 Row(verticalAlignment = Alignment.CenterVertically) {
+                    if (showStatsToggle) {
+                        LogsStatsToggle(statsActive = statsActive, onToggle = onToggleStats)
+                    }
                     IconButton(onClick = onSaveClick, modifier = Modifier.size(36.dp)) {
                         Icon(Icons.Default.Save, stringResource(R.string.cd_save), tint = MaterialTheme.colorScheme.onSurface)
                     }
@@ -394,8 +426,8 @@ private fun ExpandedView(
             HorizontalDivider(color = Color.White.copy(alpha = 0.08f))
         }
 
-        // --- Selection action bar (Copy / Search / Prohibit) ---
-        AnimatedVisibility(visible = selectedLineIds.isNotEmpty(), enter = fadeIn(), exit = fadeOut()) {
+        // --- Selection action bar (Copy / Search / Prohibit) — logs only ---
+        AnimatedVisibility(visible = !statsActive && selectedLineIds.isNotEmpty(), enter = fadeIn(), exit = fadeOut()) {
             val count = selectedLines.size
             Row(
                 modifier = Modifier
@@ -437,7 +469,14 @@ private fun ExpandedView(
                 .fillMaxWidth()
                 .pointerInputHorizontalDrag(threshold = 64f, onLeft = onSwipeLeft, onRight = onSwipeRight)
         ) {
-            if (indexedLog.isEmpty()) {
+            if (statsActive) {
+                StatsView(
+                    stats = appStats,
+                    fontFamily = fontFamily,
+                    fontSize = fontSize,
+                    modifier = Modifier.fillMaxSize(),
+                )
+            } else if (indexedLog.isEmpty()) {
                 Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
                     Text(stringResource(R.string.sheet_no_logs), color = Color.Gray)
                 }
@@ -528,6 +567,47 @@ private fun LogRow(
                 overflow = TextOverflow.Visible,
             )
         }
+    }
+}
+
+/**
+ * Compact two-segment pill that flips an app tab between its Logs and developer-Stats views.
+ * Shown only when an app-specific tab is selected.
+ */
+@Composable
+private fun LogsStatsToggle(statsActive: Boolean, onToggle: () -> Unit) {
+    val activeBg = MaterialTheme.colorScheme.primary.copy(alpha = 0.85f)
+    Row(
+        modifier = Modifier
+            .padding(end = 4.dp)
+            .clip(RoundedCornerShape(50))
+            .background(Color.White.copy(alpha = 0.08f))
+            .clickable(
+                indication = null,
+                interactionSource = remember { MutableInteractionSource() }
+            ) { onToggle() }
+            .padding(2.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Segment(stringResource(R.string.stats_toggle_logs), active = !statsActive, activeBg = activeBg)
+        Segment(stringResource(R.string.stats_toggle_stats), active = statsActive, activeBg = activeBg)
+    }
+}
+
+@Composable
+private fun Segment(label: String, active: Boolean, activeBg: Color) {
+    Box(
+        modifier = Modifier
+            .clip(RoundedCornerShape(50))
+            .background(if (active) activeBg else Color.Transparent)
+            .padding(horizontal = 10.dp, vertical = 3.dp)
+    ) {
+        Text(
+            label,
+            fontSize = 11.sp,
+            color = if (active) Color.White else Color.White.copy(alpha = 0.6f),
+            maxLines = 1,
+        )
     }
 }
 

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/LogBottomSheet.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/LogBottomSheet.kt
@@ -45,7 +45,7 @@ import androidx.compose.material3.TabRowDefaults.tabIndicatorOffset
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -143,9 +143,11 @@ fun LogBottomSheet(
     // Stats view *and* the sheet is expanded, so it costs nothing when collapsed or showing logs.
     val expanded = controller.detent == AzSheetDetent.HALF || controller.detent == AzSheetDetent.FULL
     val collectStats = statsActive && expanded
-    LaunchedEffect(collectStats, selectedTab.id, selectedTab.filterValue) {
+    // DisposableEffect (not LaunchedEffect) so onDispose always stops the poller — its job lives in
+    // viewModelScope, which outlives this composition, so a plain cancellation wouldn't halt it.
+    DisposableEffect(collectStats, selectedTab.id, selectedTab.filterValue) {
         if (collectStats) viewModel.setStatsTarget(selectedTab.filterValue, selectedTab.title)
-        else viewModel.setStatsTarget(null)
+        onDispose { viewModel.setStatsTarget(null) }
     }
 
     when (controller.detent) {

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/MainViewModel.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/MainViewModel.kt
@@ -12,6 +12,7 @@ import androidx.lifecycle.viewModelScope
 import com.hereliesaz.logkitty.services.LogKittyAccessibilityService
 import com.hereliesaz.logkitty.ui.delegates.IndexedLogLine
 import com.hereliesaz.logkitty.ui.delegates.StateDelegate
+import com.hereliesaz.logkitty.ui.delegates.StatsDelegate
 import com.hereliesaz.logkitty.ui.theme.CodingFont
 import com.hereliesaz.logkitty.utils.LogcatReader
 import com.hereliesaz.logkitty.utils.LogSourceClassifier
@@ -109,6 +110,26 @@ class MainViewModel(
 
     // Delegate to handle the heavy lifting of log buffering.
     val stateDelegate = StateDelegate(viewModelScope, bufferSizeFlow = userPreferences.bufferSize)
+
+    // Delegate that polls per-app developer stats (CPU, memory, GPU/frames, network, power) for the
+    // app currently shown in the Stats view. Idle until a target is set.
+    val statsDelegate = StatsDelegate(viewModelScope, application)
+    val appStats: StateFlow<com.hereliesaz.logkitty.model.AppStats?> = statsDelegate.stats
+
+    // The package currently displayed in the Stats view, so the poll can be re-targeted when the
+    // root toggle changes underneath it.
+    private var statsTargetPkg: String? = null
+    private var statsTargetLabel: String = ""
+
+    /**
+     * Points the developer-stats poller at [pkg] (or stops it when `null`). Safe to call repeatedly;
+     * the delegate ignores no-op re-targets.
+     */
+    fun setStatsTarget(pkg: String?, label: String = pkg ?: "") {
+        statsTargetPkg = pkg
+        statsTargetLabel = label
+        statsDelegate.setTarget(pkg, label, isRootEnabled.value)
+    }
 
     // --- State Flows ---
 
@@ -269,6 +290,14 @@ class MainViewModel(
             userPreferences.activeSourceFilters.collect { syncSourceTabs(it) }
         }
 
+        // If the user flips Root Access while the Stats view is open, re-target the poller so it
+        // switches between full and best-effort collection without the user reopening the view.
+        viewModelScope.launch {
+            isRootEnabled.collect { useRoot ->
+                statsTargetPkg?.let { statsDelegate.setTarget(it, statsTargetLabel, useRoot) }
+            }
+        }
+
         // Register the Accessibility Receiver
         val filter = IntentFilter(LogKittyAccessibilityService.ACTION_FOREGROUND_APP_CHANGED)
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
@@ -381,6 +410,7 @@ class MainViewModel(
 
     override fun onCleared() {
         super.onCleared()
+        statsDelegate.stop()
         try {
             getApplication<Application>().unregisterReceiver(receiver)
         } catch (e: Exception) {

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/StatsView.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/StatsView.kt
@@ -1,0 +1,336 @@
+package com.hereliesaz.logkitty.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.hereliesaz.logkitty.model.AppStats
+import com.hereliesaz.logkitty.model.CpuStats
+import com.hereliesaz.logkitty.model.GpuStats
+import com.hereliesaz.logkitty.model.HealthStats
+import com.hereliesaz.logkitty.model.MemoryStats
+import com.hereliesaz.logkitty.model.NetworkStats
+import com.hereliesaz.logkitty.model.PowerStats
+
+/**
+ * The developer-stats body shown when an app tab is toggled from Logs to Stats. Renders the live
+ * [AppStats] snapshot as a set of scrollable sections. Any unavailable section/metric shows a "—"
+ * placeholder rather than a misleading zero, and root/permission caveats appear as banners up top.
+ */
+@Composable
+fun StatsView(
+    stats: AppStats?,
+    fontFamily: FontFamily?,
+    fontSize: Int,
+    modifier: Modifier = Modifier,
+) {
+    if (stats == null) {
+        Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            Text("Collecting stats…", color = Color.Gray, fontSize = fontSize.sp, fontFamily = fontFamily)
+        }
+        return
+    }
+
+    val labelColor = Color.White.copy(alpha = 0.65f)
+    val valueColor = Color.White
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(horizontal = 12.dp, vertical = 8.dp),
+        verticalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        // Header: which app, and how the data was gathered.
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                stats.label,
+                color = valueColor,
+                fontSize = (fontSize + 2).sp,
+                fontWeight = FontWeight.Bold,
+                fontFamily = fontFamily,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.weight(1f),
+            )
+            val mode = when {
+                stats.rootUsed && stats.processFound -> "root • live"
+                stats.rootUsed -> "root"
+                else -> "best-effort"
+            }
+            Text(mode, color = labelColor, fontSize = (fontSize - 2).sp, fontFamily = fontFamily)
+        }
+        if (stats.pids.isNotEmpty()) {
+            Text(
+                "${stats.packageName}  ·  pid ${stats.pids.joinToString(", ")}",
+                color = labelColor, fontSize = (fontSize - 3).sp, fontFamily = fontFamily,
+                maxLines = 1, overflow = TextOverflow.Ellipsis,
+            )
+        }
+
+        stats.notes.forEach { note -> NoteBanner(note, fontFamily, fontSize) }
+
+        stats.cpu?.let { CpuSection(it, fontFamily, fontSize, labelColor, valueColor) }
+        stats.memory?.let { MemorySection(it, fontFamily, fontSize, labelColor, valueColor) }
+        stats.gpu?.let { GpuSection(it, fontFamily, fontSize, labelColor, valueColor) }
+        stats.network?.let { NetworkSection(it, fontFamily, fontSize, labelColor, valueColor) }
+        stats.power?.let { PowerSection(it, fontFamily, fontSize, labelColor, valueColor) }
+        stats.health?.let { HealthSection(it, fontFamily, fontSize, labelColor, valueColor) }
+
+        Spacer(Modifier.height(16.dp))
+    }
+}
+
+// ----------------------------------------------------------------------------------------------
+// Sections
+// ----------------------------------------------------------------------------------------------
+
+@Composable
+private fun CpuSection(cpu: CpuStats, ff: FontFamily?, fs: Int, lc: Color, vc: Color) {
+    StatCard("CPU", ff, fs) {
+        PercentBar("App CPU (of device)", cpu.appPercent, 100f, ff, fs, lc, vc)
+        StatRow("User / Kernel", "${pct(cpu.userPercent)} / ${pct(cpu.kernelPercent)}", ff, fs, lc, vc)
+        StatRow("Device busy", pct(cpu.deviceBusyPercent), ff, fs, lc, vc)
+        StatRow("Cores", cpu.numCores.toString(), ff, fs, lc, vc)
+        if (cpu.threads.isNotEmpty()) {
+            Spacer(Modifier.height(4.dp))
+            Text(
+                "Top threads — the library behind the load",
+                color = lc, fontSize = (fs - 2).sp, fontFamily = ff, fontWeight = FontWeight.Medium,
+            )
+            cpu.threads.forEach { t ->
+                Row(modifier = Modifier.fillMaxWidth().padding(top = 2.dp), verticalAlignment = Alignment.CenterVertically) {
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(t.name, color = vc, fontSize = (fs - 1).sp, fontFamily = ff,
+                            maxLines = 1, overflow = TextOverflow.Ellipsis)
+                        t.library?.let {
+                            Text(it, color = accentFor(it), fontSize = (fs - 3).sp, fontFamily = ff)
+                        }
+                    }
+                    Text(pct(t.percent), color = vc, fontSize = (fs - 1).sp, fontFamily = ff,
+                        fontWeight = FontWeight.Bold)
+                }
+            }
+        } else {
+            StatRow("Top threads", "sampling… (needs 2 reads)", ff, fs, lc, vc)
+        }
+    }
+}
+
+@Composable
+private fun MemorySection(m: MemoryStats, ff: FontFamily?, fs: Int, lc: Color, vc: Color) {
+    StatCard("Memory", ff, fs) {
+        StatRow("Total PSS", kb(m.totalPssKb), ff, fs, lc, vc, emphasize = true)
+        StatRow("Java heap", kb(m.javaHeapKb), ff, fs, lc, vc)
+        StatRow("Native heap", kb(m.nativeHeapKb), ff, fs, lc, vc)
+        StatRow("Graphics", kb(m.graphicsKb), ff, fs, lc, vc)
+        StatRow("Code", kb(m.codeKb), ff, fs, lc, vc)
+        StatRow("Stack", kb(m.stackKb), ff, fs, lc, vc)
+        StatRow("Total RSS", kb(m.rssKb), ff, fs, lc, vc)
+        if (m.deviceTotalRamKb != null) {
+            val used = m.deviceTotalRamKb - (m.deviceAvailRamKb ?: 0)
+            StatRow("Device RAM", "${kb(used)} / ${kb(m.deviceTotalRamKb)} used", ff, fs, lc, vc)
+        }
+    }
+}
+
+@Composable
+private fun GpuSection(g: GpuStats, ff: FontFamily?, fs: Int, lc: Color, vc: Color) {
+    StatCard("GPU & Frames", ff, fs) {
+        g.jankPercent?.let {
+            PercentBar("Janky frames", it, 100f, ff, fs, lc, vc, warnAbove = 5f, badAbove = 20f)
+        }
+        StatRow("Frames rendered", g.totalFrames?.toString() ?: "—", ff, fs, lc, vc)
+        StatRow("Janky frames", g.jankyFrames?.toString() ?: "—", ff, fs, lc, vc)
+        StatRow("50/90/95/99th", ms4(g.p50Ms, g.p90Ms, g.p95Ms, g.p99Ms), ff, fs, lc, vc)
+        StatRow("Missed vsync", g.missedVsync?.toString() ?: "—", ff, fs, lc, vc)
+        StatRow("Slow UI thread", g.slowUiThread?.toString() ?: "—", ff, fs, lc, vc)
+        StatRow("Slow draw cmds", g.slowDrawCommands?.toString() ?: "—", ff, fs, lc, vc)
+        g.gpuBusyPercent?.let { StatRow("GPU busy (device)", pct(it), ff, fs, lc, vc) }
+    }
+}
+
+@Composable
+private fun NetworkSection(n: NetworkStats, ff: FontFamily?, fs: Int, lc: Color, vc: Color) {
+    StatCard("Network", ff, fs) {
+        StatRow("Down / Up now", "${rate(n.rxBytesPerSec)} / ${rate(n.txBytesPerSec)}", ff, fs, lc, vc, emphasize = true)
+        StatRow("Received (24h)", bytes(n.totalRxBytes), ff, fs, lc, vc)
+        StatRow("Sent (24h)", bytes(n.totalTxBytes), ff, fs, lc, vc)
+        StatRow("Wi-Fi / Mobile", "${bytes(n.wifiBytes)} / ${bytes(n.mobileBytes)}", ff, fs, lc, vc)
+    }
+}
+
+@Composable
+private fun PowerSection(p: PowerStats, ff: FontFamily?, fs: Int, lc: Color, vc: Color) {
+    StatCard("Power & Scheduling", ff, fs) {
+        StatRow("Wakelocks held", p.wakelockCount?.toString() ?: "—", ff, fs, lc, vc)
+        StatRow("Partial wakelock time", p.partialWakelockMs?.let { ms(it) } ?: "—", ff, fs, lc, vc)
+        StatRow("Jobs registered", p.jobsRegistered?.toString() ?: "—", ff, fs, lc, vc)
+        StatRow("Alarms registered", p.alarmsRegistered?.toString() ?: "—", ff, fs, lc, vc)
+        val batt = p.batteryLevelPercent?.let { "$it%${if (p.charging == true) " ⚡" else ""}" } ?: "—"
+        StatRow("Battery", batt, ff, fs, lc, vc)
+        StatRow("Battery temp", p.batteryTempC?.let { "${"%.1f".format(it)}°C" } ?: "—", ff, fs, lc, vc)
+    }
+}
+
+@Composable
+private fun HealthSection(h: HealthStats, ff: FontFamily?, fs: Int, lc: Color, vc: Color) {
+    StatCard("Process Health", ff, fs) {
+        StatRow("Threads", h.threadCount?.toString() ?: "—", ff, fs, lc, vc)
+        StatRow("Open file descriptors", h.fdCount?.toString() ?: "—", ff, fs, lc, vc)
+        StatRow("Disk read / write now", "${rate(h.ioReadBytesPerSec)} / ${rate(h.ioWriteBytesPerSec)}", ff, fs, lc, vc, emphasize = true)
+        StatRow("Disk read total", bytes(h.totalIoReadBytes), ff, fs, lc, vc)
+        StatRow("Disk write total", bytes(h.totalIoWriteBytes), ff, fs, lc, vc)
+    }
+}
+
+// ----------------------------------------------------------------------------------------------
+// Reusable pieces
+// ----------------------------------------------------------------------------------------------
+
+@Composable
+private fun StatCard(title: String, ff: FontFamily?, fs: Int, content: @Composable () -> Unit) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(8.dp))
+            .background(Color.White.copy(alpha = 0.05f))
+            .padding(12.dp),
+        verticalArrangement = Arrangement.spacedBy(3.dp),
+    ) {
+        Text(title, color = Color.White, fontSize = (fs + 1).sp, fontWeight = FontWeight.Bold, fontFamily = ff)
+        Spacer(Modifier.height(2.dp))
+        content()
+    }
+}
+
+@Composable
+private fun StatRow(
+    label: String, value: String, ff: FontFamily?, fs: Int, lc: Color, vc: Color,
+    emphasize: Boolean = false,
+) {
+    Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+        Text(label, color = lc, fontSize = (fs - 1).sp, fontFamily = ff, modifier = Modifier.weight(1f),
+            maxLines = 1, overflow = TextOverflow.Ellipsis)
+        Text(value, color = vc, fontSize = (if (emphasize) fs + 1 else fs - 1).sp, fontFamily = ff,
+            fontWeight = if (emphasize) FontWeight.Bold else FontWeight.Normal)
+    }
+}
+
+@Composable
+private fun PercentBar(
+    label: String, value: Float, max: Float, ff: FontFamily?, fs: Int, lc: Color, vc: Color,
+    warnAbove: Float = 60f, badAbove: Float = 85f,
+) {
+    val fraction = (value / max).coerceIn(0f, 1f)
+    val barColor = when {
+        value >= badAbove -> Color(0xFFE53935)
+        value >= warnAbove -> Color(0xFFFFB300)
+        else -> Color(0xFF43A047)
+    }
+    Column(modifier = Modifier.fillMaxWidth().padding(vertical = 2.dp)) {
+        Row(modifier = Modifier.fillMaxWidth()) {
+            Text(label, color = lc, fontSize = (fs - 1).sp, fontFamily = ff, modifier = Modifier.weight(1f))
+            Text(pct(value), color = vc, fontSize = (fs - 1).sp, fontFamily = ff, fontWeight = FontWeight.Bold)
+        }
+        Spacer(Modifier.height(3.dp))
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(6.dp)
+                .clip(RoundedCornerShape(3.dp))
+                .background(Color.White.copy(alpha = 0.10f)),
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth(fraction)
+                    .height(6.dp)
+                    .clip(RoundedCornerShape(3.dp))
+                    .background(barColor),
+            )
+        }
+    }
+}
+
+@Composable
+private fun NoteBanner(note: String, ff: FontFamily?, fs: Int) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(6.dp))
+            .background(Color(0xFFFFB300).copy(alpha = 0.14f))
+            .padding(horizontal = 10.dp, vertical = 6.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text("⚠", color = Color(0xFFFFB300), fontSize = (fs).sp, fontFamily = ff)
+        Spacer(Modifier.width(8.dp))
+        Text(note, color = Color.White.copy(alpha = 0.85f), fontSize = (fs - 2).sp, fontFamily = ff)
+    }
+}
+
+// ----------------------------------------------------------------------------------------------
+// Formatting
+// ----------------------------------------------------------------------------------------------
+
+private fun pct(v: Float?): String = if (v == null) "—" else "${"%.1f".format(v)}%"
+
+private fun kb(v: Long?): String = if (v == null) "—" else bytes(v * 1024)
+
+private fun bytes(v: Long?): String {
+    if (v == null) return "—"
+    if (v < 1024) return "$v B"
+    val units = arrayOf("KB", "MB", "GB", "TB")
+    var size = v.toDouble() / 1024
+    var i = 0
+    while (size >= 1024 && i < units.size - 1) { size /= 1024; i++ }
+    return "${"%.1f".format(size)} ${units[i]}"
+}
+
+private fun rate(v: Long?): String = if (v == null) "—" else "${bytes(v)}/s"
+
+private fun ms(v: Long): String {
+    if (v < 1000) return "${v}ms"
+    val s = v / 1000
+    if (s < 60) return "${s}s"
+    val m = s / 60
+    if (m < 60) return "${m}m ${s % 60}s"
+    return "${m / 60}h ${m % 60}m"
+}
+
+private fun ms4(a: Float?, b: Float?, c: Float?, d: Float?): String {
+    if (a == null && b == null && c == null && d == null) return "—"
+    fun f(x: Float?) = x?.let { "${it.toInt()}" } ?: "—"
+    return "${f(a)}/${f(b)}/${f(c)}/${f(d)} ms"
+}
+
+/** Stable-ish accent color for a library label so the eye can group threads by library. */
+private fun accentFor(library: String): Color {
+    val palette = listOf(
+        Color(0xFF4FC3F7), Color(0xFF81C784), Color(0xFFFFB74D), Color(0xFFBA68C8),
+        Color(0xFF4DD0E1), Color(0xFFE57373), Color(0xFFA1887F), Color(0xFF90A4AE),
+    )
+    val idx = (library.hashCode() and 0x7FFFFFFF) % palette.size
+    return palette[idx]
+}

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/delegates/StatsDelegate.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/delegates/StatsDelegate.kt
@@ -1,0 +1,76 @@
+package com.hereliesaz.logkitty.ui.delegates
+
+import android.content.Context
+import com.hereliesaz.logkitty.model.AppStats
+import com.hereliesaz.logkitty.utils.AppStatsCollector
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+
+/**
+ * Owns the lifecycle of the developer-stats polling loop.
+ *
+ * The UI declares which app it currently wants stats for via [setTarget]; the delegate then polls
+ * [AppStatsCollector] on a fast cadence for the live metrics and a slower cadence for the heavy
+ * power/scheduling stats, publishing merged snapshots on [stats]. Polling only runs while a target
+ * is set, so it costs nothing when the Stats view is closed.
+ */
+class StatsDelegate(
+    private val scope: CoroutineScope,
+    context: Context,
+) {
+    private val appContext = context.applicationContext
+
+    private val _stats = MutableStateFlow<AppStats?>(null)
+    val stats: StateFlow<AppStats?> = _stats.asStateFlow()
+
+    private var pollJob: Job? = null
+    private var currentTarget: String? = null
+
+    /**
+     * Begins (or redirects) polling for [pkg]. Passing the same package again is a no-op so the loop
+     * isn't restarted on every recomposition. Passing `null` stops polling and clears the snapshot.
+     */
+    fun setTarget(pkg: String?, label: String, useRoot: Boolean) {
+        val key = pkg?.let { "$it|$useRoot" }
+        if (key == currentTarget) return
+        currentTarget = key
+        pollJob?.cancel()
+        _stats.value = null
+        if (pkg == null) return
+
+        pollJob = scope.launch(Dispatchers.IO) {
+            val collector = AppStatsCollector(appContext)
+            var cachedPower = collector.collectPower(pkg, useRoot)
+            var iteration = 0
+            while (isActive) {
+                val snapshot = collector.collect(pkg, label, useRoot)
+                if (iteration % POWER_REFRESH_EVERY == 0 && iteration != 0) {
+                    cachedPower = collector.collectPower(pkg, useRoot)
+                }
+                _stats.value = snapshot.copy(power = cachedPower)
+                iteration++
+                delay(FAST_INTERVAL_MS)
+            }
+        }
+    }
+
+    fun stop() {
+        pollJob?.cancel()
+        pollJob = null
+        currentTarget = null
+        _stats.value = null
+    }
+
+    companion object {
+        private const val FAST_INTERVAL_MS = 2000L
+        // Power/scheduling stats refresh every Nth fast poll (here ~10s).
+        private const val POWER_REFRESH_EVERY = 5
+    }
+}

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/utils/AppStatsCollector.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/utils/AppStatsCollector.kt
@@ -420,16 +420,17 @@ class AppStatsCollector(private val context: Context) {
     ): Pair<Long, Long>? {
         return try {
             @Suppress("DEPRECATION")
-            val stats = nsm.queryDetailsForUid(networkType, null, start, end, uid)
+            val stats = nsm.queryDetailsForUid(networkType, null, start, end, uid) ?: return null
             var rx = 0L
             var tx = 0L
             val bucket = android.app.usage.NetworkStats.Bucket()
-            while (stats.hasNextBucket()) {
-                stats.getNextBucket(bucket)
-                rx += bucket.rxBytes
-                tx += bucket.txBytes
+            stats.use { s ->
+                while (s.hasNextBucket()) {
+                    s.getNextBucket(bucket)
+                    rx += bucket.rxBytes
+                    tx += bucket.txBytes
+                }
             }
-            stats.close()
             rx to tx
         } catch (e: Exception) {
             null
@@ -469,7 +470,7 @@ class AppStatsCollector(private val context: Context) {
         // batterystats prints partial wake locks as e.g. "Wake lock NAME: 1m 23s 456ms partial".
         var total = 0L
         var matched = false
-        for (m in Regex("""(?:(\d+)h)?\s*(?:(\d+)m)?\s*(?:(\d+)s)?\s*(?:(\d+)ms)?\s+partial""").findAll(bs)) {
+        for (m in Regex("""Wake lock\s+[^:]+:\s*(?:(\d+)h)?\s*(?:(\d+)m)?\s*(?:(\d+)s)?\s*(?:(\d+)ms)?\s+partial""").findAll(bs)) {
             val h = m.groupValues[1].toLongOrNull() ?: 0
             val min = m.groupValues[2].toLongOrNull() ?: 0
             val s = m.groupValues[3].toLongOrNull() ?: 0

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/utils/AppStatsCollector.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/utils/AppStatsCollector.kt
@@ -1,0 +1,486 @@
+package com.hereliesaz.logkitty.utils
+
+import android.app.usage.NetworkStatsManager
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.net.ConnectivityManager
+import android.os.BatteryManager
+import com.hereliesaz.logkitty.model.AppStats
+import com.hereliesaz.logkitty.model.CpuStats
+import com.hereliesaz.logkitty.model.GpuStats
+import com.hereliesaz.logkitty.model.HealthStats
+import com.hereliesaz.logkitty.model.MemoryStats
+import com.hereliesaz.logkitty.model.NetworkStats
+import com.hereliesaz.logkitty.model.PowerStats
+import com.hereliesaz.logkitty.model.ThreadCpu
+
+/**
+ * Gathers a full [AppStats] snapshot for one targeted package.
+ *
+ * **Design**
+ * - A single root shell script (see [buildBatchScript]) collects everything proc/dumpsys-based in
+ *   one `su` invocation per poll, to keep overhead low even while polling every couple of seconds.
+ * - Network comes from [NetworkStatsManager] (public API, needs the "Usage access" permission) so it
+ *   works even without root.
+ * - Battery level/temperature come from the sticky `ACTION_BATTERY_CHANGED` intent (no permission).
+ * - Rate metrics (CPU %, I/O B/s, network B/s) require two samples, so the collector remembers the
+ *   previous reading. Call [reset] whenever the target package changes so stale deltas are dropped.
+ *
+ * The collector is **stateful and single-target**: hold one instance per active stats view.
+ */
+class AppStatsCollector(private val context: Context) {
+
+    private var lastPackage: String? = null
+
+    // --- Previous-sample state for delta/rate computation ---
+    private var prevTotalJiffies = 0L
+    private var prevIdleJiffies = 0L
+    private var prevUtime = 0L
+    private var prevStime = 0L
+    private var prevThreadJiffies = HashMap<Int, Long>()
+    private var prevIoRead = -1L
+    private var prevIoWrite = -1L
+    private var prevNetRx = -1L
+    private var prevNetTx = -1L
+    private var prevSampleNanos = 0L
+
+    private val numCores = Runtime.getRuntime().availableProcessors().coerceAtLeast(1)
+
+    /** Drops remembered deltas so the next snapshot starts a fresh rate baseline. */
+    fun reset() {
+        lastPackage = null
+        prevTotalJiffies = 0L
+        prevIdleJiffies = 0L
+        prevUtime = 0L
+        prevStime = 0L
+        prevThreadJiffies = HashMap()
+        prevIoRead = -1L
+        prevIoWrite = -1L
+        prevNetRx = -1L
+        prevNetTx = -1L
+        prevSampleNanos = 0L
+    }
+
+    /**
+     * Collects the fast-changing sections (CPU, memory, GPU/frames, I/O, network). Power stats are
+     * gathered separately via [collectPower] on a slower cadence because `dumpsys batterystats` is
+     * heavy.
+     */
+    suspend fun collect(pkg: String, label: String, useRoot: Boolean): AppStats {
+        if (pkg != lastPackage) {
+            reset()
+            lastPackage = pkg
+        }
+        val now = System.currentTimeMillis()
+        val nowNanos = System.nanoTime()
+        val dtSec = if (prevSampleNanos > 0) (nowNanos - prevSampleNanos) / 1e9 else 0.0
+        val notes = mutableListOf<String>()
+
+        // Network and battery work without root; gather them first so a non-rooted device still
+        // shows something useful.
+        val network = collectNetwork(pkg, dtSec, notes)
+
+        if (!useRoot) {
+            notes.add("Root is off — CPU, memory, GPU and I/O need root. Network is from Usage Access.")
+            prevSampleNanos = nowNanos
+            return AppStats(
+                packageName = pkg, label = label, rootUsed = false, processFound = false,
+                pids = emptyList(), collectedAtMs = now, network = network, notes = notes,
+            )
+        }
+
+        val raw = RootShell.run(buildBatchScript(pkg), useRoot = true, timeoutMs = 5000)
+        if (raw == null) {
+            notes.add("Root shell unavailable — falling back to network-only stats.")
+            prevSampleNanos = nowNanos
+            return AppStats(
+                packageName = pkg, label = label, rootUsed = false, processFound = false,
+                pids = emptyList(), collectedAtMs = now, network = network, notes = notes,
+            )
+        }
+
+        val sections = splitSections(raw)
+        val pids = parsePids(sections["PIDS"])
+        if (pids.isEmpty()) {
+            notes.add("$label isn't running right now — start it to see CPU, memory and frame stats.")
+            prevSampleNanos = nowNanos
+            return AppStats(
+                packageName = pkg, label = label, rootUsed = true, processFound = false,
+                pids = emptyList(), collectedAtMs = now, network = network, notes = notes,
+            )
+        }
+
+        val cpu = parseCpu(sections, pids)
+        val memory = parseMemory(sections["MEMINFO"])
+        val gpu = parseGpu(sections)
+        val health = parseHealth(sections, pids, dtSec)
+
+        prevSampleNanos = nowNanos
+        return AppStats(
+            packageName = pkg, label = label, rootUsed = true, processFound = true,
+            pids = pids, collectedAtMs = now, cpu = cpu, memory = memory, gpu = gpu,
+            network = network, health = health, notes = notes,
+        )
+    }
+
+    /** Heavier, slower-changing power/scheduling stats. Safe to call less frequently. */
+    suspend fun collectPower(pkg: String, useRoot: Boolean): PowerStats {
+        val (level, temp, charging) = readBattery()
+        if (!useRoot) {
+            return PowerStats(null, null, null, null, level, temp, charging)
+        }
+        val raw = RootShell.run(buildPowerScript(pkg), useRoot = true, timeoutMs = 6000)
+        val sections = if (raw != null) splitSections(raw) else emptyMap()
+        val bs = sections["BATTERYSTATS"].orEmpty()
+        val wakelockCount = Regex("Wake lock", RegexOption.IGNORE_CASE).findAll(bs).count().takeIf { it > 0 }
+        val partialMs = parsePartialWakelockMs(bs)
+        val jobs = sections["JOBS"]?.trim()?.toIntOrNull()?.takeIf { it >= 0 }
+        val alarms = sections["ALARMS"]?.trim()?.toIntOrNull()?.takeIf { it >= 0 }
+        return PowerStats(wakelockCount, partialMs, jobs, alarms, level, temp, charging)
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Shell scripts
+    // ---------------------------------------------------------------------------------------------
+
+    private fun buildBatchScript(pkg: String): String {
+        val p = shellEscape(pkg)
+        return """
+            PIDS=${'$'}(pidof $p 2>/dev/null)
+            if [ -z "${'$'}PIDS" ]; then PIDS=${'$'}(pgrep -f $p 2>/dev/null); fi
+            echo "@@PIDS@@"; echo "${'$'}PIDS"
+            echo "@@CPU@@"; head -n 1 /proc/stat 2>/dev/null
+            echo "@@GPUPCT@@"; cat /sys/class/kgsl/kgsl-3d0/gpu_busy_percentage 2>/dev/null
+            echo "@@GPUBUSY@@"; cat /sys/class/kgsl/kgsl-3d0/gpubusy 2>/dev/null
+            for pp in ${'$'}PIDS; do
+              echo "@@PSTAT ${'$'}pp@@"; cat /proc/${'$'}pp/stat 2>/dev/null
+              echo "@@PSTATUS ${'$'}pp@@"; cat /proc/${'$'}pp/status 2>/dev/null
+              echo "@@PIO ${'$'}pp@@"; cat /proc/${'$'}pp/io 2>/dev/null
+              echo "@@PFD ${'$'}pp@@"; ls /proc/${'$'}pp/fd 2>/dev/null | wc -l
+              echo "@@PTASKS ${'$'}pp@@"; cat /proc/${'$'}pp/task/*/stat 2>/dev/null
+            done
+            echo "@@MEMINFO@@"; dumpsys meminfo $p 2>/dev/null
+            echo "@@GFXINFO@@"; dumpsys gfxinfo $p 2>/dev/null
+            echo "@@END@@"
+        """.trimIndent()
+    }
+
+    private fun buildPowerScript(pkg: String): String {
+        val p = shellEscape(pkg)
+        return """
+            echo "@@BATTERYSTATS@@"; dumpsys batterystats $p 2>/dev/null
+            echo "@@JOBS@@"; dumpsys jobscheduler 2>/dev/null | grep -c $p
+            echo "@@ALARMS@@"; dumpsys alarm 2>/dev/null | grep -c $p
+            echo "@@END@@"
+        """.trimIndent()
+    }
+
+    /** Wraps a package name in single quotes, neutralizing any embedded quote, for safe shell use. */
+    private fun shellEscape(s: String): String = "'" + s.replace("'", "'\\''") + "'"
+
+    // ---------------------------------------------------------------------------------------------
+    // Output parsing
+    // ---------------------------------------------------------------------------------------------
+
+    /** Splits the marker-delimited batch output into a map keyed by the marker (e.g. "PSTAT 1234"). */
+    private fun splitSections(raw: String): Map<String, String> {
+        val result = LinkedHashMap<String, String>()
+        var key: String? = null
+        val buf = StringBuilder()
+        for (line in raw.lineSequence()) {
+            val m = MARKER.matchEntire(line.trim())
+            if (m != null) {
+                if (key != null) result[key!!] = buf.toString().trim()
+                key = m.groupValues[1]
+                buf.setLength(0)
+            } else if (key != null) {
+                buf.append(line).append('\n')
+            }
+        }
+        if (key != null) result[key!!] = buf.toString().trim()
+        return result
+    }
+
+    private fun parsePids(s: String?): List<Int> =
+        s?.trim()?.split(Regex("\\s+"))?.mapNotNull { it.toIntOrNull() }?.distinct() ?: emptyList()
+
+    private fun parseCpu(sections: Map<String, String>, pids: List<Int>): CpuStats? {
+        val cpuLine = sections["CPU"]?.trim() ?: return null
+        val nums = cpuLine.removePrefix("cpu").trim().split(Regex("\\s+")).mapNotNull { it.toLongOrNull() }
+        if (nums.size < 4) return null
+        val total = nums.sum()
+        val idle = nums[3] + (nums.getOrNull(4) ?: 0L) // idle + iowait
+
+        var utime = 0L
+        var stime = 0L
+        for (pid in pids) {
+            val stat = sections["PSTAT $pid"] ?: continue
+            val (u, s) = parseStatCpu(stat) ?: continue
+            utime += u
+            stime += s
+        }
+
+        // Per-thread CPU (utime+stime), with library attribution from the thread name.
+        val threadCur = HashMap<Int, Long>()
+        val threadNames = HashMap<Int, String>()
+        for (pid in pids) {
+            val tasks = sections["PTASKS $pid"] ?: continue
+            for (line in tasks.lineSequence()) {
+                if (line.isBlank()) continue
+                val tid = line.trim().substringBefore(' ').toIntOrNull() ?: continue
+                val cpu = parseStatCpu(line) ?: continue
+                threadCur[tid] = cpu.first + cpu.second
+                threadNames[tid] = parseStatComm(line) ?: "tid $tid"
+            }
+        }
+
+        val deltaTotal = total - prevTotalJiffies
+        val haveBaseline = prevTotalJiffies > 0L && deltaTotal > 0L
+        val appPercent: Float
+        val userPercent: Float
+        val kernelPercent: Float
+        val deviceBusy: Float
+        val threads: List<ThreadCpu>
+        if (haveBaseline) {
+            val dt = deltaTotal.toFloat()
+            userPercent = 100f * (utime - prevUtime).coerceAtLeast(0) / dt
+            kernelPercent = 100f * (stime - prevStime).coerceAtLeast(0) / dt
+            appPercent = userPercent + kernelPercent
+            deviceBusy = 100f * (deltaTotal - (idle - prevIdleJiffies)).coerceAtLeast(0) / dt
+            threads = threadCur.mapNotNull { (tid, cur) ->
+                val prev = prevThreadJiffies[tid] ?: return@mapNotNull null
+                val pct = 100f * (cur - prev).coerceAtLeast(0) / dt
+                if (pct <= 0.05f) null
+                else ThreadCpu(tid, threadNames[tid] ?: "tid $tid", pct,
+                    LibraryAttribution.forThread(threadNames[tid] ?: ""))
+            }.sortedByDescending { it.percent }.take(12)
+        } else {
+            appPercent = 0f; userPercent = 0f; kernelPercent = 0f; deviceBusy = 0f; threads = emptyList()
+        }
+
+        prevTotalJiffies = total
+        prevIdleJiffies = idle
+        prevUtime = utime
+        prevStime = stime
+        prevThreadJiffies = threadCur
+
+        return CpuStats(appPercent, userPercent, kernelPercent, numCores, deviceBusy, threads, threadCur.size)
+    }
+
+    /** Returns (utime, stime) jiffies from a `/proc/.../stat` line, handling spaces in the comm field. */
+    private fun parseStatCpu(stat: String): Pair<Long, Long>? {
+        val close = stat.lastIndexOf(')')
+        if (close < 0) return null
+        val after = stat.substring(close + 1).trim().split(Regex("\\s+"))
+        // Fields after comm start at field 3 (state). utime = field 14 -> index 11; stime = 15 -> 12.
+        val u = after.getOrNull(11)?.toLongOrNull() ?: return null
+        val s = after.getOrNull(12)?.toLongOrNull() ?: return null
+        return u to s
+    }
+
+    /** Extracts the `comm` (thread/process name) from a `/proc/.../stat` line. */
+    private fun parseStatComm(stat: String): String? {
+        val open = stat.indexOf('(')
+        val close = stat.lastIndexOf(')')
+        if (open < 0 || close <= open) return null
+        return stat.substring(open + 1, close)
+    }
+
+    private fun parseMemory(meminfo: String?): MemoryStats? {
+        if (meminfo.isNullOrBlank()) return null
+        fun field(label: String): Long? =
+            Regex("""$label:\s+(\d+)""").find(meminfo)?.groupValues?.get(1)?.toLongOrNull()
+        val total = field("TOTAL PSS") ?: Regex("""TOTAL\s+(\d+)""").find(meminfo)?.groupValues?.get(1)?.toLongOrNull()
+        val (totalRam, availRam) = readDeviceRam()
+        return MemoryStats(
+            totalPssKb = total,
+            javaHeapKb = field("Java Heap"),
+            nativeHeapKb = field("Native Heap"),
+            graphicsKb = field("Graphics"),
+            codeKb = field("Code"),
+            stackKb = field("Stack"),
+            rssKb = field("TOTAL RSS"),
+            deviceTotalRamKb = totalRam,
+            deviceAvailRamKb = availRam,
+        )
+    }
+
+    private fun parseGpu(sections: Map<String, String>): GpuStats? {
+        val gfx = sections["GFXINFO"]
+        var busyPct: Float? = sections["GPUPCT"]?.let { Regex("""(\d+)""").find(it)?.groupValues?.get(1)?.toFloatOrNull() }
+        if (busyPct == null) {
+            sections["GPUBUSY"]?.trim()?.split(Regex("\\s+"))?.let { parts ->
+                val busy = parts.getOrNull(0)?.toFloatOrNull()
+                val tot = parts.getOrNull(1)?.toFloatOrNull()
+                if (busy != null && tot != null && tot > 0f) busyPct = 100f * busy / tot
+            }
+        }
+        if (gfx.isNullOrBlank() && busyPct == null) return null
+
+        fun longOf(re: String): Long? = gfx?.let { Regex(re).find(it)?.groupValues?.get(1)?.toLongOrNull() }
+        fun floatOf(re: String): Float? = gfx?.let { Regex(re).find(it)?.groupValues?.get(1)?.toFloatOrNull() }
+        return GpuStats(
+            totalFrames = longOf("""Total frames rendered:\s*(\d+)"""),
+            jankyFrames = longOf("""Janky frames:\s*(\d+)"""),
+            jankPercent = floatOf("""Janky frames:\s*\d+\s*\(([\d.]+)%\)"""),
+            p50Ms = floatOf("""50th percentile:\s*(\d+)ms"""),
+            p90Ms = floatOf("""90th percentile:\s*(\d+)ms"""),
+            p95Ms = floatOf("""95th percentile:\s*(\d+)ms"""),
+            p99Ms = floatOf("""99th percentile:\s*(\d+)ms"""),
+            missedVsync = longOf("""Number Missed Vsync:\s*(\d+)"""),
+            slowUiThread = longOf("""Number Slow UI thread:\s*(\d+)"""),
+            slowDrawCommands = longOf("""Number Slow issue draw commands:\s*(\d+)"""),
+            gpuBusyPercent = busyPct,
+        )
+    }
+
+    private fun parseHealth(sections: Map<String, String>, pids: List<Int>, dtSec: Double): HealthStats {
+        var threads = 0
+        var fds = 0
+        var ioRead = 0L
+        var ioWrite = 0L
+        var sawIo = false
+        for (pid in pids) {
+            sections["PSTATUS $pid"]?.let { st ->
+                Regex("""Threads:\s+(\d+)""").find(st)?.groupValues?.get(1)?.toIntOrNull()?.let { threads += it }
+            }
+            sections["PFD $pid"]?.trim()?.toIntOrNull()?.let { fds += it }
+            sections["PIO $pid"]?.let { io ->
+                Regex("""read_bytes:\s+(\d+)""").find(io)?.groupValues?.get(1)?.toLongOrNull()?.let { ioRead += it; sawIo = true }
+                Regex("""write_bytes:\s+(\d+)""").find(io)?.groupValues?.get(1)?.toLongOrNull()?.let { ioWrite += it }
+            }
+        }
+        var readRate: Long? = null
+        var writeRate: Long? = null
+        if (sawIo) {
+            if (prevIoRead >= 0 && dtSec > 0) {
+                readRate = ((ioRead - prevIoRead).coerceAtLeast(0) / dtSec).toLong()
+                writeRate = ((ioWrite - prevIoWrite).coerceAtLeast(0) / dtSec).toLong()
+            }
+            prevIoRead = ioRead
+            prevIoWrite = ioWrite
+        }
+        return HealthStats(
+            threadCount = threads.takeIf { it > 0 },
+            fdCount = fds.takeIf { it > 0 },
+            ioReadBytesPerSec = readRate,
+            ioWriteBytesPerSec = writeRate,
+            totalIoReadBytes = if (sawIo) ioRead else null,
+            totalIoWriteBytes = if (sawIo) ioWrite else null,
+        )
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Public-API / no-root sources
+    // ---------------------------------------------------------------------------------------------
+
+    @Suppress("DEPRECATION") // ConnectivityManager.TYPE_* + queryDetailsForUid remain the per-UID path.
+    private fun collectNetwork(pkg: String, dtSec: Double, notes: MutableList<String>): NetworkStats? {
+        val uid = try {
+            context.packageManager.getApplicationInfo(pkg, 0).uid
+        } catch (e: Exception) { return null }
+
+        val nsm = context.getSystemService(Context.NETWORK_STATS_SERVICE) as? NetworkStatsManager ?: return null
+        val end = System.currentTimeMillis()
+        // A wide window so cumulative totals are stable; the per-poll delta gives the live rate.
+        val start = end - 24L * 60 * 60 * 1000
+
+        val wifi = queryUidBytes(nsm, ConnectivityManager.TYPE_WIFI, start, end, uid)
+        val mobile = queryUidBytes(nsm, ConnectivityManager.TYPE_MOBILE, start, end, uid)
+        if (wifi == null && mobile == null) {
+            notes.add("Network stats need the Usage Access permission (Settings → Special access).")
+            return null
+        }
+        val rx = (wifi?.first ?: 0L) + (mobile?.first ?: 0L)
+        val tx = (wifi?.second ?: 0L) + (mobile?.second ?: 0L)
+
+        var rxRate: Long? = null
+        var txRate: Long? = null
+        if (prevNetRx >= 0 && dtSec > 0) {
+            rxRate = ((rx - prevNetRx).coerceAtLeast(0) / dtSec).toLong()
+            txRate = ((tx - prevNetTx).coerceAtLeast(0) / dtSec).toLong()
+        }
+        prevNetRx = rx
+        prevNetTx = tx
+
+        return NetworkStats(
+            rxBytesPerSec = rxRate,
+            txBytesPerSec = txRate,
+            totalRxBytes = rx,
+            totalTxBytes = tx,
+            mobileBytes = mobile?.let { it.first + it.second },
+            wifiBytes = wifi?.let { it.first + it.second },
+        )
+    }
+
+    /** Returns (rxBytes, txBytes) for [uid] over the window, or null if the query is denied/unsupported. */
+    private fun queryUidBytes(
+        nsm: NetworkStatsManager, networkType: Int, start: Long, end: Long, uid: Int,
+    ): Pair<Long, Long>? {
+        return try {
+            @Suppress("DEPRECATION")
+            val stats = nsm.queryDetailsForUid(networkType, null, start, end, uid)
+            var rx = 0L
+            var tx = 0L
+            val bucket = android.app.usage.NetworkStats.Bucket()
+            while (stats.hasNextBucket()) {
+                stats.getNextBucket(bucket)
+                rx += bucket.rxBytes
+                tx += bucket.txBytes
+            }
+            stats.close()
+            rx to tx
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    private fun readBattery(): Triple<Int?, Float?, Boolean?> {
+        return try {
+            val intent = context.registerReceiver(null, IntentFilter(Intent.ACTION_BATTERY_CHANGED))
+                ?: return Triple(null, null, null)
+            val level = intent.getIntExtra(BatteryManager.EXTRA_LEVEL, -1)
+            val scale = intent.getIntExtra(BatteryManager.EXTRA_SCALE, -1)
+            val pct = if (level >= 0 && scale > 0) (level * 100 / scale) else null
+            val tempTenths = intent.getIntExtra(BatteryManager.EXTRA_TEMPERATURE, Int.MIN_VALUE)
+            val temp = if (tempTenths != Int.MIN_VALUE) tempTenths / 10f else null
+            val status = intent.getIntExtra(BatteryManager.EXTRA_STATUS, -1)
+            val charging = status == BatteryManager.BATTERY_STATUS_CHARGING ||
+                status == BatteryManager.BATTERY_STATUS_FULL
+            Triple(pct, temp, charging)
+        } catch (e: Exception) {
+            Triple(null, null, null)
+        }
+    }
+
+    private fun readDeviceRam(): Pair<Long?, Long?> {
+        return try {
+            val am = context.getSystemService(Context.ACTIVITY_SERVICE) as android.app.ActivityManager
+            val mi = android.app.ActivityManager.MemoryInfo()
+            am.getMemoryInfo(mi)
+            (mi.totalMem / 1024) to (mi.availMem / 1024)
+        } catch (e: Exception) {
+            null to null
+        }
+    }
+
+    private fun parsePartialWakelockMs(bs: String): Long? {
+        // batterystats prints partial wake locks as e.g. "Wake lock NAME: 1m 23s 456ms partial".
+        var total = 0L
+        var matched = false
+        for (m in Regex("""(?:(\d+)h)?\s*(?:(\d+)m)?\s*(?:(\d+)s)?\s*(?:(\d+)ms)?\s+partial""").findAll(bs)) {
+            val h = m.groupValues[1].toLongOrNull() ?: 0
+            val min = m.groupValues[2].toLongOrNull() ?: 0
+            val s = m.groupValues[3].toLongOrNull() ?: 0
+            val ms = m.groupValues[4].toLongOrNull() ?: 0
+            val sum = ((h * 60 + min) * 60 + s) * 1000 + ms
+            if (sum > 0) { total += sum; matched = true }
+        }
+        return if (matched) total else null
+    }
+
+    companion object {
+        private val MARKER = Regex("""@@([A-Z]+(?: \d+)?)@@""")
+    }
+}

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/utils/LibraryAttribution.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/utils/LibraryAttribution.kt
@@ -1,0 +1,87 @@
+package com.hereliesaz.logkitty.utils
+
+/**
+ * Maps a Linux thread name (`comm`, max 15 chars) to the library or subsystem it most likely
+ * belongs to.
+ *
+ * You cannot attribute CPU to a specific library *inside another app's process* from the outside —
+ * that needs in-process profiling hooks. But almost every library names its worker threads, so a
+ * per-thread CPU table effectively shows which library is doing the work. This is the realistic,
+ * honest version of "broken down by library": an informed guess from the thread name, good enough
+ * to point a developer at the culprit.
+ */
+object LibraryAttribution {
+
+    // Ordered: more specific matches first. Each entry is (substring-to-match, friendly-label).
+    // Matching is case-insensitive and substring-based because `comm` is truncated to 15 chars.
+    private val RULES: List<Pair<String, String>> = listOf(
+        "okhttp" to "OkHttp",
+        "okio" to "Okio",
+        "firebase" to "Firebase",
+        "firestore" to "Firebase",
+        "crashlytics" to "Crashlytics",
+        "grpc" to "gRPC",
+        "glide" to "Glide",
+        "coil" to "Coil",
+        "picasso" to "Picasso",
+        "exoplayer" to "ExoPlayer / Media3",
+        "exo" to "ExoPlayer / Media3",
+        "rxcomputation" to "RxJava",
+        "rxcachedthread" to "RxJava",
+        "rxnewthread" to "RxJava",
+        "rxio" to "RxJava",
+        "rxschedule" to "RxJava",
+        "defaultdispatch" to "Coroutines",
+        "kotlinx.coroutin" to "Coroutines",
+        "renderthread" to "HWUI / RenderThread",
+        "hwuitask" to "HWUI",
+        "rendereng" to "RenderEngine",
+        "glthread" to "OpenGL",
+        "crrenderermain" to "WebView / Chromium",
+        "chromium" to "WebView / Chromium",
+        "chrome" to "WebView / Chromium",
+        "cronet" to "Cronet",
+        "googleapihandl" to "Play Services",
+        "gmsdynamite" to "Play Services",
+        "gms" to "Play Services",
+        "finalizerdaemon" to "ART GC",
+        "referencequeue" to "ART GC",
+        "heaptaskdaemon" to "ART GC",
+        "finalizerwatch" to "ART GC",
+        "hwbinder" to "HW Binder IPC",
+        "binder:" to "Binder IPC",
+        "jit thread pool" to "ART JIT",
+        "profile saver" to "ART Profile",
+        "queued-work-loo" to "SharedPreferences",
+        "asynctask" to "AsyncTask",
+        "pool-" to "Thread pool",
+        "workmanager" to "WorkManager",
+        "camerax" to "CameraX",
+        "sqlite" to "SQLite / Room",
+        "room" to "Room",
+        "realm" to "Realm",
+        "netty" to "Netty",
+        "unity" to "Unity",
+        "mono" to "Mono / Unity",
+        "flutter" to "Flutter",
+        "dartworker" to "Flutter / Dart",
+        "hermes" to "React Native (Hermes)",
+        "mqt_" to "React Native",
+        "reactnative" to "React Native",
+    )
+
+    /**
+     * Returns the friendly library/subsystem name for [threadName], or `null` if it looks like an
+     * app's own thread (e.g. the main thread or a custom-named worker).
+     */
+    fun forThread(threadName: String): String? {
+        val name = threadName.trim()
+        if (name.isEmpty()) return null
+        if (name.equals("main", ignoreCase = true)) return "App main thread"
+        val lower = name.lowercase()
+        for ((needle, label) in RULES) {
+            if (lower.contains(needle)) return label
+        }
+        return null
+    }
+}

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/utils/RootShell.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/utils/RootShell.kt
@@ -1,6 +1,8 @@
 package com.hereliesaz.logkitty.utils
 
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.io.BufferedReader
 import java.io.InputStreamReader
@@ -25,11 +27,17 @@ object RootShell {
             val cmd = if (useRoot) listOf("su", "-c", script) else listOf("sh", "-c", script)
             var process: Process? = null
             try {
-                process = ProcessBuilder(cmd).redirectErrorStream(true).start()
-                // Drain stdout continuously so a large dumpsys can't deadlock on a full pipe buffer.
-                val output = BufferedReader(InputStreamReader(process.inputStream)).use { it.readText() }
-                val finished = process.waitFor(timeoutMs, java.util.concurrent.TimeUnit.MILLISECONDS)
-                if (!finished) process.destroyForcibly()
+                val started = ProcessBuilder(cmd).redirectErrorStream(true).start()
+                process = started
+                // readText() blocks until the stream hits EOF, which only happens when the process
+                // exits. If `su` hangs (e.g. waiting on a root-permission prompt) that would block
+                // forever, so a watchdog force-kills the process after the timeout to unblock the read.
+                val watchdog = launch {
+                    delay(timeoutMs)
+                    started.destroyForcibly()
+                }
+                val output = BufferedReader(InputStreamReader(started.inputStream)).use { it.readText() }
+                watchdog.cancel()
                 output.ifBlank { null }
             } catch (e: Exception) {
                 null

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/utils/RootShell.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/utils/RootShell.kt
@@ -1,0 +1,44 @@
+package com.hereliesaz.logkitty.utils
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.BufferedReader
+import java.io.InputStreamReader
+
+/**
+ * Runs short, one-shot shell scripts and returns their combined output.
+ *
+ * Mirrors the privilege model [LogcatReader] already uses: when [useRoot] is true the script is run
+ * through `su -c`, capturing data from any process on the device; otherwise it runs in the app's own
+ * unprivileged shell, where most `/proc/<other-pid>` reads and `dumpsys` calls are denied. Callers
+ * are expected to treat a `null` result (or empty sections) as "unavailable" and degrade gracefully.
+ */
+object RootShell {
+
+    /**
+     * Executes [script] (a `sh` snippet, may span multiple lines / use globs and pipes) and returns
+     * its combined stdout+stderr, or `null` if the process could not be started or timed out before
+     * producing output.
+     */
+    suspend fun run(script: String, useRoot: Boolean, timeoutMs: Long = 4000): String? =
+        withContext(Dispatchers.IO) {
+            val cmd = if (useRoot) listOf("su", "-c", script) else listOf("sh", "-c", script)
+            var process: Process? = null
+            try {
+                process = ProcessBuilder(cmd).redirectErrorStream(true).start()
+                // Drain stdout continuously so a large dumpsys can't deadlock on a full pipe buffer.
+                val output = BufferedReader(InputStreamReader(process.inputStream)).use { it.readText() }
+                val finished = process.waitFor(timeoutMs, java.util.concurrent.TimeUnit.MILLISECONDS)
+                if (!finished) process.destroyForcibly()
+                output.ifBlank { null }
+            } catch (e: Exception) {
+                null
+            } finally {
+                process?.destroyForcibly()
+            }
+        }
+
+    /** True if a root shell is reachable (used to decide between full and best-effort collection). */
+    suspend fun isRootAvailable(): Boolean =
+        run("id -u", useRoot = true, timeoutMs = 3000)?.trim() == "0"
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -119,6 +119,8 @@
     <string name="cd_search_google">Search Google</string>
     <string name="cd_prohibit_tag">Prohibit this tag</string>
     <string name="cd_deselect">Deselect</string>
+    <string name="stats_toggle_logs">Logs</string>
+    <string name="stats_toggle_stats">Stats</string>
 
     <!-- Tabs -->
     <string name="tab_all">All</string>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 agp = "9.2.1"
 aetherTransportFile = "2.0.14"
-aznavrail = "10.1
+aznavrail = "10.1"
 playServicesAds = "25.3.0"
 coreKtx = "1.19.0"
 kotlinxCoroutinesCore = "1.11.0"


### PR DESCRIPTION
## What

Adds a **Logs / Stats** toggle to each app-specific tab in the HALF and FULL detents. Flipping a monitored app's tab to **Stats** shows a live, scrollable developer dashboard for that app — the stuff you can't get from logs or lints.

Per your direction: **root-gated with a graceful best-effort fallback** (network + battery only when root is off), a **Logs/Stats toggle per app tab**, and **all categories** in v1.

## Metrics

- **CPU** — app % of device, user/kernel split, device busy %, core count, and a **top-thread breakdown that attributes load to the likely library** via thread names (OkHttp, HWUI/RenderThread, ART GC, Play Services, RxJava, Coroutines, WebView/Chromium, ExoPlayer, Glide, Firebase, …). This is the realistic version of "broken down by library": you can't attribute CPU inside another process from outside, but almost every library names its threads.
- **Memory** — total PSS, Java/native/graphics/code/stack heaps, RSS, device RAM used/total.
- **GPU & frames** — `dumpsys gfxinfo` jank %, 50/90/95/99th-percentile frame times, missed vsync, slow UI-thread / slow draw-command counts, plus device GPU busy % (Adreno/KGSL).
- **Network** — per-UID live throughput (down/up) and 24h totals, split Wi-Fi vs mobile, via `NetworkStatsManager` (works **without root** given Usage Access).
- **Power & scheduling** — wakelocks held, partial-wakelock time, jobs & alarms registered, battery level/temp/charging.
- **Process health** — thread count, open file descriptors (FD-leak hint), and live disk read/write rates.

Janky-frame and CPU bars are color-coded green→amber→red so problems jump out.

## How it works

- `AppStatsCollector` resolves the app's pid(s) and gathers everything proc/`dumpsys`-based in **one `su` batch per poll** to keep overhead low; rate metrics (CPU %, I/O B/s, net B/s) are computed from remembered deltas between samples.
- `StatsDelegate` polls only while an app tab's Stats view is open **and the sheet is expanded** — it costs nothing when collapsed or showing logs. Live metrics refresh ~2s; heavy power/scheduling stats refresh ~10s.
- `RootShell` mirrors the existing `LogcatReader` privilege model (`su -c` vs unprivileged shell); `LibraryAttribution` maps thread names to libraries.
- Re-targets automatically if you flip Root Access while the view is open.

## Permissions

Network stats use the already-declared `PACKAGE_USAGE_STATS` (Usage Access) app-op — the collector adds an inline banner prompting for it when missing. Everything else rides on the existing root path.

## Testing note

⚠️ This branch was **not compiled in CI** — the sandbox's network policy blocks the Gradle plugin portal (`plugins.gradle.org`), so `:app:compileDebugKotlin` couldn't resolve the `foojay-resolver` settings plugin. The code was reviewed manually for correctness; **please build locally before merging.** Device behavior (especially `dumpsys` output shapes and `/sys/class/kgsl` paths) varies by ROM, so the parsers are defensive and degrade to "—" rather than fabricating values.

## Ideas not yet included (easy follow-ups)
Sparkline history per metric, binder/IPC transaction counts, sensor/GPS usage (`dumpsys sensorservice`/`location`), running services & registered receivers, crash/ANR history from dropbox, and thermal-throttle state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GSxjeuLJyBVyFhGXcxbkSe)_