### PR TITLE
Stats v2 (1): live trend sparklines + running-services section

### DIFF
--- a/feature/stats/src/main/kotlin/com/hereliesaz/logkitty/feature/stats/AppStats.kt
+++ b/feature/stats/src/main/kotlin/com/hereliesaz/logkitty/feature/stats/AppStats.kt
@@ -25,6 +25,7 @@ data class AppStats(
     val network: NetworkStats? = null,
     val power: PowerStats? = null,
     val health: HealthStats? = null,
+    val components: ComponentStats? = null,
     /** Human-readable caveats, e.g. "Root required for CPU, memory, GPU and I/O stats". */
     val notes: List<String> = emptyList(),
 )
@@ -106,4 +107,11 @@ data class HealthStats(
     val ioWriteBytesPerSec: Long?,
     val totalIoReadBytes: Long?,
     val totalIoWriteBytes: Long?,
+)
+
+/** Running components for the app, parsed from `dumpsys activity services` (root, best-effort). */
+data class ComponentStats(
+    val runningServiceCount: Int?,
+    /** Short service class names currently running (deduped, capped). */
+    val runningServices: List<String>,
 )

--- a/feature/stats/src/main/kotlin/com/hereliesaz/logkitty/feature/stats/AppStatsCollector.kt
+++ b/feature/stats/src/main/kotlin/com/hereliesaz/logkitty/feature/stats/AppStatsCollector.kt
@@ -107,12 +107,13 @@ class AppStatsCollector(private val context: Context) {
         val memory = parseMemory(sections["MEMINFO"])
         val gpu = parseGpu(sections)
         val health = parseHealth(sections, pids, dtSec)
+        val components = parseComponents(sections["SERVICES"])
 
         prevSampleNanos = nowNanos
         return AppStats(
             packageName = pkg, label = label, rootUsed = true, processFound = true,
             pids = pids, collectedAtMs = now, cpu = cpu, memory = memory, gpu = gpu,
-            network = network, health = health, notes = notes,
+            network = network, health = health, components = components, notes = notes,
         )
     }
 
