### PR TITLE
Stats v2 (2): sensor/GPS, crash/ANR history, and binder/IPC sections

### DIFF
--- a/feature/stats/src/main/kotlin/com/hereliesaz/logkitty/feature/stats/AppStats.kt
+++ b/feature/stats/src/main/kotlin/com/hereliesaz/logkitty/feature/stats/AppStats.kt
@@ -26,6 +26,9 @@ data class AppStats(
     val power: PowerStats? = null,
     val health: HealthStats? = null,
     val components: ComponentStats? = null,
+    val sensors: SensorStats? = null,
+    val crashes: CrashStats? = null,
+    val binder: BinderStats? = null,
     /** Human-readable caveats, e.g. "Root required for CPU, memory, GPU and I/O stats". */
     val notes: List<String> = emptyList(),
 )
@@ -114,4 +117,45 @@ data class ComponentStats(
     val runningServiceCount: Int?,
     /** Short service class names currently running (deduped, capped). */
     val runningServices: List<String>,
+)
+
+/**
+ * Sensor and location usage for the app, parsed from `dumpsys sensorservice` / `dumpsys location`
+ * (root, best-effort). Tells you whether the app is quietly holding a sensor or GPS request — a
+ * common, hard-to-spot battery drain.
+ */
+data class SensorStats(
+    /** Number of active sensor connections the app currently holds. */
+    val activeSensorConnections: Int?,
+    /** Distinct sensor types the app is subscribed to (keyword-matched from the dump). */
+    val activeSensors: List<String>,
+    /** True if the app currently holds a location request; null when it can't be determined. */
+    val locationActive: Boolean?,
+    /** Location providers the app is requesting (e.g. "gps", "fused", "network"). */
+    val locationProviders: List<String>,
+)
+
+/**
+ * Recent crash / ANR history for the app, read from the logcat **crash** buffer and the system log.
+ * Unlike most sections this works **without root** — it only needs the `READ_LOGS` grant the app
+ * already relies on. Timestamps are the raw logcat "MM-DD HH:MM:SS" string (no year/zone guessing).
+ */
+data class CrashStats(
+    val crashCount: Int,
+    val anrCount: Int,
+    val lastCrashWhen: String?,
+    val lastCrashSummary: String?,
+    val lastAnrWhen: String?,
+    val lastAnrSummary: String?,
+)
+
+/**
+ * Binder / IPC footprint, parsed from `/sys/kernel/debug/binder/proc/<pid>` (root + debugfs,
+ * best-effort). High node/ref counts or pending transactions hint at chatty or leaking IPC.
+ */
+data class BinderStats(
+    val threads: Int?,
+    val nodes: Int?,
+    val refs: Int?,
+    val pendingTransactions: Int?,
 )

