### PR TITLE
Clear Pause and Stop buttons in the overlay notification

### DIFF
--- a/app/src/main/kotlin/com/hereliesaz/logkitty/services/LogKittyOverlayService.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/services/LogKittyOverlayService.kt
@@ -291,6 +291,9 @@ class LogKittyOverlayService : Service() {
     private fun createNotification(): Notification {
         val isPaused = (applicationContext as MainApplication).mainViewModel.isPaused.value
 
+        // Tapping the body opens LogKitty; capture/teardown are driven by the explicit actions below.
+        val openIntent = Intent(this, MainActivity::class.java).apply { addFlags(Intent.FLAG_ACTIVITY_NEW_TASK) }
+        val openPending = PendingIntent.getActivity(this, 3, openIntent, PendingIntent.FLAG_IMMUTABLE)
         val stopIntent = Intent(this, LogKittyOverlayService::class.java).apply { action = ACTION_STOP_SERVICE }
         val stopPending = PendingIntent.getService(this, 0, stopIntent, PendingIntent.FLAG_IMMUTABLE)
         val settingsIntent = Intent(this, LogKittyOverlayService::class.java).apply { action = ACTION_OPEN_SETTINGS }
@@ -304,15 +307,15 @@ class LogKittyOverlayService : Service() {
                 if (isPaused) getString(R.string.notif_text_paused) else getString(R.string.notif_text_running)
             )
             .setSmallIcon(android.R.drawable.ic_menu_view)
-            // Body tap and the "Turn Off" action both stop the service (tears down the overlay).
-            .setContentIntent(stopPending)
-            // Start/Stop toggles log capture (mirrors the sheet's play/pause).
+            .setContentIntent(openPending)
+            // Pause/Resume toggles log capture (mirrors the sheet's play/pause control).
             .addAction(
                 if (isPaused) android.R.drawable.ic_media_play else android.R.drawable.ic_media_pause,
-                if (isPaused) getString(R.string.notif_action_start) else getString(R.string.notif_action_stop),
+                if (isPaused) getString(R.string.notif_action_resume) else getString(R.string.notif_action_pause),
                 pausePending
             )
-            .addAction(android.R.drawable.ic_menu_close_clear_cancel, getString(R.string.notif_action_turn_off), stopPending)
+            // Stop tears down the overlay and the foreground service entirely.
+            .addAction(android.R.drawable.ic_menu_close_clear_cancel, getString(R.string.notif_action_stop), stopPending)
             .addAction(android.R.drawable.ic_menu_preferences, getString(R.string.notif_action_app_settings), settingsPending)
             .setOngoing(true)
             .setForegroundServiceBehavior(NotificationCompat.FOREGROUND_SERVICE_IMMEDIATE)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -155,11 +155,11 @@
     <!-- Notifications (overlay service) -->
     <string name="notif_channel_name">Overlay Service</string>
     <string name="notif_title">LogKitty is running</string>
-    <string name="notif_text_paused">Logging paused. Tap to turn off.</string>
-    <string name="notif_text_running">Logging. Tap to turn off.</string>
-    <string name="notif_action_start">Start</string>
+    <string name="notif_text_paused">Logging paused.</string>
+    <string name="notif_text_running">Logging.</string>
+    <string name="notif_action_pause">Pause</string>
+    <string name="notif_action_resume">Resume</string>
     <string name="notif_action_stop">Stop</string>
-    <string name="notif_action_turn_off">Turn Off LogKitty</string>
     <string name="notif_action_app_settings">App Settings</string>
 
     <!-- Permissions section -->


### PR DESCRIPTION
## What

Makes the overlay foreground-service notification show two clearly-labeled controls: **Pause/Resume** and **Stop**.

## Why

The notification already had a pause toggle and a stop action, but the labels were misleading:
- The pause toggle read **"Stop"** (running) / **"Start"** (paused) — so the button that merely *pauses logging* read "Stop".
- The actual service-stop action read **"Turn Off LogKitty"**.
- Tapping the notification body *also* silently stopped the service.

Net effect: two different "stop-ish" labels, neither of which clearly said "Pause."

## How

- **Pause toggle → "Pause" / "Resume"** (play/pause icon unchanged), still calls `ACTION_TOGGLE_PAUSE`.
- **Service-stop action → "Stop"** (calls `ACTION_STOP_SERVICE`, tears down the overlay + foreground service).
- **Body tap now opens LogKitty** (`MainActivity`) instead of stopping the service — Stop has its own explicit button now. The body text drops the now-stale "Tap to turn off."
- Removed the unused `notif_action_start` / `notif_action_turn_off` strings; added `notif_action_pause` / `notif_action_resume`.

This also makes the FGS demonstration video clearer (the notification's Pause/Stop controls are now self-explanatory for the `FOREGROUND_SERVICE_SPECIAL_USE` review).

## Verification
- ❌ Not built here (sandbox can't run Gradle) — relying on CI. Changes are confined to notification construction + string resources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GSxjeuLJyBVyFhGXcxbkSe)_

## Summary by Sourcery

Clarify and separate pause/resume vs stop controls in the overlay foreground-service notification.

New Features:
- Make tapping the notification body open the main LogKitty activity instead of stopping the service.

Bug Fixes:
- Prevent inadvertent service stops by removing the implicit stop behavior from tapping the notification body.

Enhancements:
- Rename and relabel notification actions so the primary control clearly indicates Pause/Resume while a separate Stop button terminates the overlay service.
- Simplify notification body text to remove outdated instructions about tapping to turn off logging.