### PR TITLE
Drop foojay-resolver plugin to clear build-classpath Netty CVEs

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -40,10 +40,10 @@ jobs:
             echo "Warning: google-services.json.template not found. Skipping injection."
           fi
 
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
 
       - name: Setup Gradle

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,11 +27,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up JDK 19
+      - name: Set up JDK 21
         uses: actions/setup-java@v4.1.0
         with:
           distribution: 'temurin'
-          java-version: '19'
+          java-version: '21'
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3

--- a/.github/workflows/play-publish.yml
+++ b/.github/workflows/play-publish.yml
@@ -53,10 +53,10 @@ jobs:
             echo "Warning: google-services.json.template not found. Skipping injection."
           fi
 
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
 
       - name: Setup Gradle

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,9 +11,6 @@ pluginManagement {
         gradlePluginPortal()
     }
 }
-plugins {
-    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
-}
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {


### PR DESCRIPTION
## What

Removes the `org.gradle.toolchains.foojay-resolver-convention` settings plugin and provides **JDK 21 directly in CI** instead.

## Why

Dependabot flagged a cluster of Netty CVEs (#35, #36, #37, #38, #39, #40, #41) against `settings.gradle.kts`:

| Severity | Advisory | Component |
| --- | --- | --- |
| High | IPv6 Subnet Filter Bypass (incorrect comparator masking) | netty-handler |
| High | SNI handler pre-allocates up to 16 MiB from nine attacker bytes | netty-handler |
| High | Wrapping plain trust manager silently disables hostname verification | netty-handler |
| Moderate | HTTP/2 Reset Attack with different on-the-wire signature | netty-codec-http2 |
| Moderate | ByteBuf ref-count leak in DelegatingDecompressorFrameListener | netty-codec-http2 |
| Moderate | Advertised MAX_CONCURRENT_STREAMS not enforced | netty-codec-http2 |
| Moderate | HttpObjectDecoder skips arbitrary initial control characters | netty-codec-http |

**These are build-time only — Netty never ships in the app's APK/AAB**, so there is no runtime exposure for end users. The risk is confined to the build environment.

Netty rode in transitively via the **foojay-resolver** settings plugin (its JDK-discovery HTTP client). The repo already force-pins a safe Netty in the root `build.gradle.kts` `buildscript {}` block — but that governs the *root project's* classpath, whereas a settings plugin's classpath is resolved during settings evaluation, separately. That mismatch is exactly why the alerts kept pointing at `settings.gradle.kts`. The plugin is already on its latest version (1.0.0), so a bump wouldn't help.

## How

The plugin's sole purpose here was auto-downloading a **JDK 21** toolchain, because CI ran on JDK 17/19 while every module targets `jvmToolchain(21)`. If CI sets up JDK 21 directly, the Gradle-running JVM already satisfies the toolchain and no download is needed — making the plugin (and its Netty) dead weight.

- `settings.gradle.kts`: remove the `foojay-resolver-convention` plugin.
- `build-and-release.yml`, `play-publish.yml`, `codeql.yml`: `setup-java` 17/19 → **21**.

Side benefit: CI no longer downloads a JDK on every run.

## Verification
- ❌ Not built here (sandbox can't reach the Gradle plugin portal) — relying on CI. The key thing CI proves is that the build still resolves the JDK 21 toolchain from the directly-installed JDK with foojay gone.
- Once merged, the Dependabot Netty alerts against `settings.gradle.kts` should auto-close on the next dependency-graph submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GSxjeuLJyBVyFhGXcxbkSe)_

## Summary by Sourcery

Remove the Foojay toolchains resolver plugin and standardize CI to run builds and analysis on JDK 21 to eliminate build-classpath Netty vulnerabilities.

Build:
- Update GitHub Actions workflows to use Temurin JDK 21 instead of JDK 17/19 for build, release, and publishing jobs.

CI:
- Align CodeQL and other CI workflows to JDK 21 so Gradle toolchains no longer require the Foojay resolver plugin.

Chores:
- Drop the org.gradle.toolchains.foojay-resolver-convention settings plugin to remove its transitive Netty dependency from the build classpath.