@@ -154,6 +155,7 @@ class AppStatsCollector(private val context: Context) {
             done
             echo "@@MEMINFO@@"; dumpsys meminfo $p 2>/dev/null
             echo "@@GFXINFO@@"; dumpsys gfxinfo $p 2>/dev/null
+            echo "@@SERVICES@@"; dumpsys activity services $p 2>/dev/null
             echo "@@END@@"
         """.trimIndent()
     }
@@ -196,6 +198,22 @@ class AppStatsCollector(private val context: Context) {
 
     private fun parsePids(s: String?): List<Int> =
         s?.trim()?.split(Regex("\\s+"))?.mapNotNull { it.toIntOrNull() }?.distinct() ?: emptyList()
+
+    /**
+     * Parses running services from `dumpsys activity services <pkg>`. Each running service appears as
+     * `ServiceRecord{hash u0 <pkg>/<ServiceName> ...}`; we capture the short class name. Best-effort:
+     * returns `null` if the format isn't recognized (the UI then shows nothing for this section).
+     */
+    private fun parseComponents(services: String?): ComponentStats? {
+        if (services.isNullOrBlank()) return null
+        val names = SERVICE_RECORD.findAll(services)
+            .map { it.groupValues[1].substringAfterLast('.') }
+            .filter { it.isNotBlank() }
+            .distinct()
+            .toList()
+        if (names.isEmpty()) return null
+        return ComponentStats(runningServiceCount = names.size, runningServices = names.take(12))
+    }
 
     private fun parseCpu(sections: Map<String, String>, pids: List<Int>): CpuStats? {
         val cpuLine = sections["CPU"]?.trim() ?: return null
@@ -475,5 +493,7 @@ class AppStatsCollector(private val context: Context) {
 
     companion object {
         private val MARKER = Regex("""@@([A-Z]+(?: \d+)?)@@""")
+        // Captures the class name from `ServiceRecord{hash u0 pkg/<Name> ...}` (running service).
+        private val SERVICE_RECORD = Regex("""ServiceRecord\{[^}]*/([^\s}]+)""")
     }
 }

--- a/feature/stats/src/main/kotlin/com/hereliesaz/logkitty/feature/stats/StatsFeatureImpl.kt
+++ b/feature/stats/src/main/kotlin/com/hereliesaz/logkitty/feature/stats/StatsFeatureImpl.kt
@@ -30,34 +30,38 @@ class StatsFeatureImpl : StatsFeature {
         val appContext = LocalContext.current.applicationContext
 
         // Poll on a fast cadence for live metrics, refreshing the heavy power/scheduling stats less
-        // often. produceState ties the loop to composition: it restarts when the target/root flag
-        // changes and is cancelled when the Stats view leaves the screen.
-        val stats by produceState<AppStats?>(initialValue = null, packageName, useRoot, label) {
+        // often, and keep a rolling window of recent snapshots so the UI can draw trend sparklines.
+        // produceState ties the loop to composition: it restarts when the target/root flag changes
+        // and is cancelled when the Stats view leaves the screen.
+        val history by produceState<List<AppStats>>(initialValue = emptyList(), packageName, useRoot, label) {
             // produceState runs on the composition's (main) dispatcher; the collector does blocking
             // binder calls (NetworkStatsManager) and root shell I/O, so run the loop off the main
-            // thread. produceState cancels this coroutine when the keys change or it leaves
-            // composition; delay() is the cancellation point that breaks the loop.
+            // thread. delay() is the cancellation point that breaks the loop.
             withContext(Dispatchers.IO) {
                 val collector = AppStatsCollector(appContext)
                 var cachedPower = collector.collectPower(packageName, useRoot)
+                val buffer = ArrayDeque<AppStats>()
                 var iteration = 0
                 while (true) {
                     val snapshot = collector.collect(packageName, label, useRoot)
                     if (iteration % POWER_REFRESH_EVERY == 0 && iteration != 0) {
                         cachedPower = collector.collectPower(packageName, useRoot)
                     }
-                    value = snapshot.copy(power = cachedPower)
+                    buffer.addLast(snapshot.copy(power = cachedPower))
+                    while (buffer.size > HISTORY_MAX) buffer.removeFirst()
+                    value = buffer.toList()
                     iteration++
                     delay(FAST_INTERVAL_MS)
                 }
             }
         }
 
-        StatsView(stats = stats, fontFamily = fontFamily, fontSize = fontSize, modifier = modifier)
+        StatsView(history = history, fontFamily = fontFamily, fontSize = fontSize, modifier = modifier)
     }
 
     private companion object {
         const val FAST_INTERVAL_MS = 2000L
         const val POWER_REFRESH_EVERY = 5
+        const val HISTORY_MAX = 45 // ~90s of trend at the 2s cadence
     }
 }

--- a/feature/stats/src/main/kotlin/com/hereliesaz/logkitty/feature/stats/StatsView.kt
+++ b/feature/stats/src/main/kotlin/com/hereliesaz/logkitty/feature/stats/StatsView.kt
@@ -21,9 +21,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.Path
-import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -143,17 +142,30 @@ private fun SparkRow(
 private fun Sparkline(values: List<Float>, color: Color, modifier: Modifier) {
     Canvas(modifier = modifier) {
         if (values.size < 2) return@Canvas
-        val min = values.min()
-        val max = values.max()
-        val range = (max - min).takeIf { it > 0f } ?: 1f
-        val stepX = size.width / (values.size - 1)
-        val path = Path()
-        values.forEachIndexed { i, v ->
-            val x = i * stepX
-            val y = size.height - ((v - min) / range) * size.height
-            if (i == 0) path.moveTo(x, y) else path.lineTo(x, y)
+        // Single pass for min/max — avoids deprecated min()/max() and a second iteration.
+        var min = values[0]
+        var max = values[0]
+        for (v in values) {
+            if (v < min) min = v
+            if (v > max) max = v
         }
-        drawPath(path, color, style = Stroke(width = 2.dp.toPx()))
+        val range = max - min
+        val stepX = size.width / (values.size - 1)
+        val strokePx = 2.dp.toPx()
+        // Flat series (range == 0) is drawn through the vertical center, not pinned to the bottom.
+        fun yOf(v: Float): Float =
+            if (range > 0f) size.height - ((v - min) / range) * size.height else size.height / 2f
+        // drawLine per segment — Offset is a value class, so the draw phase allocates nothing
+        // (no Path/Stroke objects created on each frame while the parent column scrolls).
+        var prevX = 0f
+        var prevY = yOf(values[0])
+        for (i in 1 until values.size) {
+            val x = i * stepX
+            val y = yOf(values[i])
+            drawLine(color, Offset(prevX, prevY), Offset(x, y), strokeWidth = strokePx)
+            prevX = x
+            prevY = y
+        }
     }
 }
 

--- a/feature/stats/src/main/kotlin/com/hereliesaz/logkitty/feature/stats/StatsView.kt
+++ b/feature/stats/src/main/kotlin/com/hereliesaz/logkitty/feature/stats/StatsView.kt
@@ -1,5 +1,6 @@
 package com.hereliesaz.logkitty.feature.stats
 
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -21,6 +22,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -34,11 +37,12 @@ import androidx.compose.ui.unit.sp
  */
 @Composable
 fun StatsView(
-    stats: AppStats?,
+    history: List<AppStats>,
     fontFamily: FontFamily?,
     fontSize: Int,
     modifier: Modifier = Modifier,
 ) {
+    val stats = history.lastOrNull()
     if (stats == null) {
         Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
             Text("Collecting stats…", color = Color.Gray, fontSize = fontSize.sp, fontFamily = fontFamily)
@@ -85,12 +89,15 @@ fun StatsView(
 
         stats.notes.forEach { note -> NoteBanner(note, fontFamily, fontSize) }
 
+        if (history.size >= 2) TrendsSection(history, fontFamily, fontSize, labelColor, valueColor)
+
         stats.cpu?.let { CpuSection(it, fontFamily, fontSize, labelColor, valueColor) }
         stats.memory?.let { MemorySection(it, fontFamily, fontSize, labelColor, valueColor) }
         stats.gpu?.let { GpuSection(it, fontFamily, fontSize, labelColor, valueColor) }
         stats.network?.let { NetworkSection(it, fontFamily, fontSize, labelColor, valueColor) }
         stats.power?.let { PowerSection(it, fontFamily, fontSize, labelColor, valueColor) }
         stats.health?.let { HealthSection(it, fontFamily, fontSize, labelColor, valueColor) }
+        stats.components?.let { ComponentsSection(it, fontFamily, fontSize, labelColor, valueColor) }
 
         Spacer(Modifier.height(16.dp))
     }
@@ -99,6 +106,70 @@ fun StatsView(
 // ----------------------------------------------------------------------------------------------
 // Sections
 // ----------------------------------------------------------------------------------------------
+
+@Composable
+private fun TrendsSection(history: List<AppStats>, ff: FontFamily?, fs: Int, lc: Color, vc: Color) {
+    val cpu = history.mapNotNull { it.cpu?.appPercent }
+    val rx = history.mapNotNull { it.network?.rxBytesPerSec?.toFloat() }
+    val tx = history.mapNotNull { it.network?.txBytesPerSec?.toFloat() }
+    val pss = history.mapNotNull { it.memory?.totalPssKb?.toFloat() }
+    val io = history.mapNotNull { it.health?.ioWriteBytesPerSec?.toFloat() }
+    val jank = history.mapNotNull { it.gpu?.jankPercent }
+    if (listOf(cpu, rx, tx, pss, io, jank).none { it.size >= 2 }) return
+
+    StatCard("Trends · last ~${history.size * 2}s", ff, fs) {
+        if (cpu.size >= 2) SparkRow("CPU", cpu, pct(cpu.last()), Color(0xFF4FC3F7), ff, fs, lc, vc)
+        if (rx.size >= 2) SparkRow("Net ↓", rx, rate(rx.last().toLong()), Color(0xFF81C784), ff, fs, lc, vc)
+        if (tx.size >= 2) SparkRow("Net ↑", tx, rate(tx.last().toLong()), Color(0xFFFFB74D), ff, fs, lc, vc)
+        if (pss.size >= 2) SparkRow("PSS", pss, kb(pss.last().toLong()), Color(0xFFBA68C8), ff, fs, lc, vc)
+        if (io.size >= 2) SparkRow("Disk ✎", io, rate(io.last().toLong()), Color(0xFFE57373), ff, fs, lc, vc)
+        if (jank.size >= 2) SparkRow("Jank", jank, pct(jank.last()), Color(0xFF4DD0E1), ff, fs, lc, vc)
+    }
+}
+
+@Composable
+private fun SparkRow(
+    label: String, values: List<Float>, current: String, color: Color,
+    ff: FontFamily?, fs: Int, lc: Color, vc: Color,
+) {
+    Row(modifier = Modifier.fillMaxWidth().padding(vertical = 2.dp), verticalAlignment = Alignment.CenterVertically) {
+        Text(label, color = lc, fontSize = (fs - 1).sp, fontFamily = ff, modifier = Modifier.width(52.dp), maxLines = 1)
+        Sparkline(values, color, Modifier.weight(1f).height(22.dp).padding(horizontal = 8.dp))
+        Text(current, color = vc, fontSize = (fs - 1).sp, fontFamily = ff, fontWeight = FontWeight.Bold)
+    }
+}
+
+@Composable
+private fun Sparkline(values: List<Float>, color: Color, modifier: Modifier) {
+    Canvas(modifier = modifier) {
+        if (values.size < 2) return@Canvas
+        val min = values.min()
+        val max = values.max()
+        val range = (max - min).takeIf { it > 0f } ?: 1f
+        val stepX = size.width / (values.size - 1)
+        val path = Path()
+        values.forEachIndexed { i, v ->
+            val x = i * stepX
+            val y = size.height - ((v - min) / range) * size.height
+            if (i == 0) path.moveTo(x, y) else path.lineTo(x, y)
+        }
+        drawPath(path, color, style = Stroke(width = 2.dp.toPx()))
+    }
+}
+
+@Composable
+private fun ComponentsSection(c: ComponentStats, ff: FontFamily?, fs: Int, lc: Color, vc: Color) {
+    StatCard("Components", ff, fs) {
+        StatRow("Running services", c.runningServiceCount?.toString() ?: "—", ff, fs, lc, vc, emphasize = true)
+        c.runningServices.forEach { svc ->
+            Text(
+                svc, color = vc, fontSize = (fs - 1).sp, fontFamily = ff,
+                maxLines = 1, overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.fillMaxWidth().padding(top = 1.dp),
+            )
+        }
+    }
+}
 
 @Composable
 private fun CpuSection(cpu: CpuStats, ff: FontFamily?, fs: Int, lc: Color, vc: Color) {


### PR DESCRIPTION
## Stats v2 — increment 1: trend sparklines + running services

First slice of the parked Stats v2 ideas. All additive and self-contained in `:feature:stats`; existing sections are untouched.

### Sparklines (the headline)
- `StatsFeatureImpl` now keeps a **rolling ~90s window** of snapshots instead of only the latest.
- New **"Trends" card** at the top of the stats view draws `Canvas` sparklines for **CPU %, network ↓/↑, PSS, disk write, and jank %**, each with its current value. Turns the point-in-time numbers into at-a-glance trends — much better for spotting spikes, ramps, and leaks than single readings.
- No new data collection, no new permissions — purely derived from data already gathered.

### Components section
- New **"Components"** card lists **running services**, parsed best-effort from `dumpsys activity services <pkg>` (root). Like every other section, it degrades to nothing if the output isn't recognized — so it can't break anything.

### Deliberately deferred (need on-device parser validation)
The remaining Stats v2 ideas each depend on `dumpsys` output I can't verify here, so they're follow-up increments: **sensor/GPS usage** (`dumpsys sensorservice`/`location`), **crash/ANR history** (dropbox), and **binder/IPC counts**.

### Verified vs. not
- ✅ Self-contained; single `StatsView` caller updated; sparkline drawing is verifiable by inspection.
- ❌ **Not built here** (sandbox can't run Gradle) — relying on CI. The `dumpsys activity services` parser (`SERVICE_RECORD` regex) needs an on-device check against real output; worst case it shows nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GSxjeuLJyBVyFhGXcxbkSe)_

## Summary by Sourcery

Introduce trend sparklines and a components card to the stats feature using a rolling history of app metrics.

New Features:
- Add a rolling history buffer of recent AppStats snapshots to support time-based views.
- Display a Trends card with sparklines for CPU, network, memory PSS, disk writes, and jank percentages.
- Show a Components card listing currently running services for the app, based on dumpsys activity services output.

Enhancements:
- Wire the updated StatsView to consume a history of AppStats rather than a single snapshot while keeping existing sections intact.