--- a/feature/stats/src/main/kotlin/com/hereliesaz/logkitty/feature/stats/AppStatsCollector.kt
+++ b/feature/stats/src/main/kotlin/com/hereliesaz/logkitty/feature/stats/AppStatsCollector.kt
@@ -130,7 +130,7 @@ class AppStatsCollector(private val context: Context) {
      */
     suspend fun collectSlow(pkg: String, useRoot: Boolean): SlowStats {
         val (level, temp, charging) = readBattery()
-        val raw = RootShell.run(buildSlowScript(pkg), useRoot = useRoot, timeoutMs = 8000)
+        val raw = RootShell.run(buildSlowScript(pkg, useRoot), useRoot = useRoot, timeoutMs = 8000)
         val sections = if (raw != null) splitSections(raw) else emptyMap()
 
         val power = if (useRoot) {
@@ -168,7 +168,7 @@ class AppStatsCollector(private val context: Context) {
               echo "@@PIO ${'$'}pp@@"; cat /proc/${'$'}pp/io 2>/dev/null
               echo "@@PFD ${'$'}pp@@"; ls /proc/${'$'}pp/fd 2>/dev/null | wc -l
               echo "@@PTASKS ${'$'}pp@@"; cat /proc/${'$'}pp/task/*/stat 2>/dev/null
-              echo "@@BINDER ${'$'}pp@@"; cat /sys/kernel/debug/binder/proc/${'$'}pp 2>/dev/null
+              echo "@@BINDER ${'$'}pp@@"; cat /sys/kernel/debug/binder/proc/${'$'}pp 2>/dev/null || cat /dev/binderfs/binder_logs/proc/${'$'}pp 2>/dev/null
             done
             echo "@@MEMINFO@@"; dumpsys meminfo $p 2>/dev/null
             echo "@@GFXINFO@@"; dumpsys gfxinfo $p 2>/dev/null
@@ -177,18 +177,26 @@ class AppStatsCollector(private val context: Context) {
         """.trimIndent()
     }
 
-    private fun buildSlowScript(pkg: String): String {
+    /**
+     * The slow batch. The `dumpsys`-based sections are root-only, so on a non-rooted device we omit
+     * them entirely rather than spawn processes that will just be denied — the crash/ANR logcat
+     * dumps work either way (they only need `READ_LOGS`).
+     */
+    private fun buildSlowScript(pkg: String, useRoot: Boolean): String {
         val p = shellEscape(pkg)
+        val crashLogs = """
+            echo "@@CRASHLOG@@"; logcat -b crash -d -v threadtime -t 400 2>/dev/null
+            echo "@@ANRLOG@@"; logcat -b system -d -v threadtime 2>/dev/null | grep "ANR in" | grep -F $p | tail -n 40
+            echo "@@END@@"
+        """.trimIndent()
+        if (!useRoot) return crashLogs
         return """
             echo "@@BATTERYSTATS@@"; dumpsys batterystats $p 2>/dev/null
             echo "@@JOBS@@"; dumpsys jobscheduler 2>/dev/null | grep -c $p
             echo "@@ALARMS@@"; dumpsys alarm 2>/dev/null | grep -c $p
             echo "@@SENSORS@@"; dumpsys sensorservice 2>/dev/null
             echo "@@LOCATION@@"; dumpsys location 2>/dev/null
-            echo "@@CRASHLOG@@"; logcat -b crash -d -v threadtime -t 400 2>/dev/null
-            echo "@@ANRLOG@@"; logcat -b system -d -v threadtime 2>/dev/null | grep "ANR in" | grep -F $p | tail -n 40
-            echo "@@END@@"
-        """.trimIndent()
+        """.trimIndent() + "\n" + crashLogs
     }
 
     /** Wraps a package name in single quotes, neutralizing any embedded quote, for safe shell use. */

--- a/feature/stats/src/main/kotlin/com/hereliesaz/logkitty/feature/stats/AppStatsCollector.kt
+++ b/feature/stats/src/main/kotlin/com/hereliesaz/logkitty/feature/stats/AppStatsCollector.kt
@@ -186,7 +186,7 @@ class AppStatsCollector(private val context: Context) {
         val p = shellEscape(pkg)
         val crashLogs = """
             echo "@@CRASHLOG@@"; logcat -b crash -d -v threadtime -t 400 2>/dev/null
-            echo "@@ANRLOG@@"; logcat -b system -d -v threadtime 2>/dev/null | grep "ANR in" | grep -F $p | tail -n 40
+            echo "@@ANRLOG@@"; logcat -b system -d -v threadtime -t 2000 2>/dev/null | grep "ANR in" | grep -F $p | tail -n 40
             echo "@@END@@"
         """.trimIndent()
         if (!useRoot) return crashLogs

--- a/feature/stats/src/main/kotlin/com/hereliesaz/logkitty/feature/stats/AppStatsCollector.kt
+++ b/feature/stats/src/main/kotlin/com/hereliesaz/logkitty/feature/stats/AppStatsCollector.kt
@@ -55,9 +55,9 @@ class AppStatsCollector(private val context: Context) {
     }
 
     /**
-     * Collects the fast-changing sections (CPU, memory, GPU/frames, I/O, network). Power stats are
-     * gathered separately via [collectPower] on a slower cadence because `dumpsys batterystats` is
-     * heavy.
+     * Collects the fast-changing sections (CPU, memory, GPU/frames, I/O, network, binder). The
+     * heavier, slower-changing sections (power, sensors, crash history) are gathered separately via
+     * [collectSlow] on a slower cadence because `dumpsys batterystats` and friends are expensive.
      */
     suspend fun collect(pkg: String, label: String, useRoot: Boolean): AppStats {
         if (pkg != lastPackage) {
@@ -108,29 +108,45 @@ class AppStatsCollector(private val context: Context) {
         val gpu = parseGpu(sections)
         val health = parseHealth(sections, pids, dtSec)
         val components = parseComponents(sections["SERVICES"])
+        val binder = parseBinder(sections, pids)
 
         prevSampleNanos = nowNanos
         return AppStats(
             packageName = pkg, label = label, rootUsed = true, processFound = true,
             pids = pids, collectedAtMs = now, cpu = cpu, memory = memory, gpu = gpu,
-            network = network, health = health, components = components, notes = notes,
+            network = network, health = health, components = components, binder = binder,
+            notes = notes,
         )
     }
 
-    /** Heavier, slower-changing power/scheduling stats. Safe to call less frequently. */
-    suspend fun collectPower(pkg: String, useRoot: Boolean): PowerStats {
+    /**
+     * Heavier, slower-changing sections, gathered together in one shell invocation to amortize the
+     * cost: power/scheduling, sensor + location usage, and crash/ANR history. Safe to call on a
+     * slower cadence than [collect].
+     *
+     * Crash history rides the same call but is special: it comes from the logcat **crash** buffer,
+     * so it works even without root (the app already holds `READ_LOGS`). The `dumpsys`-based power
+     * and sensor sections degrade to `null` on a non-rooted device.
+     */
+    suspend fun collectSlow(pkg: String, useRoot: Boolean): SlowStats {
         val (level, temp, charging) = readBattery()
-        if (!useRoot) {
-            return PowerStats(null, null, null, null, level, temp, charging)
-        }
-        val raw = RootShell.run(buildPowerScript(pkg), useRoot = true, timeoutMs = 6000)
+        val raw = RootShell.run(buildSlowScript(pkg), useRoot = useRoot, timeoutMs = 8000)
         val sections = if (raw != null) splitSections(raw) else emptyMap()
-        val bs = sections["BATTERYSTATS"].orEmpty()
-        val wakelockCount = Regex("Wake lock", RegexOption.IGNORE_CASE).findAll(bs).count().takeIf { it > 0 }
-        val partialMs = parsePartialWakelockMs(bs)
-        val jobs = sections["JOBS"]?.trim()?.toIntOrNull()?.takeIf { it >= 0 }
-        val alarms = sections["ALARMS"]?.trim()?.toIntOrNull()?.takeIf { it >= 0 }
-        return PowerStats(wakelockCount, partialMs, jobs, alarms, level, temp, charging)
+
+        val power = if (useRoot) {
+            val bs = sections["BATTERYSTATS"].orEmpty()
+            val wakelockCount = Regex("Wake lock", RegexOption.IGNORE_CASE).findAll(bs).count().takeIf { it > 0 }
+            val partialMs = parsePartialWakelockMs(bs)
+            val jobs = sections["JOBS"]?.trim()?.toIntOrNull()?.takeIf { it >= 0 }
+            val alarms = sections["ALARMS"]?.trim()?.toIntOrNull()?.takeIf { it >= 0 }
+            PowerStats(wakelockCount, partialMs, jobs, alarms, level, temp, charging)
+        } else {
+            PowerStats(null, null, null, null, level, temp, charging)
+        }
+
+        val sensors = parseSensors(sections["SENSORS"], sections["LOCATION"], pkg)
+        val crashes = parseCrashes(sections["CRASHLOG"], sections["ANRLOG"], pkg)
+        return SlowStats(power = power, sensors = sensors, crashes = crashes)
     }
 
     // ---------------------------------------------------------------------------------------------
@@ -152,6 +168,7 @@ class AppStatsCollector(private val context: Context) {
               echo "@@PIO ${'$'}pp@@"; cat /proc/${'$'}pp/io 2>/dev/null
               echo "@@PFD ${'$'}pp@@"; ls /proc/${'$'}pp/fd 2>/dev/null | wc -l
               echo "@@PTASKS ${'$'}pp@@"; cat /proc/${'$'}pp/task/*/stat 2>/dev/null
+              echo "@@BINDER ${'$'}pp@@"; cat /sys/kernel/debug/binder/proc/${'$'}pp 2>/dev/null
             done
             echo "@@MEMINFO@@"; dumpsys meminfo $p 2>/dev/null
             echo "@@GFXINFO@@"; dumpsys gfxinfo $p 2>/dev/null
@@ -160,12 +177,16 @@ class AppStatsCollector(private val context: Context) {
         """.trimIndent()
     }
 
-    private fun buildPowerScript(pkg: String): String {
+    private fun buildSlowScript(pkg: String): String {
         val p = shellEscape(pkg)
         return """
             echo "@@BATTERYSTATS@@"; dumpsys batterystats $p 2>/dev/null
             echo "@@JOBS@@"; dumpsys jobscheduler 2>/dev/null | grep -c $p
             echo "@@ALARMS@@"; dumpsys alarm 2>/dev/null | grep -c $p
+            echo "@@SENSORS@@"; dumpsys sensorservice 2>/dev/null
+            echo "@@LOCATION@@"; dumpsys location 2>/dev/null
+            echo "@@CRASHLOG@@"; logcat -b crash -d -v threadtime -t 400 2>/dev/null
+            echo "@@ANRLOG@@"; logcat -b system -d -v threadtime 2>/dev/null | grep "ANR in" | grep -F $p | tail -n 40
             echo "@@END@@"
         """.trimIndent()
     }
@@ -214,6 +235,145 @@ class AppStatsCollector(private val context: Context) {
         if (names.isEmpty()) return null
         return ComponentStats(runningServiceCount = names.size, runningServices = names.take(12))
     }
+
+    /**
+     * Sums the binder footprint across the app's pids from `/sys/kernel/debug/binder/proc/<pid>`.
+     * Each pid's dump lists one indented line per `thread`, `node`, `ref`, and `pending transaction`;
+     * we just count them. Returns `null` when no pid's file was readable (non-root or debugfs off).
+     */
+    private fun parseBinder(sections: Map<String, String>, pids: List<Int>): BinderStats? {
+        var threads = 0
+        var nodes = 0
+        var refs = 0
+        var pending = 0
+        var any = false
+        for (pid in pids) {
+            val dump = sections["BINDER $pid"]
+            if (dump.isNullOrBlank()) continue
+            any = true
+            for (raw in dump.lineSequence()) {
+                val line = raw.trim()
+                when {
+                    line.startsWith("thread ") -> threads++
+                    line.startsWith("node ") -> nodes++
+                    line.startsWith("ref ") -> refs++
+                    line.startsWith("pending transaction") -> pending++
+                }
+            }
+        }
+        if (!any) return null
+        return BinderStats(
+            threads = threads.takeIf { it > 0 },
+            nodes = nodes.takeIf { it > 0 },
+            refs = refs.takeIf { it > 0 },
+            pendingTransactions = pending,
+        )
+    }
+
+    /**
+     * Best-effort sensor + location usage. `dumpsys sensorservice` lists one block per
+     * "Connection Number:"; we keep the blocks naming our package and keyword-match the sensor types
+     * inside them. `dumpsys location` is split into `<provider> provider:` blocks; a provider counts
+     * as in-use if our package appears in its block. Returns `null` when nothing is attributable.
+     */
+    private fun parseSensors(sensorDump: String?, locationDump: String?, pkg: String): SensorStats? {
+        var connCount: Int? = null
+        val sensors = LinkedHashSet<String>()
+        if (!sensorDump.isNullOrBlank()) {
+            var matched = 0
+            for (block in sensorDump.split(Regex("(?=Connection Number:)"))) {
+                if (!block.contains(pkg)) continue
+                matched++
+                for (kw in SENSOR_KEYWORDS) {
+                    if (block.contains(kw, ignoreCase = true)) sensors.add(kw)
+                }
+            }
+            if (matched > 0) connCount = matched
+        }
+
+        var locationActive: Boolean? = null
+        val providers = LinkedHashSet<String>()
+        if (!locationDump.isNullOrBlank()) {
+            for (block in locationDump.split(Regex("(?m)(?=^\\s*\\w+ provider:)"))) {
+                val header = PROVIDER_HEADER.find(block)?.groupValues?.get(1) ?: continue
+                if (block.contains(pkg)) providers.add(header)
+            }
+            locationActive = providers.isNotEmpty() || locationDump.contains(pkg)
+        }
+
+        if (connCount == null && sensors.isEmpty() && locationActive == null && providers.isEmpty()) {
+            return null
+        }
+        return SensorStats(connCount, sensors.toList(), locationActive, providers.toList())
+    }
+
+    /**
+     * Parses recent crashes from the logcat `crash` buffer and ANRs from the grepped system log.
+     * Crashes are attributed by the `Process: <pkg>` line (Java) or the `>>> <pkg> <<<` marker
+     * (native tombstone). Returns `null` when there's no readable data or nothing for this package.
+     */
+    private fun parseCrashes(crashLog: String?, anrLog: String?, pkg: String): CrashStats? {
+        if (crashLog.isNullOrBlank() && anrLog.isNullOrBlank()) return null
+
+        var crashCount = 0
+        var lastCrashWhen: String? = null
+        var lastCrashSummary: String? = null
+        if (!crashLog.isNullOrBlank()) {
+            val lines = crashLog.lines()
+            var i = 0
+            while (i < lines.size) {
+                val line = lines[i]
+                if (line.contains("FATAL EXCEPTION")) {
+                    var matched = false
+                    var summary: String? = null
+                    val limit = minOf(i + 6, lines.size)
+                    var j = i + 1
+                    while (j < limit) {
+                        val l = lines[j]
+                        if (l.contains("Process: $pkg,") || l.contains("Process: $pkg ")) matched = true
+                        if (summary == null && matched && l.contains("AndroidRuntime") &&
+                            !l.contains("FATAL EXCEPTION") && !l.contains("Process:")
+                        ) {
+                            summary = l.substringAfter("AndroidRuntime:").trim().take(160)
+                        }
+                        j++
+                    }
+                    if (matched) {
+                        crashCount++
+                        lastCrashWhen = parseLogTime(line)
+                        if (summary != null) lastCrashSummary = summary
+                    }
+                } else if (line.contains(">>> $pkg <<<")) {
+                    crashCount++
+                    lastCrashWhen = parseLogTime(line)
+                    lastCrashSummary = (i + 1 until minOf(i + 4, lines.size))
+                        .map { lines[it] }.firstOrNull { it.contains("signal ") }
+                        ?.substringAfter("DEBUG")?.trimStart(':', ' ', '\t')?.take(160)
+                        ?: "native crash"
+                }
+                i++
+            }
+        }
+
+        var anrCount = 0
+        var lastAnrWhen: String? = null
+        var lastAnrSummary: String? = null
+        if (!anrLog.isNullOrBlank()) {
+            for (line in anrLog.lineSequence()) {
+                if (!line.contains("ANR in")) continue
+                anrCount++
+                lastAnrWhen = parseLogTime(line)
+                lastAnrSummary = line.substringAfter("ANR in").trim().take(160)
+            }
+        }
+
+        if (crashCount == 0 && anrCount == 0) return null
+        return CrashStats(crashCount, anrCount, lastCrashWhen, lastCrashSummary, lastAnrWhen, lastAnrSummary)
+    }
+
+    /** Extracts the leading `MM-DD HH:MM:SS` from a `-v threadtime` logcat line, or null. */
+    private fun parseLogTime(line: String): String? =
+        LOG_TIME.find(line.trimStart())?.groupValues?.get(1)
 
     private fun parseCpu(sections: Map<String, String>, pids: List<Int>): CpuStats? {
         val cpuLine = sections["CPU"]?.trim() ?: return null
@@ -495,5 +655,23 @@ class AppStatsCollector(private val context: Context) {
         private val MARKER = Regex("""@@([A-Z]+(?: \d+)?)@@""")
         // Captures the class name from `ServiceRecord{hash u0 pkg/<Name> ...}` (running service).
         private val SERVICE_RECORD = Regex("""ServiceRecord\{[^}]*/([^\s}]+)""")
+        // `<provider> provider:` section header in `dumpsys location`.
+        private val PROVIDER_HEADER = Regex("""(?m)^\s*(\w+) provider:""")
+        // Leading timestamp of a `-v threadtime` logcat line: "MM-DD HH:MM:SS".
+        private val LOG_TIME = Regex("""^(\d{2}-\d{2} \d{2}:\d{2}:\d{2})""")
+        // Common sensor type names to look for inside a connection block (format-tolerant).
+        private val SENSOR_KEYWORDS = listOf(
+            "Accelerometer", "Gyroscope", "Magnetometer", "Magnetic", "Orientation", "Light",
+            "Proximity", "Pressure", "Gravity", "Linear Acceleration", "Rotation Vector",
+            "Game Rotation", "Significant Motion", "Step Counter", "Step Detector", "Heart Rate",
+            "Temperature", "Humidity",
+        )
     }
 }
+
+/** The slower-cadence sections gathered together by [AppStatsCollector.collectSlow]. */
+data class SlowStats(
+    val power: PowerStats,
+    val sensors: SensorStats?,
+    val crashes: CrashStats?,
+)

--- a/feature/stats/src/main/kotlin/com/hereliesaz/logkitty/feature/stats/StatsFeatureImpl.kt
+++ b/feature/stats/src/main/kotlin/com/hereliesaz/logkitty/feature/stats/StatsFeatureImpl.kt
@@ -39,15 +39,21 @@ class StatsFeatureImpl : StatsFeature {
             // thread. delay() is the cancellation point that breaks the loop.
             withContext(Dispatchers.IO) {
                 val collector = AppStatsCollector(appContext)
-                var cachedPower = collector.collectPower(packageName, useRoot)
+                var cachedSlow = collector.collectSlow(packageName, useRoot)
                 val buffer = ArrayDeque<AppStats>()
                 var iteration = 0
                 while (true) {
                     val snapshot = collector.collect(packageName, label, useRoot)
-                    if (iteration % POWER_REFRESH_EVERY == 0 && iteration != 0) {
-                        cachedPower = collector.collectPower(packageName, useRoot)
+                    if (iteration % SLOW_REFRESH_EVERY == 0 && iteration != 0) {
+                        cachedSlow = collector.collectSlow(packageName, useRoot)
                     }
-                    buffer.addLast(snapshot.copy(power = cachedPower))
+                    buffer.addLast(
+                        snapshot.copy(
+                            power = cachedSlow.power,
+                            sensors = cachedSlow.sensors,
+                            crashes = cachedSlow.crashes,
+                        ),
+                    )
                     while (buffer.size > HISTORY_MAX) buffer.removeFirst()
                     value = buffer.toList()
                     iteration++
@@ -61,7 +67,7 @@ class StatsFeatureImpl : StatsFeature {
 
     private companion object {
         const val FAST_INTERVAL_MS = 2000L
-        const val POWER_REFRESH_EVERY = 5
+        const val SLOW_REFRESH_EVERY = 5
         const val HISTORY_MAX = 45 // ~90s of trend at the 2s cadence
     }
 }

--- a/feature/stats/src/main/kotlin/com/hereliesaz/logkitty/feature/stats/StatsFeatureImpl.kt
+++ b/feature/stats/src/main/kotlin/com/hereliesaz/logkitty/feature/stats/StatsFeatureImpl.kt
@@ -7,8 +7,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontFamily
 import com.hereliesaz.logkitty.core.feature.StatsFeature
+import java.util.concurrent.atomic.AtomicReference
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 /**
@@ -39,25 +41,35 @@ class StatsFeatureImpl : StatsFeature {
             // thread. delay() is the cancellation point that breaks the loop.
             withContext(Dispatchers.IO) {
                 val collector = AppStatsCollector(appContext)
-                var cachedSlow = collector.collectSlow(packageName, useRoot)
                 val buffer = ArrayDeque<AppStats>()
-                var iteration = 0
-                while (true) {
-                    val snapshot = collector.collect(packageName, label, useRoot)
-                    if (iteration % SLOW_REFRESH_EVERY == 0 && iteration != 0) {
-                        cachedSlow = collector.collectSlow(packageName, useRoot)
+                // collectSlow fires several heavy dumpsys/logcat shells under an 8s timeout. Running
+                // it inline would stall the 2s fast loop (live CPU/mem/GPU) and block the first frame
+                // until it finished, so run it in its own coroutine and just read the latest result.
+                // AtomicReference gives a clean happens-before across the two IO-pool threads.
+                val cachedSlow = AtomicReference<SlowStats?>(null)
+                val slowJob = launch {
+                    while (true) {
+                        cachedSlow.set(collector.collectSlow(packageName, useRoot))
+                        delay(FAST_INTERVAL_MS * SLOW_REFRESH_EVERY)
                     }
-                    buffer.addLast(
-                        snapshot.copy(
-                            power = cachedSlow.power,
-                            sensors = cachedSlow.sensors,
-                            crashes = cachedSlow.crashes,
-                        ),
-                    )
-                    while (buffer.size > HISTORY_MAX) buffer.removeFirst()
-                    value = buffer.toList()
-                    iteration++
-                    delay(FAST_INTERVAL_MS)
+                }
+                try {
+                    while (true) {
+                        val snapshot = collector.collect(packageName, label, useRoot)
+                        val slow = cachedSlow.get()
+                        buffer.addLast(
+                            snapshot.copy(
+                                power = slow?.power,
+                                sensors = slow?.sensors,
+                                crashes = slow?.crashes,
+                            ),
+                        )
+                        while (buffer.size > HISTORY_MAX) buffer.removeFirst()
+                        value = buffer.toList()
+                        delay(FAST_INTERVAL_MS)
+                    }
+                } finally {
+                    slowJob.cancel()
                 }
             }
         }

--- a/feature/stats/src/main/kotlin/com/hereliesaz/logkitty/feature/stats/StatsView.kt
+++ b/feature/stats/src/main/kotlin/com/hereliesaz/logkitty/feature/stats/StatsView.kt
@@ -191,7 +191,7 @@ private fun SensorSection(s: SensorStats, ff: FontFamily?, fs: Int, lc: Color, v
     StatCard("Sensors & Location", ff, fs) {
         StatRow("Active sensor connections", s.activeSensorConnections?.toString() ?: "—", ff, fs, lc, vc, emphasize = true)
         if (s.activeSensors.isNotEmpty()) {
-            StatRow("Sensors", s.activeSensors.joinToString(", "), ff, fs, lc, vc)
+            WrapStatRow("Sensors", s.activeSensors.joinToString(", "), ff, fs, lc, vc)
         }
         val loc = when (s.locationActive) {
             true -> "Yes"
@@ -200,7 +200,7 @@ private fun SensorSection(s: SensorStats, ff: FontFamily?, fs: Int, lc: Color, v
         }
         StatRow("Location request", loc, ff, fs, lc, vc)
         if (s.locationProviders.isNotEmpty()) {
-            StatRow("Providers", s.locationProviders.joinToString(", "), ff, fs, lc, vc)
+            WrapStatRow("Providers", s.locationProviders.joinToString(", "), ff, fs, lc, vc)
         }
     }
 }
@@ -368,6 +368,21 @@ private fun StatRow(
             maxLines = 1, overflow = TextOverflow.Ellipsis)
         Text(value, color = vc, fontSize = (if (emphasize) fs + 1 else fs - 1).sp, fontFamily = ff,
             fontWeight = if (emphasize) FontWeight.Bold else FontWeight.Normal)
+    }
+}
+
+/**
+ * Like [StatRow] but for a potentially long value (e.g. a comma-joined list). Both texts share the
+ * width via weights, so a long value ellipsizes instead of squeezing the label to zero width.
+ */
+@Composable
+private fun WrapStatRow(label: String, value: String, ff: FontFamily?, fs: Int, lc: Color, vc: Color) {
+    Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+        Text(label, color = lc, fontSize = (fs - 1).sp, fontFamily = ff, modifier = Modifier.weight(1f),
+            maxLines = 1, overflow = TextOverflow.Ellipsis)
+        Spacer(Modifier.width(8.dp))
+        Text(value, color = vc, fontSize = (fs - 1).sp, fontFamily = ff, maxLines = 1,
+            overflow = TextOverflow.Ellipsis, modifier = Modifier.weight(1f, fill = false))
     }
 }
 

--- a/feature/stats/src/main/kotlin/com/hereliesaz/logkitty/feature/stats/StatsView.kt
+++ b/feature/stats/src/main/kotlin/com/hereliesaz/logkitty/feature/stats/StatsView.kt
@@ -96,7 +96,10 @@ fun StatsView(
         stats.network?.let { NetworkSection(it, fontFamily, fontSize, labelColor, valueColor) }
         stats.power?.let { PowerSection(it, fontFamily, fontSize, labelColor, valueColor) }
         stats.health?.let { HealthSection(it, fontFamily, fontSize, labelColor, valueColor) }
+        stats.sensors?.let { SensorSection(it, fontFamily, fontSize, labelColor, valueColor) }
+        stats.binder?.let { BinderSection(it, fontFamily, fontSize, labelColor, valueColor) }
         stats.components?.let { ComponentsSection(it, fontFamily, fontSize, labelColor, valueColor) }
+        stats.crashes?.let { CrashSection(it, fontFamily, fontSize, labelColor, valueColor) }
 
         Spacer(Modifier.height(16.dp))
     }
@@ -177,6 +180,59 @@ private fun ComponentsSection(c: ComponentStats, ff: FontFamily?, fs: Int, lc: C
             Text(
                 svc, color = vc, fontSize = (fs - 1).sp, fontFamily = ff,
                 maxLines = 1, overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.fillMaxWidth().padding(top = 1.dp),
+            )
+        }
+    }
+}
+
+@Composable
+private fun SensorSection(s: SensorStats, ff: FontFamily?, fs: Int, lc: Color, vc: Color) {
+    StatCard("Sensors & Location", ff, fs) {
+        StatRow("Active sensor connections", s.activeSensorConnections?.toString() ?: "—", ff, fs, lc, vc, emphasize = true)
+        if (s.activeSensors.isNotEmpty()) {
+            StatRow("Sensors", s.activeSensors.joinToString(", "), ff, fs, lc, vc)
+        }
+        val loc = when (s.locationActive) {
+            true -> "Yes"
+            false -> "No"
+            null -> "—"
+        }
+        StatRow("Location request", loc, ff, fs, lc, vc)
+        if (s.locationProviders.isNotEmpty()) {
+            StatRow("Providers", s.locationProviders.joinToString(", "), ff, fs, lc, vc)
+        }
+    }
+}
+
+@Composable
+private fun BinderSection(b: BinderStats, ff: FontFamily?, fs: Int, lc: Color, vc: Color) {
+    StatCard("Binder / IPC", ff, fs) {
+        StatRow("Binder threads", b.threads?.toString() ?: "—", ff, fs, lc, vc, emphasize = true)
+        StatRow("Nodes", b.nodes?.toString() ?: "—", ff, fs, lc, vc)
+        StatRow("Refs", b.refs?.toString() ?: "—", ff, fs, lc, vc)
+        StatRow("Pending transactions", b.pendingTransactions?.toString() ?: "—", ff, fs, lc, vc)
+    }
+}
+
+@Composable
+private fun CrashSection(c: CrashStats, ff: FontFamily?, fs: Int, lc: Color, vc: Color) {
+    StatCard("Crashes & ANRs", ff, fs) {
+        StatRow("Recent crashes", c.crashCount.toString(), ff, fs, lc, vc, emphasize = true)
+        c.lastCrashWhen?.let { StatRow("Last crash", it, ff, fs, lc, vc) }
+        c.lastCrashSummary?.let {
+            Text(
+                it, color = vc, fontSize = (fs - 1).sp, fontFamily = ff,
+                maxLines = 2, overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.fillMaxWidth().padding(top = 1.dp, bottom = 2.dp),
+            )
+        }
+        StatRow("Recent ANRs", c.anrCount.toString(), ff, fs, lc, vc, emphasize = true)
+        c.lastAnrWhen?.let { StatRow("Last ANR", it, ff, fs, lc, vc) }
+        c.lastAnrSummary?.let {
+            Text(
+                it, color = vc, fontSize = (fs - 1).sp, fontFamily = ff,
+                maxLines = 2, overflow = TextOverflow.Ellipsis,
                 modifier = Modifier.fillMaxWidth().padding(top = 1.dp),
             )
         }


### PR DESCRIPTION
## Stats v2 — increment 2: the three deferred ideas

Closes out the items parked from increment 1 (#146). All additive and self-contained in `:feature:stats`; existing sections are untouched, and every new parser returns `null` on unrecognized output so a bad parse can only **hide** a section, never crash the view.

### Sensors & Location (root, best-effort)
Parses `dumpsys sensorservice` (per-`Connection Number:` block for the package, keyword-matched sensor types) and `dumpsys location` (per-`<provider> provider:` block). Surfaces quiet sensor/GPS holds — a classic hard-to-spot battery drain.

### Crashes & ANRs (works **without root**)
Reads the logcat **crash** buffer (attributed by the `Process: <pkg>` line for Java crashes and the `>>> <pkg> <<<` marker for native tombstones) and the system log (`ANR in <pkg>`). This only needs the `READ_LOGS` grant the app already relies on — so it's the one Stats v2 section that works on a non-rooted device. Shows recent crash/ANR counts plus the most-recent timestamp and summary.

### Binder / IPC (root + debugfs)
Counts `thread` / `node` / `ref` / `pending transaction` lines from `/sys/kernel/debug/binder/proc/<pid>`, summed across the app's pids. High node/ref counts or pending transactions hint at chatty or leaking IPC.

### Plumbing
- Folds the old `collectPower` into a broader `collectSlow` that gathers power + sensors + crash history in **one** slow-cadence shell invocation (binder rides the existing fast root batch).
- New data classes `SensorStats`, `CrashStats`, `BinderStats`, and the `SlowStats` bundle.

### Verified vs. not
- ✅ Self-contained; single `StatsView` caller wired up; null-degradation by construction.
- ❌ **Not built here** (sandbox can't run Gradle) — relying on CI. The `dumpsys sensorservice` / `location` and `/sys/kernel/debug/binder` parsers need an on-device check against real output; worst case a section shows nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GSxjeuLJyBVyFhGXcxbkSe)_

## Summary by Sourcery

Add new slow-cadence stats for sensors, crash history, and binder IPC, and surface them in the stats UI while integrating them into the existing fast/slow collection loop.

New Features:
- Introduce SensorStats, CrashStats, BinderStats, and SlowStats data models for additional app diagnostics.
- Add parsing and collection of sensor/location usage, crash/ANR history, and binder/IPC metrics from system dumps.
- Display new Sensors & Location, Binder / IPC, and Crashes & ANRs sections in the StatsView UI.

Enhancements:
- Refactor power collection into a broader slow stats collection pipeline with separate fast and slow loops to avoid blocking the UI.
- Extend fast root batch collection to include binder debug information from kernel debugfs or binderfs.
- Improve stat row layout handling for long values with a dedicated wrapped row composable.