### PR TITLE
Banner ad at the bottom of the log (HALF/FULL detents)

### DIFF
--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/AdBannerSlot.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/AdBannerSlot.kt
@@ -1,0 +1,57 @@
+package com.hereliesaz.logkitty.ui
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import com.hereliesaz.logkitty.BuildConfig
+import com.hereliesaz.logkitty.core.feature.AdsFeature
+import com.hereliesaz.logkitty.core.feature.FeatureLoader
+import com.hereliesaz.logkitty.core.feature.FeatureModules
+import com.hereliesaz.logkitty.feature.FeatureInstallStatus
+import com.hereliesaz.logkitty.feature.rememberFeatureInstall
+
+/**
+ * Reusable AdMob banner slot.
+ *
+ * The AdMob SDK and the [com.google.android.gms.ads.AdView] live in the on-demand `:feature:ads`
+ * module (so `play-services-ads` and the `AD_ID` permission ship only with it). This composable
+ * installs that module in the background on first composition, loads the [AdsFeature] entry point
+ * reflectively, and renders the banner once present.
+ *
+ * It occupies **no layout space until the ad is ready**, so callers can drop it at the bottom of a
+ * layout (Settings, the log sheet) without reserving an empty gap when ads aren't available yet.
+ *
+ * The unit ID comes from [BuildConfig.ADMOB_BANNER_UNIT_ID]: Google's test unit for debug, the real
+ * unit for release when configured in local.properties/env. The app ID lives in AndroidManifest;
+ * SDK init happens here via [AdsFeature.initialize]. TODO: add a UMP consent flow before serving
+ * personalized ads.
+ *
+ * @param showTopDivider draws a hairline divider above the banner — but only once the banner is
+ *   actually rendered, so no stray line is left behind when ads aren't available.
+ */
+@Composable
+fun AdBannerSlot(modifier: Modifier = Modifier, showTopDivider: Boolean = false) {
+    val context = LocalContext.current
+    val handle = rememberFeatureInstall(FeatureModules.ADS)
+    LaunchedEffect(Unit) { handle.install() }
+    if (handle.status is FeatureInstallStatus.Installed) {
+        val ads = remember { FeatureLoader.load<AdsFeature>(FeatureModules.ADS_IMPL, context) }
+        if (ads != null) {
+            LaunchedEffect(ads) { ads.initialize(context.applicationContext) }
+            if (showTopDivider) {
+                Column(modifier = modifier) {
+                    HorizontalDivider(color = Color.White.copy(alpha = 0.08f))
+                    ads.BannerAd(BuildConfig.ADMOB_BANNER_UNIT_ID, Modifier.fillMaxWidth())
+                }
+            } else {
+                ads.BannerAd(BuildConfig.ADMOB_BANNER_UNIT_ID, modifier)
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/LogBottomSheet.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/LogBottomSheet.kt
@@ -500,6 +500,11 @@ private fun ExpandedView(
                 }
             }
         }
+
+        // --- Banner ad, pinned to the bottom of the expanded sheet (HALF / FULL only). ---
+        // Takes no space (and shows no divider) until the on-demand :feature:ads module is installed
+        // and the ad loads, so it never leaves an empty gap below the log.
+        AdBannerSlot(modifier = Modifier.fillMaxWidth(), showTopDivider = true)
     }
 }
 

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/SettingsScreen.kt
@@ -555,7 +555,7 @@ private fun SettingsMainScreen(
             SettingsFooter(context)
 
             Spacer(modifier = Modifier.height(16.dp))
-            SettingsAdBanner()
+            AdBannerSlot()
 
             // Large trailing margin so the footer can be scrolled well up the screen.
             Spacer(modifier = Modifier.height(240.dp))
@@ -629,35 +629,6 @@ private fun SettingsFooter(context: android.content.Context) {
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             modifier = Modifier.padding(top = 8.dp)
         )
-    }
-}
-
-/**
- * AdMob banner shown at the bottom of Settings. The unit ID comes from build config
- * (BuildConfig.ADMOB_BANNER_UNIT_ID): Google's test unit for debug, the real unit for release when
- * configured in local.properties/env. The app ID lives in AndroidManifest; SDK init is in
- * MainApplication. TODO: add a UMP consent flow before serving personalized ads.
- */
-@Composable
-private fun SettingsAdBanner() {
-    val context = LocalContext.current
-    // The AdMob SDK + AdView live in the on-demand :feature:ads module (so play-services-ads and
-    // the AD_ID permission ship only with it). Fetch it silently in the background on first Settings
-    // view, then load the entry point reflectively and render the banner once present.
-    val handle = com.hereliesaz.logkitty.feature.rememberFeatureInstall(
-        com.hereliesaz.logkitty.core.feature.FeatureModules.ADS
-    )
-    androidx.compose.runtime.LaunchedEffect(Unit) { handle.install() }
-    if (handle.status is com.hereliesaz.logkitty.feature.FeatureInstallStatus.Installed) {
-        val ads = remember {
-            com.hereliesaz.logkitty.core.feature.FeatureLoader.load<com.hereliesaz.logkitty.core.feature.AdsFeature>(
-                com.hereliesaz.logkitty.core.feature.FeatureModules.ADS_IMPL, context
-            )
-        }
-        if (ads != null) {
-            androidx.compose.runtime.LaunchedEffect(ads) { ads.initialize(context.applicationContext) }
-            ads.BannerAd(BuildConfig.ADMOB_BANNER_UNIT_ID, Modifier)
-        }
     }
 }
 


### PR DESCRIPTION
## What

Adds an AdMob banner to the bottom of the log sheet at the **HALF** and **FULL** detents.

## How

- **New `AdBannerSlot` composable** — extracts the existing Settings banner logic into one reusable slot. It installs the on-demand `:feature:ads` module in the background, loads the `AdsFeature` entry point reflectively, and renders the banner. Crucially it **occupies no layout space until the ad is ready**, so it never leaves an empty gap below the log when ads aren't installed/loaded yet.
- **`LogBottomSheet`** — drops `AdBannerSlot` at the bottom of `ExpandedView`, which is rendered only for `HALF` and `FULL` (PEEK/HIDDEN strips are untouched). A hairline top divider separates it from the log, and is itself gated on the ad rendering (no stray line when there's no ad).
- **`SettingsScreen`** — now reuses `AdBannerSlot` instead of the private `SettingsAdBanner` it duplicated (same behavior).

The banner sits at the bottom of the expanded sheet for both the Logs and Stats views (it's the bottom of the sheet, above the nav bar). Unit ID is `BuildConfig.ADMOB_BANNER_UNIT_ID` (Google's test unit in debug; real unit in release when configured) — same source the Settings banner already used.

## Verification
- ❌ Not built here (sandbox can't run Gradle) — relying on CI. Changes are confined to three Compose files in `:app`; no new dependencies (the ads module + AdMob SDK were already wired).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GSxjeuLJyBVyFhGXcxbkSe)_

## Summary by Sourcery

Introduce a reusable AdMob banner slot and integrate it into the log bottom sheet and settings screen.

New Features:
- Add a reusable AdBannerSlot composable that lazily installs the ads feature module and displays a banner ad without occupying space until ready.
- Display a banner ad at the bottom of the log bottom sheet in HALF and FULL detents, separated by an optional divider.

Enhancements:
- Refactor the settings screen to reuse the shared AdBannerSlot instead of its own settings-specific ad banner implementation.