### PR TITLE
Release readiness: in-app updates, resource shrinking, pre-release checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Comprehensive documentation is available in the `docs/` directory:
 
 *   **[Setup Guide](docs/SETUP.md):** Build instructions, prerequisites, and installation.
 *   **[Releasing](docs/RELEASING.md):** Signed App Bundle, versionCode, dynamic feature modules, and Play Console publishing.
+*   **[Pre-release checklist](docs/PRE_RELEASE_CHECKLIST.md):** Play setup, data-safety, and on-device smoke tests to run before publishing.
 *   **[Architecture](docs/architecture.md):** High-level overview of the system design (MVVM, Services).
 *   **[API Reference](docs/API.md):** Detailed description of key classes and components.
 *   **[File Descriptions](docs/file_descriptions.md):** A map of the project structure.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -119,6 +119,10 @@ android {
         release {
             signingConfig = signingConfigs.getByName("release")
             isMinifyEnabled = true
+            // Strip unused resources alongside R8 code shrinking. Resources referenced only across
+            // module boundaries (the dynamic-feature dist:title strings) are protected by
+            // res/raw/keep.xml. Verify on a release build that nothing needed was removed.
+            isShrinkResources = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
@@ -238,6 +242,9 @@ dependencies {
     // Play Feature Delivery: install/observe on-demand modules at runtime via SplitInstallManager.
     implementation(libs.play.feature.delivery)
     implementation(libs.play.feature.delivery.ktx)
+
+    // Play in-app updates (flexible) — prompts Play users to update without leaving the app.
+    implementation(libs.play.app.update)
 
     // Keep libraries needed for UI and logging
     implementation(libs.androidx.core.ktx)

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/MainActivity.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/MainActivity.kt
@@ -80,7 +80,9 @@ class MainActivity : ComponentActivity() {
     private val appUpdateManager by lazy { AppUpdateManagerFactory.create(this) }
     private var updateReadyToInstall by mutableStateOf(false)
     private val installStateListener = InstallStateUpdatedListener { state ->
-        if (state.installStatus() == InstallStatus.DOWNLOADED) updateReadyToInstall = true
+        // Bind the prompt to the download status so it clears if the update is canceled or fails,
+        // rather than latching on once and showing a stale "Restart" card.
+        updateReadyToInstall = state.installStatus() == InstallStatus.DOWNLOADED
     }
     // Flexible-update download runs in the background; progress is tracked via installStateListener,
     // so the result itself isn't needed here.
@@ -255,23 +257,25 @@ class MainActivity : ComponentActivity() {
     private fun checkForAppUpdate() {
         appUpdateManager.registerListener(installStateListener)
         appUpdateManager.appUpdateInfo.addOnSuccessListener { info ->
-            when {
-                info.installStatus() == InstallStatus.DOWNLOADED -> updateReadyToInstall = true
+            updateReadyToInstall = info.installStatus() == InstallStatus.DOWNLOADED
+            if (!updateReadyToInstall &&
                 info.updateAvailability() == UpdateAvailability.UPDATE_AVAILABLE &&
-                    info.isUpdateTypeAllowed(AppUpdateType.FLEXIBLE) -> runCatching {
-                        appUpdateManager.startUpdateFlowForResult(
-                            info, appUpdateLauncher, AppUpdateOptions.defaultOptions(AppUpdateType.FLEXIBLE),
-                        )
-                    }
+                info.isUpdateTypeAllowed(AppUpdateType.FLEXIBLE)
+            ) {
+                runCatching {
+                    appUpdateManager.startUpdateFlowForResult(
+                        info, appUpdateLauncher, AppUpdateOptions.defaultOptions(AppUpdateType.FLEXIBLE),
+                    )
+                }
             }
         }
     }
 
     override fun onResume() {
         super.onResume()
-        // If a flexible update finished downloading while the user was away, show the restart prompt.
+        // Re-sync the restart prompt with the actual download state so a stale prompt isn't shown.
         appUpdateManager.appUpdateInfo.addOnSuccessListener { info ->
-            if (info.installStatus() == InstallStatus.DOWNLOADED) updateReadyToInstall = true
+            updateReadyToInstall = info.installStatus() == InstallStatus.DOWNLOADED
         }
     }
 

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/MainActivity.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/MainActivity.kt
@@ -27,6 +27,12 @@ import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
+import com.google.android.play.core.appupdate.AppUpdateManagerFactory
+import com.google.android.play.core.appupdate.AppUpdateOptions
+import com.google.android.play.core.install.InstallStateUpdatedListener
+import com.google.android.play.core.install.model.AppUpdateType
+import com.google.android.play.core.install.model.InstallStatus
+import com.google.android.play.core.install.model.UpdateAvailability
 import com.hereliesaz.aznavrail.AzButton
 import com.hereliesaz.aznavrail.model.AzButtonShape
 import com.hereliesaz.logkitty.services.LogKittyOverlayService
@@ -69,6 +75,19 @@ class MainActivity : ComponentActivity() {
         ActivityResultContracts.RequestPermission()
     ) { startOverlayService() }
 
+    // --- Play in-app updates (flexible) ---
+    // Only does anything for Play-installed builds; on sideloaded/GitHub builds no update is found.
+    private val appUpdateManager by lazy { AppUpdateManagerFactory.create(this) }
+    private var updateReadyToInstall by mutableStateOf(false)
+    private val installStateListener = InstallStateUpdatedListener { state ->
+        if (state.installStatus() == InstallStatus.DOWNLOADED) updateReadyToInstall = true
+    }
+    // Flexible-update download runs in the background; progress is tracked via installStateListener,
+    // so the result itself isn't needed here.
+    private val appUpdateLauncher = registerForActivityResult(
+        ActivityResultContracts.StartIntentSenderForResult()
+    ) { }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -78,6 +97,9 @@ class MainActivity : ComponentActivity() {
 
         // Attempt to gain root access silently if available (for "Root Mode").
         requestRootAccess()
+
+        // Offer a flexible in-app update if Play has a newer build.
+        checkForAppUpdate()
 
         // Handle intent arguments (e.g., opening directly to Settings from the Notification).
         if (intent?.getBooleanExtra("EXTRA_SHOW_SETTINGS", false) == true) {
@@ -117,6 +139,8 @@ class MainActivity : ComponentActivity() {
                             isReadLogsGranted = isReadLogsGranted,
                             isRootEnabled = isRootEnabled,
                             isServiceRunning = isServiceRunning,
+                            updateReadyToInstall = updateReadyToInstall,
+                            onCompleteUpdate = { appUpdateManager.completeUpdate() },
                             onGrantOverlay = { requestOverlayPermission() },
                             onToggleService = { toggleOverlayService() },
                             onOpenSettings = { showSettings = true }
@@ -226,6 +250,35 @@ class MainActivity : ComponentActivity() {
             } catch (e: Exception) { e.printStackTrace() }
         }.start()
     }
+
+    /** Starts a flexible Play update if one is available, or surfaces the restart prompt if already downloaded. */
+    private fun checkForAppUpdate() {
+        appUpdateManager.registerListener(installStateListener)
+        appUpdateManager.appUpdateInfo.addOnSuccessListener { info ->
+            when {
+                info.installStatus() == InstallStatus.DOWNLOADED -> updateReadyToInstall = true
+                info.updateAvailability() == UpdateAvailability.UPDATE_AVAILABLE &&
+                    info.isUpdateTypeAllowed(AppUpdateType.FLEXIBLE) -> runCatching {
+                        appUpdateManager.startUpdateFlowForResult(
+                            info, appUpdateLauncher, AppUpdateOptions.defaultOptions(AppUpdateType.FLEXIBLE),
+                        )
+                    }
+            }
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        // If a flexible update finished downloading while the user was away, show the restart prompt.
+        appUpdateManager.appUpdateInfo.addOnSuccessListener { info ->
+            if (info.installStatus() == InstallStatus.DOWNLOADED) updateReadyToInstall = true
+        }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        appUpdateManager.unregisterListener(installStateListener)
+    }
 }
 
 /**
@@ -237,6 +290,8 @@ fun MainScreenContent(
     isReadLogsGranted: Boolean,
     isRootEnabled: Boolean,
     isServiceRunning: Boolean,
+    updateReadyToInstall: Boolean,
+    onCompleteUpdate: () -> Unit,
     onGrantOverlay: () -> Unit,
     onToggleService: () -> Unit,
     onOpenSettings: () -> Unit
@@ -262,6 +317,17 @@ fun MainScreenContent(
             )
             Text(text = stringResource(R.string.app_name), style = MaterialTheme.typography.displayMedium, color = MaterialTheme.colorScheme.primary)
             Spacer(modifier = Modifier.height(32.dp))
+
+            // In-app update ready (flexible update finished downloading) → offer restart.
+            if (updateReadyToInstall) {
+                PermissionCard(
+                    title = stringResource(R.string.update_ready_title),
+                    description = stringResource(R.string.update_ready_desc),
+                    buttonText = stringResource(R.string.update_restart),
+                    onClick = onCompleteUpdate
+                )
+                Spacer(modifier = Modifier.height(16.dp))
+            }
 
             // Step 1: Overlay Permission
             if (!isOverlayGranted) {

--- a/app/src/main/res/raw/keep.xml
+++ b/app/src/main/res/raw/keep.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Resource-shrinker keep list. These strings are referenced from dynamic feature module manifests
+  (<dist:module dist:title="@string/...">) but defined in the base module, so the shrinker may not
+  see the cross-module reference. Keep them explicitly.
+-->
+<resources xmlns:tools="http://schemas.android.com/tools"
+    tools:keep="@string/feature_stats_title,@string/feature_ads_title" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -27,6 +27,9 @@
     <string name="main_ready_to_purr">Ready to Purr</string>
     <string name="main_stop_service">Stop Service</string>
     <string name="main_start_service">Start Service</string>
+    <string name="update_ready_title">Update ready</string>
+    <string name="update_ready_desc">A new version has downloaded. Restart to finish updating.</string>
+    <string name="update_restart">Restart &amp; update</string>
 
     <!-- Settings screen -->
     <string name="settings_title">Settings</string>

--- a/docs/PRE_RELEASE_CHECKLIST.md
+++ b/docs/PRE_RELEASE_CHECKLIST.md
@@ -1,0 +1,44 @@
+# Pre-release checklist
+
+Run through this before publishing a LogKitty release. See **[RELEASING.md](RELEASING.md)** for the
+build/signing/publish mechanics; this is the human checklist around them.
+
+## One-time Google Play setup (first release only)
+- [ ] Create a **Google Cloud service account** + JSON key; add it as the `PLAY_SERVICE_ACCOUNT_JSON`
+      repo secret.
+- [ ] In **Play Console → Users & permissions**, invite the service account and grant release access
+      (testing tracks at minimum; production if you'll publish there).
+- [ ] **Upload the first `.aab` manually** in the Play Console and complete the store listing,
+      content rating, and **Data safety** form. The Play API can only publish to an app that already
+      exists — automation can't do the first upload.
+- [ ] Enrol in **Play App Signing** (recommended): your CI key becomes the upload key.
+
+## Data safety / privacy (every release if it changed)
+- [ ] Declare **AdMob / `AD_ID`** usage (data shared with Google for advertising) in the Data safety
+      form; ensure the listing's privacy policy is current. See `PRIVACY_POLICY.md` / `PERMISSIONS.md`.
+- [ ] Confirm the declared sensitive permissions still match the app: `READ_LOGS`,
+      `SYSTEM_ALERT_WINDOW`, `FOREGROUND_SERVICE_SPECIAL_USE`, `PACKAGE_USAGE_STATS`.
+
+## Build verification (CI)
+- [ ] `build-and-release` green on the release commit (compiles + bundles all modules).
+- [ ] Do a **dry run** of `play-publish.yml` with `publish: off` and inspect the produced `.aab`
+      artifact.
+
+## On-device smoke test (CI can't cover these)
+Install a release build — ideally from a **Play internal-testing** track, or a
+`bundletool build-apks --local-testing` install — and verify:
+- [ ] **Resource shrinking** didn't strip anything needed: the on-demand install dialogs show their
+      titles (Developer Stats, Ads), and no screen is missing text/icons. (`isShrinkResources` is on;
+      cross-module title strings are protected by `res/raw/keep.xml`.)
+- [ ] **On-demand modules install and load**: open the Stats tab (downloads `:feature:stats`); the
+      AdMob banner appears in Settings (downloads `:feature:ads`).
+- [ ] **Context Mode** works: foreground-app auto-filtering after granting Usage Access (non-root),
+      and via `dumpsys` on a rooted device (no grant needed).
+- [ ] **Root vs non-root**: logcat via `su` (root) and via the ADB `READ_LOGS` grant (non-root); the
+      app picker shows the full list on root and launchable apps otherwise.
+- [ ] **In-app update**: with a higher `versionCode` on the track, launching the app offers the
+      flexible update and, once downloaded, shows the "Restart & update" prompt.
+
+## Versioning
+- [ ] `versionCode` increases — CI derives it from `git rev-list --count HEAD`, so just make sure the
+      release commit is ahead of the last published one.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,6 +25,7 @@ dokar3Sheets = "0.7.4"
 documentfile = "1.1.0"
 r8 = "9.1.31"
 playFeatureDelivery = "2.1.0"
+playAppUpdate = "2.1.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -58,6 +59,7 @@ r8 = { module = "com.android.tools:r8", version.ref = "r8" }
 okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
 play-feature-delivery = { module = "com.google.android.play:feature-delivery", version.ref = "playFeatureDelivery" }
 play-feature-delivery-ktx = { module = "com.google.android.play:feature-delivery-ktx", version.ref = "playFeatureDelivery" }
+play-app-update = { module = "com.google.android.play:app-update", version.ref = "playAppUpdate" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
Knocks out items **1, 2, and 4** from the follow-up menu. (3 — Stats v2 — is in flight as #146.)

## 1. Play in-app updates (flexible)
- `MainActivity` checks for an update on launch via `AppUpdateManager`; if one is available it starts a **flexible** (non-blocking) update, and when the download finishes shows a **"Restart & update"** card that calls `completeUpdate()`. Resumes the prompt on `onResume` if it downloaded while away; listener unregistered in `onDestroy`.
- No-op on sideloaded/GitHub builds (no update found), exactly like `SplitInstall`.
- Adds `com.google.android.play:app-update`.

## 2. Resource shrinking
- Enables `isShrinkResources = true` for release (alongside the existing R8 minify).
- `res/raw/keep.xml` protects the **cross-module** dynamic-feature `dist:title` strings (`feature_stats_title`, `feature_ads_title`) — the shrinker may not see references that live in a feature module's manifest but point at base resources.
- ⚠️ Resource shrinking breaks at *runtime*, not build time, so CI green isn't proof — see the checklist's on-device step.

## 4. Pre-release checklist
- New `docs/PRE_RELEASE_CHECKLIST.md` (linked from README): one-time Play service-account setup + manual first upload, Data-safety/permission declarations, the `publish: off` CI dry run, and the on-device smoke tests (resource shrinking, on-demand install, Context Mode, root vs non-root, in-app update).

## Verified vs. not
- ✅ Self-consistent; single `MainScreenContent` caller updated; keep-list strings confirmed present.
- ❌ **Not built here** (sandbox can't run Gradle) — relying on CI. Two things specifically need a device: confirming resource shrinking didn't strip anything needed, and the in-app-update flow (needs a real Play track with a higher versionCode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GSxjeuLJyBVyFhGXcxbkSe)_

## Summary by Sourcery

Add Play in-app update support, enable resource shrinking for release builds, and introduce a pre-release checklist for Play publishing.

New Features:
- Offer flexible Play in-app updates that surface an in-app restart prompt when a new version has been downloaded.

Enhancements:
- Enable resource shrinking in release builds while protecting dynamic-feature title strings via a keep list.

Build:
- Add Play in-app update dependency and corresponding version catalog entry for release builds.

Documentation:
- Document a pre-release checklist covering Play setup, data safety, CI checks, and on-device smoke tests, and link it from the main README.

Chores:
- Add a resource-shrinker keep list file to ensure cross-module string resources are retained.