### PR TITLE
GitHub Actions Phase 1: PAT + repo Settings with secure store

### DIFF
--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/MainViewModel.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/MainViewModel.kt
@@ -149,13 +149,21 @@ class MainViewModel(
     val tagColoringEnabled: StateFlow<Boolean> = userPreferences.tagColoringEnabled
 
     // GitHub Actions config. Repo coordinates are non-secret (UserPreferences); the PAT lives in the
-    // backup-excluded secure store. setGithubToken(null/blank) clears it.
+    // backup-excluded secure store. Only a boolean is exposed reactively — the decrypted secret is
+    // produced on demand via [readGithubToken] (called off the main thread by the feature panel).
     val githubOwner: StateFlow<String> = userPreferences.githubOwner
     val githubRepo: StateFlow<String> = userPreferences.githubRepo
-    val githubToken: StateFlow<String?> = githubCredentials.token
+    val hasGithubToken: StateFlow<Boolean> = githubCredentials.hasToken
     fun setGithubOwner(owner: String) = userPreferences.setGithubOwner(owner)
     fun setGithubRepo(repo: String) = userPreferences.setGithubRepo(repo)
-    fun setGithubToken(token: String?) = githubCredentials.setToken(token)
+
+    /** Stores/clears the PAT off the main thread (AES/GCM + Keystore work). */
+    fun setGithubToken(token: String?) {
+        viewModelScope.launch(Dispatchers.IO) { githubCredentials.setToken(token) }
+    }
+
+    /** Decrypts the PAT on demand. Call off the main thread (it touches the Keystore). */
+    fun readGithubToken(): String? = githubCredentials.readToken()
 
     /**
      * Per-tab "cleared" baseline. When the user clears a single tab we record the size of the

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/MainViewModel.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/MainViewModel.kt
@@ -74,6 +74,8 @@ class MainViewModel(
 
     // Repositories
     private val userPreferences = UserPreferences(application)
+    // Secure, backup-excluded store for the GitHub PAT (kept out of UserPreferences/backups).
+    private val githubCredentials = com.hereliesaz.logkitty.utils.GitHubCredentials(application)
 
     // Cache of package name -> Android UID (-1 = resolved-but-unknown). Used to filter the log
     // stream to a specific app reliably (UID is stable across process restarts, unlike PID).
@@ -145,6 +147,15 @@ class MainViewModel(
     val activeLogLevels: StateFlow<Set<String>> = userPreferences.activeLogLevels
     val colorScheme: StateFlow<LogColorScheme> = userPreferences.colorScheme
     val tagColoringEnabled: StateFlow<Boolean> = userPreferences.tagColoringEnabled
+
+    // GitHub Actions config. Repo coordinates are non-secret (UserPreferences); the PAT lives in the
+    // backup-excluded secure store. setGithubToken(null/blank) clears it.
+    val githubOwner: StateFlow<String> = userPreferences.githubOwner
+    val githubRepo: StateFlow<String> = userPreferences.githubRepo
+    val githubToken: StateFlow<String?> = githubCredentials.token
+    fun setGithubOwner(owner: String) = userPreferences.setGithubOwner(owner)
+    fun setGithubRepo(repo: String) = userPreferences.setGithubRepo(repo)
+    fun setGithubToken(token: String?) = githubCredentials.setToken(token)
 
     /**
      * Per-tab "cleared" baseline. When the user clears a single tab we record the size of the

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/SettingsScreen.kt
@@ -135,7 +135,7 @@ private fun SettingsMainScreen(
     val activeSourceFilters by viewModel.activeSourceFilters.collectAsState()
     val githubOwner by viewModel.githubOwner.collectAsState()
     val githubRepo by viewModel.githubRepo.collectAsState()
-    val githubToken by viewModel.githubToken.collectAsState()
+    val hasGithubToken by viewModel.hasGithubToken.collectAsState()
 
     var showColorPicker by remember { mutableStateOf(false) }
     var showSchemeMenu by remember { mutableStateOf(false) }
@@ -555,7 +555,7 @@ private fun SettingsMainScreen(
                 modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)
             )
             Text(
-                stringResource(if (githubToken != null) R.string.github_token_saved else R.string.github_token_none),
+                stringResource(if (hasGithubToken) R.string.github_token_saved else R.string.github_token_none),
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier.padding(bottom = 4.dp)

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/SettingsScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Switch
@@ -61,7 +62,11 @@ import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.res.stringResource
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
@@ -128,6 +133,9 @@ private fun SettingsMainScreen(
     val prohibitedCount by viewModel.prohibitedTags.collectAsState()
     val monitoredApps by viewModel.monitoredApps.collectAsState()
     val activeSourceFilters by viewModel.activeSourceFilters.collectAsState()
+    val githubOwner by viewModel.githubOwner.collectAsState()
+    val githubRepo by viewModel.githubRepo.collectAsState()
+    val githubToken by viewModel.githubToken.collectAsState()
 
     var showColorPicker by remember { mutableStateOf(false) }
     var showSchemeMenu by remember { mutableStateOf(false) }
@@ -502,6 +510,80 @@ private fun SettingsMainScreen(
                 keys = LogSources.CATEGORY_BUCKETS,
                 enabled = activeSourceFilters,
                 onToggle = { key, on -> viewModel.setSourceFilterEnabled(key, on) }
+            )
+            HorizontalDivider(modifier = Modifier.padding(vertical = 16.dp))
+
+            SettingsSectionHeader(stringResource(R.string.settings_section_github))
+            Text(
+                stringResource(R.string.settings_github_desc),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(bottom = 8.dp)
+            )
+            // Local edit state, seeded from the persisted values; the PAT field is never seeded with
+            // the secret — saving writes it to the secure store and the field is cleared.
+            var ownerField by remember(githubOwner) { mutableStateOf(githubOwner) }
+            var repoField by remember(githubRepo) { mutableStateOf(githubRepo) }
+            var tokenField by remember { mutableStateOf("") }
+            var showToken by remember { mutableStateOf(false) }
+            OutlinedTextField(
+                value = ownerField,
+                onValueChange = { ownerField = it },
+                label = { Text(stringResource(R.string.github_owner_label)) },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)
+            )
+            OutlinedTextField(
+                value = repoField,
+                onValueChange = { repoField = it },
+                label = { Text(stringResource(R.string.github_repo_label)) },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)
+            )
+            OutlinedTextField(
+                value = tokenField,
+                onValueChange = { tokenField = it },
+                label = { Text(stringResource(R.string.github_token_label)) },
+                singleLine = true,
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+                visualTransformation = if (showToken) VisualTransformation.None else PasswordVisualTransformation(),
+                trailingIcon = {
+                    TextButton(onClick = { showToken = !showToken }) {
+                        Text(stringResource(if (showToken) R.string.github_hide else R.string.github_show))
+                    }
+                },
+                modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)
+            )
+            Text(
+                stringResource(if (githubToken != null) R.string.github_token_saved else R.string.github_token_none),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(bottom = 4.dp)
+            )
+            AzButton(
+                onClick = {
+                    viewModel.setGithubOwner(ownerField.trim())
+                    viewModel.setGithubRepo(repoField.trim())
+                    if (tokenField.isNotBlank()) {
+                        viewModel.setGithubToken(tokenField)
+                        tokenField = ""
+                        showToken = false
+                    }
+                    Toast.makeText(context, context.getString(R.string.toast_github_saved), Toast.LENGTH_SHORT).show()
+                },
+                text = stringResource(R.string.github_save),
+                shape = AzButtonShape.RECTANGLE,
+                modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)
+            )
+            AzButton(
+                onClick = {
+                    viewModel.setGithubToken(null)
+                    tokenField = ""
+                    Toast.makeText(context, context.getString(R.string.toast_github_token_cleared), Toast.LENGTH_SHORT).show()
+                },
+                text = stringResource(R.string.github_clear_token),
+                shape = AzButtonShape.RECTANGLE,
+                modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)
             )
             HorizontalDivider(modifier = Modifier.padding(vertical = 16.dp))
 

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/utils/GitHubCredentials.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/utils/GitHubCredentials.kt
@@ -29,11 +29,30 @@ class GitHubCredentials(context: Context) {
 
     private val prefs = context.applicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
 
-    private val _token = MutableStateFlow(load())
-    /** The decrypted PAT, or null when none is set / it couldn't be decrypted. */
-    val token: StateFlow<String?> = _token.asStateFlow()
+    private val _hasToken = MutableStateFlow(prefs.contains(KEY_TOKEN))
+    /**
+     * Whether a PAT is stored. Reactive and cheap — a `prefs.contains` check that never decrypts, so
+     * the plaintext secret is not held in memory and init does no Keystore work.
+     */
+    val hasToken: StateFlow<Boolean> = _hasToken.asStateFlow()
 
-    /** Stores (encrypted) or, for a null/blank value, clears the PAT. */
+    /**
+     * Decrypts and returns the stored PAT on demand, or null when none is set / it couldn't be
+     * decrypted. Touches the Keystore, so call it **off the main thread** (e.g. inside the feature's
+     * IO poll loop). On a decryption failure the corrupt entry is dropped so the user can re-enter.
+     */
+    fun readToken(): String? {
+        val stored = prefs.getString(KEY_TOKEN, null) ?: return null
+        return runCatching { decrypt(stored) }.getOrElse {
+            clear()
+            null
+        }
+    }
+
+    /**
+     * Stores (encrypted) or, for a null/blank value, clears the PAT. Performs AES/GCM + Keystore
+     * work (the first call may generate the key), so call it **off the main thread**.
+     */
     fun setToken(raw: String?) {
         val value = raw?.trim().orEmpty()
         if (value.isEmpty()) {
@@ -46,21 +65,12 @@ class GitHubCredentials(context: Context) {
             return
         }
         prefs.edit().putString(KEY_TOKEN, encrypted).apply()
-        _token.value = value
+        _hasToken.value = true
     }
 
     fun clear() {
         prefs.edit().remove(KEY_TOKEN).apply()
-        _token.value = null
-    }
-
-    private fun load(): String? {
-        val stored = prefs.getString(KEY_TOKEN, null) ?: return null
-        return runCatching { decrypt(stored) }.getOrElse {
-            // Key rotated/invalidated or corrupt blob — drop it so the user can re-enter cleanly.
-            prefs.edit().remove(KEY_TOKEN).apply()
-            null
-        }
+        _hasToken.value = false
     }
 
     // --- AES/GCM via the Android Keystore. Stored form: base64(iv):base64(ciphertext). ---

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/utils/GitHubCredentials.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/utils/GitHubCredentials.kt
@@ -1,0 +1,110 @@
+package com.hereliesaz.logkitty.utils
+
+import android.content.Context
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
+import android.util.Base64
+import java.security.KeyStore
+import javax.crypto.Cipher
+import javax.crypto.KeyGenerator
+import javax.crypto.SecretKey
+import javax.crypto.spec.GCMParameterSpec
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * Secure on-device store for the GitHub Personal Access Token.
+ *
+ * The PAT is sensitive, so it is kept **out of [UserPreferences]** (whose `logkitty_user_prefs` file
+ * is cloud-backed-up/device-transferred and exported in the settings JSON). It lives in its own
+ * `logkitty_secure_prefs` file — which must be excluded in `res/xml/backup_rules.xml` and
+ * `res/xml/data_extraction_rules.xml` — and is encrypted at rest with an AES/GCM key held in the
+ * Android Keystore (so the stored ciphertext is useless off-device, and there is no new dependency).
+ *
+ * All crypto is best-effort: any failure (e.g. the Keystore key was invalidated) degrades to "no
+ * token" rather than throwing, and corrupt state is cleared.
+ */
+class GitHubCredentials(context: Context) {
+
+    private val prefs = context.applicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+    private val _token = MutableStateFlow(load())
+    /** The decrypted PAT, or null when none is set / it couldn't be decrypted. */
+    val token: StateFlow<String?> = _token.asStateFlow()
+
+    /** Stores (encrypted) or, for a null/blank value, clears the PAT. */
+    fun setToken(raw: String?) {
+        val value = raw?.trim().orEmpty()
+        if (value.isEmpty()) {
+            clear()
+            return
+        }
+        val encrypted = runCatching { encrypt(value) }.getOrNull()
+        if (encrypted == null) {
+            clear()
+            return
+        }
+        prefs.edit().putString(KEY_TOKEN, encrypted).apply()
+        _token.value = value
+    }
+
+    fun clear() {
+        prefs.edit().remove(KEY_TOKEN).apply()
+        _token.value = null
+    }
+
+    private fun load(): String? {
+        val stored = prefs.getString(KEY_TOKEN, null) ?: return null
+        return runCatching { decrypt(stored) }.getOrElse {
+            // Key rotated/invalidated or corrupt blob — drop it so the user can re-enter cleanly.
+            prefs.edit().remove(KEY_TOKEN).apply()
+            null
+        }
+    }
+
+    // --- AES/GCM via the Android Keystore. Stored form: base64(iv):base64(ciphertext). ---
+
+    private fun encrypt(plain: String): String {
+        val cipher = Cipher.getInstance(TRANSFORMATION)
+        cipher.init(Cipher.ENCRYPT_MODE, getOrCreateKey())
+        val iv = cipher.iv
+        val ct = cipher.doFinal(plain.toByteArray(Charsets.UTF_8))
+        return Base64.encodeToString(iv, Base64.NO_WRAP) + ":" + Base64.encodeToString(ct, Base64.NO_WRAP)
+    }
+
+    private fun decrypt(stored: String): String {
+        val parts = stored.split(":", limit = 2)
+        require(parts.size == 2) { "malformed ciphertext" }
+        val iv = Base64.decode(parts[0], Base64.NO_WRAP)
+        val ct = Base64.decode(parts[1], Base64.NO_WRAP)
+        val cipher = Cipher.getInstance(TRANSFORMATION)
+        cipher.init(Cipher.DECRYPT_MODE, getOrCreateKey(), GCMParameterSpec(GCM_TAG_BITS, iv))
+        return String(cipher.doFinal(ct), Charsets.UTF_8)
+    }
+
+    private fun getOrCreateKey(): SecretKey {
+        val ks = KeyStore.getInstance(ANDROID_KEYSTORE).apply { load(null) }
+        (ks.getEntry(KEY_ALIAS, null) as? KeyStore.SecretKeyEntry)?.let { return it.secretKey }
+        val generator = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, ANDROID_KEYSTORE)
+        generator.init(
+            KeyGenParameterSpec.Builder(
+                KEY_ALIAS,
+                KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT,
+            )
+                .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+                .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+                .build(),
+        )
+        return generator.generateKey()
+    }
+
+    private companion object {
+        const val PREFS_NAME = "logkitty_secure_prefs"
+        const val KEY_TOKEN = "github_pat"
+        const val ANDROID_KEYSTORE = "AndroidKeyStore"
+        const val KEY_ALIAS = "logkitty_github_pat"
+        const val TRANSFORMATION = "AES/GCM/NoPadding"
+        const val GCM_TAG_BITS = 128
+    }
+}

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/utils/UserPreferences.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/utils/UserPreferences.kt
@@ -36,7 +36,11 @@ data class ExportedPreferences(
     val colorScheme: String = LogColorScheme.MATERIAL.name,
     val tagColoringEnabled: Boolean = true,
     val monitoredApps: List<String> = emptyList(),
-    val activeSourceFilters: List<String> = emptyList()
+    val activeSourceFilters: List<String> = emptyList(),
+    // GitHub repo config is non-secret and safe to back up. The PAT is NOT here — it lives in the
+    // separate, backup-excluded GitHubCredentials store and is never exported.
+    val githubOwner: String = "",
+    val githubRepo: String = ""
 )
 
 /**
@@ -132,6 +136,14 @@ class UserPreferences(context: Context) {
     // --- Preference: Tag-Based Coloring ---
     private val _tagColoringEnabled = MutableStateFlow(prefs.getBoolean(KEY_TAG_COLORING, true))
     val tagColoringEnabled: StateFlow<Boolean> = _tagColoringEnabled.asStateFlow()
+
+    // --- Preference: GitHub repo (owner/name) ---
+    // Non-secret repo coordinates for the GitHub Actions tab. The PAT is stored separately in the
+    // backup-excluded GitHubCredentials store, never here.
+    private val _githubOwner = MutableStateFlow(prefs.getString(KEY_GITHUB_OWNER, "") ?: "")
+    val githubOwner: StateFlow<String> = _githubOwner.asStateFlow()
+    private val _githubRepo = MutableStateFlow(prefs.getString(KEY_GITHUB_REPO, "") ?: "")
+    val githubRepo: StateFlow<String> = _githubRepo.asStateFlow()
 
     // --- Preference: Log Colors ---
     // Map of LogLevel to ARGB Color Integer. Reflects the active scheme until the user customizes.
@@ -302,6 +314,16 @@ class UserPreferences(context: Context) {
         _tagColoringEnabled.value = enabled
     }
 
+    fun setGithubOwner(owner: String) {
+        prefs.edit().putString(KEY_GITHUB_OWNER, owner).apply()
+        _githubOwner.value = owner
+    }
+
+    fun setGithubRepo(repo: String) {
+        prefs.edit().putString(KEY_GITHUB_REPO, repo).apply()
+        _githubRepo.value = repo
+    }
+
     // --- Helpers ---
 
     private fun loadProhibitedTags(): Set<String> {
@@ -356,7 +378,9 @@ class UserPreferences(context: Context) {
             colorScheme = _colorScheme.value.name,
             tagColoringEnabled = _tagColoringEnabled.value,
             monitoredApps = _monitoredApps.value.toList(),
-            activeSourceFilters = _activeSourceFilters.value.toList()
+            activeSourceFilters = _activeSourceFilters.value.toList(),
+            githubOwner = _githubOwner.value,
+            githubRepo = _githubRepo.value
         )
         return try {
             Json { prettyPrint = true }.encodeToString(exported)
@@ -399,6 +423,9 @@ class UserPreferences(context: Context) {
             prefs.edit().putStringSet(KEY_ACTIVE_SOURCE_FILTERS, sources).apply()
             _activeSourceFilters.value = sources
 
+            setGithubOwner(imported.githubOwner)
+            setGithubRepo(imported.githubRepo)
+
             val scheme = try { LogColorScheme.valueOf(imported.colorScheme) } catch (e: Exception) { LogColorScheme.MATERIAL }
 
             val editor = prefs.edit()
@@ -440,5 +467,7 @@ class UserPreferences(context: Context) {
         private const val KEY_TAG_COLORING = "tag_coloring_enabled"
         private const val KEY_MONITORED_APPS = "monitored_apps"
         private const val KEY_ACTIVE_SOURCE_FILTERS = "active_source_filters"
+        private const val KEY_GITHUB_OWNER = "github_owner"
+        private const val KEY_GITHUB_REPO = "github_repo"
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -138,6 +138,20 @@
     <string name="github_installing">Installing GitHub Actions…</string>
     <string name="github_finishing_install">Finishing install — tap to load.</string>
     <string name="github_coming_soon">GitHub Actions coming soon…</string>
+    <!-- GitHub settings -->
+    <string name="settings_section_github">GitHub Actions</string>
+    <string name="settings_github_desc">Browse a repo\'s workflow runs, jobs and logs from the GitHub tab. Use a fine-grained token with Actions: Read access (plus repository access for private repos). The token is encrypted on this device and never backed up.</string>
+    <string name="github_owner_label">Owner (user or org)</string>
+    <string name="github_repo_label">Repository</string>
+    <string name="github_token_label">Personal access token</string>
+    <string name="github_token_saved">A token is saved on this device.</string>
+    <string name="github_token_none">No token saved.</string>
+    <string name="github_show">Show</string>
+    <string name="github_hide">Hide</string>
+    <string name="github_save">Save</string>
+    <string name="github_clear_token">Clear token</string>
+    <string name="toast_github_saved">GitHub settings saved</string>
+    <string name="toast_github_token_cleared">GitHub token cleared</string>
 
     <!-- Tabs -->
     <string name="tab_all">All</string>

--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -3,4 +3,6 @@
     <include domain="sharedpref" path="."/>
     <include domain="database" path="."/>
     <include domain="file" path="."/>
+    <!-- Never back up the GitHub PAT (Keystore-encrypted and device-bound). -->
+    <exclude domain="sharedpref" path="logkitty_secure_prefs.xml"/>
 </full-backup-content>

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -3,9 +3,12 @@
     <cloud-backup>
         <include domain="database" path="."/>
         <include domain="sharedpref" path="."/>
+        <!-- Never back up the GitHub PAT (Keystore-encrypted and device-bound). -->
+        <exclude domain="sharedpref" path="logkitty_secure_prefs.xml"/>
     </cloud-backup>
     <device-transfer>
         <include domain="database" path="."/>
         <include domain="sharedpref" path="."/>
+        <exclude domain="sharedpref" path="logkitty_secure_prefs.xml"/>
     </device-transfer>
 </data-extraction-rules>


### PR DESCRIPTION
## GitHub Actions feature — Phase 1 (PAT + repo in Settings)

**Stacked on #152 (Phase 0).** Base is the Phase 0 branch so the diff is just Phase 1; it will auto-retarget to `main` once #152 merges.

Adds the secure credential store and the Settings UI to configure the GitHub integration. No panel logic yet (that's Phase 2) — this is the data layer + config screen.

### Secure PAT storage (security-critical)
- **`GitHubCredentials`** — stores the PAT in a dedicated `logkitty_secure_prefs` file, **encrypted at rest with an AES/GCM key from the Android Keystore** (no new dependency; the Jetpack Security `EncryptedSharedPreferences` alternative is in maintenance mode). All crypto is best-effort: any failure (e.g. key invalidated) degrades to "no token" and clears corrupt state.
- **Backup exclusion** — `logkitty_secure_prefs.xml` is excluded from `backup_rules.xml` (`full-backup-content`) and `data_extraction_rules.xml` (both `cloud-backup` and `device-transfer`), since the base manifest blanket-includes all sharedprefs. The PAT is never backed up or transferred.
- The PAT is **never** in `UserPreferences`/`ExportedPreferences` (the settings JSON backup).

### Repo config (non-secret)
- `UserPreferences` gains `githubOwner`/`githubRepo` (+ `ExportedPreferences` fields, defaulted/backward-compatible) — safe to back up.
- `MainViewModel` exposes `githubOwner`/`githubRepo`/`githubToken` + setters.

### Settings UI
- A new **GitHub Actions** section: owner/repo fields, a masked PAT field with show/hide, Save and Clear-token buttons, a saved/none status line, and a scope note (Actions: Read + repo for private). Saving writes the PAT to the secure store and clears the field (the secret is never seeded back into the UI).

### Verification
- ❌ Not built here — relying on CI. (Phase 0's R8 keep-rule fix for `GitHubFeatureImpl` is included in this branch's history.)

### Next
Phase 2 wires this owner/repo + `tokenProvider` into the slot and builds the runs → jobs → job-log panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GSxjeuLJyBVyFhGXcxbkSe)_

## Summary by Sourcery

Introduce secure, non-backed-up storage for the GitHub Actions personal access token and add settings to configure the associated repository and token.

New Features:
- Add a GitHub Actions settings section allowing configuration of repository owner, repository name, and a personal access token.

Enhancements:
- Store the GitHub personal access token in a dedicated, Keystore-backed encrypted preferences file separate from general user preferences.
- Expose GitHub repository configuration and token presence through MainViewModel for use by the GitHub Actions feature.
- Include GitHub repository coordinates in preferences export/import while keeping the token out of backups and exports.
- Update backup and data extraction rules to exclude the secure GitHub credentials preferences file from cloud backup and device transfer.