### PR TITLE
GitHub Actions Phase 2: runs → jobs → job log

### DIFF
--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/GitHubFeatureSlot.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/GitHubFeatureSlot.kt
@@ -47,6 +47,11 @@ import com.hereliesaz.logkitty.feature.rememberFeatureInstall
  */
 @Composable
 fun GitHubFeatureSlot(
+    owner: String,
+    repo: String,
+    tokenProvider: () -> String?,
+    onConfigure: () -> Unit,
+    onWatchRun: (owner: String, repo: String, runId: Long, runName: String) -> Unit,
     fontFamily: FontFamily?,
     fontSize: Int,
     modifier: Modifier = Modifier,
@@ -61,13 +66,13 @@ fun GitHubFeatureSlot(
             }
             if (feature != null) {
                 feature.GitHubPanel(
-                    owner = "",
-                    repo = "",
-                    tokenProvider = { null },
+                    owner = owner,
+                    repo = repo,
+                    tokenProvider = tokenProvider,
                     fontFamily = fontFamily,
                     fontSize = fontSize,
-                    onWatchRun = { _, _, _, _ -> },
-                    onConfigure = {},
+                    onWatchRun = onWatchRun,
+                    onConfigure = onConfigure,
                     modifier = modifier,
                 )
             } else {

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/LogBottomSheet.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/LogBottomSheet.kt
@@ -120,6 +120,8 @@ fun LogBottomSheet(
     val tagColoringEnabled by viewModel.tagColoringEnabled.collectAsState()
     val isPaused by viewModel.isPaused.collectAsState()
     val isRootEnabled by viewModel.isRootEnabled.collectAsState()
+    val githubOwner by viewModel.githubOwner.collectAsState()
+    val githubRepo by viewModel.githubRepo.collectAsState()
 
     val currentFontFamily = remember(fontFamilyName) {
         val enumVal = try { CodingFont.valueOf(fontFamilyName) } catch (e: Exception) { CodingFont.SYSTEM }
@@ -241,6 +243,9 @@ fun LogBottomSheet(
                 selectedLineIds = emptySet()
                 isMultiSelectMode = false
             },
+            githubOwner = githubOwner,
+            githubRepo = githubRepo,
+            githubTokenProvider = { viewModel.readGithubToken() },
         )
     }
 }
@@ -338,6 +343,9 @@ private fun ExpandedView(
     onCopySelected: () -> Unit,
     onSearchLine: (IndexedLogLine) -> Unit,
     onProhibitLine: (IndexedLogLine) -> Unit,
+    githubOwner: String,
+    githubRepo: String,
+    githubTokenProvider: () -> String?,
 ) {
     Column(modifier = Modifier.fillMaxSize()) {
 
@@ -465,6 +473,11 @@ private fun ExpandedView(
             if (selectedTab.type == TabType.GITHUB) {
                 // The GitHub tab's body is the on-demand :feature:github panel, not the log stream.
                 GitHubFeatureSlot(
+                    owner = githubOwner,
+                    repo = githubRepo,
+                    tokenProvider = githubTokenProvider,
+                    onConfigure = onSettingsClick,
+                    onWatchRun = { _, _, _, _ -> },
                     fontFamily = fontFamily,
                     fontSize = fontSize,
                     modifier = Modifier.fillMaxSize(),

--- a/feature/github/build.gradle.kts
+++ b/feature/github/build.gradle.kts
@@ -38,4 +38,8 @@ dependencies {
     // fillMaxWidth/height & lazy lists live in compose-foundation (not pulled by compose-ui alone).
     implementation("androidx.compose.foundation:foundation")
     implementation(libs.kotlinx.coroutines.core)
+    // GitHub REST client. Same version the base uses (aligned by the root subprojects{} block), so
+    // AGP de-dupes it against the base and it isn't duplicated in this split. (org.json is in the
+    // Android framework, so it needs no declaration.)
+    implementation(libs.okhttp)
 }

--- a/feature/github/src/main/kotlin/com/hereliesaz/logkitty/feature/github/GitHubApi.kt
+++ b/feature/github/src/main/kotlin/com/hereliesaz/logkitty/feature/github/GitHubApi.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
 import okhttp3.Request
+import okhttp3.ResponseBody
 import org.json.JSONObject
 
 /**
@@ -24,7 +25,7 @@ class GitHubApi(private val tokenProvider: () -> String?) {
 
     suspend fun listRuns(owner: String, repo: String, perPage: Int = 20): GitHubResult<List<WorkflowRun>> =
         get("$API/repos/$owner/$repo/actions/runs?per_page=$perPage") { body ->
-            val arr = JSONObject(body).optJSONArray("workflow_runs") ?: return@get emptyList()
+            val arr = JSONObject(body.string()).optJSONArray("workflow_runs") ?: return@get emptyList()
             buildList {
                 for (i in 0 until arr.length()) add(parseRun(arr.getJSONObject(i)))
             }
@@ -32,22 +33,28 @@ class GitHubApi(private val tokenProvider: () -> String?) {
 
     suspend fun listJobs(owner: String, repo: String, runId: Long): GitHubResult<List<WorkflowJob>> =
         get("$API/repos/$owner/$repo/actions/runs/$runId/jobs?per_page=100") { body ->
-            val arr = JSONObject(body).optJSONArray("jobs") ?: return@get emptyList()
+            val arr = JSONObject(body.string()).optJSONArray("jobs") ?: return@get emptyList()
             buildList {
                 for (i in 0 until arr.length()) add(parseJob(arr.getJSONObject(i)))
             }
         }
 
     /**
-     * Fetches a job's plain-text log. The endpoint 302-redirects to a short-lived signed URL on
-     * another host; OkHttp follows it and drops the `Authorization` header on the cross-host hop
+     * Fetches a job's plain-text log as lines. The endpoint 302-redirects to a short-lived signed URL
+     * on another host; OkHttp follows it and drops the `Authorization` header on the cross-host hop
      * (correct — re-sending it would make the signed fetch fail), so we must NOT add a global auth
-     * interceptor. Returns the raw text (ANSI escapes intact — Phase 3 colorizes them).
+     * interceptor.
+     *
+     * Logs can be tens of MB, so we **stream** the body line-by-line and keep only the most recent
+     * [MAX_LOG_LINES] — never materializing the whole log as one String (avoids OOM). ANSI escapes
+     * are left intact for the colored view to parse.
      */
-    suspend fun fetchJobLog(owner: String, repo: String, jobId: Long): GitHubResult<String> =
-        get("$API/repos/$owner/$repo/actions/jobs/$jobId/logs", parse = { it })
+    suspend fun fetchJobLog(owner: String, repo: String, jobId: Long): GitHubResult<List<String>> =
+        get("$API/repos/$owner/$repo/actions/jobs/$jobId/logs") { body ->
+            body.charStream().useLines { lines -> lines.toList().let { if (it.size > MAX_LOG_LINES) it.takeLast(MAX_LOG_LINES) else it } }
+        }
 
-    private suspend fun <T> get(url: String, parse: (String) -> T): GitHubResult<T> =
+    private suspend fun <T> get(url: String, parse: (ResponseBody) -> T): GitHubResult<T> =
         withContext(Dispatchers.IO) {
             val builder = Request.Builder()
                 .url(url)
@@ -56,9 +63,11 @@ class GitHubApi(private val tokenProvider: () -> String?) {
             tokenProvider()?.takeIf { it.isNotBlank() }?.let { builder.header("Authorization", "Bearer $it") }
             try {
                 client.newCall(builder.build()).execute().use { resp ->
-                    val body = resp.body?.string().orEmpty()
                     when {
-                        resp.isSuccessful -> GitHubResult.Ok(parse(body))
+                        resp.isSuccessful -> {
+                            val body = resp.body ?: return@use GitHubResult.Err("Empty response from GitHub.")
+                            GitHubResult.Ok(parse(body))
+                        }
                         resp.code == 401 || resp.code == 403 ->
                             GitHubResult.Err("Unauthorized — check your token and its scopes.", unauthorized = true)
                         resp.code == 404 ->
@@ -73,23 +82,34 @@ class GitHubApi(private val tokenProvider: () -> String?) {
 
     private fun parseRun(o: JSONObject) = WorkflowRun(
         id = o.optLong("id"),
-        name = o.optString("name").ifBlank { o.optString("display_title").ifBlank { "Workflow run" } },
-        status = o.optString("status"),
-        conclusion = o.optString("conclusion").takeIf { it.isNotBlank() && it != "null" },
-        branch = o.optString("head_branch"),
-        event = o.optString("event"),
+        name = o.optStringSafe("name").ifBlank { o.optStringSafe("display_title").ifBlank { "Workflow run" } },
+        status = o.optStringSafe("status"),
+        conclusion = o.optStringSafe("conclusion").takeIf { it.isNotBlank() },
+        branch = o.optStringSafe("head_branch"),
+        event = o.optStringSafe("event"),
         runNumber = o.optInt("run_number"),
-        createdAt = o.optString("created_at"),
+        createdAt = o.optStringSafe("created_at"),
     )
 
     private fun parseJob(o: JSONObject) = WorkflowJob(
         id = o.optLong("id"),
-        name = o.optString("name").ifBlank { "Job" },
-        status = o.optString("status"),
-        conclusion = o.optString("conclusion").takeIf { it.isNotBlank() && it != "null" },
+        name = o.optStringSafe("name").ifBlank { "Job" },
+        status = o.optStringSafe("status"),
+        conclusion = o.optStringSafe("conclusion").takeIf { it.isNotBlank() },
     )
 
     private companion object {
         const val API = "https://api.github.com"
+        const val MAX_LOG_LINES = 4000
     }
+}
+
+/**
+ * Android's `JSONObject.optString` returns the literal string "null" for an explicit JSON null
+ * (`JSONObject.NULL`), which breaks `ifBlank`/`takeIf` fallbacks. This maps both a missing key and an
+ * explicit null to "".
+ */
+private fun JSONObject.optStringSafe(key: String): String {
+    val v = opt(key)
+    return if (v == null || v == JSONObject.NULL) "" else v.toString()
 }

--- a/feature/github/src/main/kotlin/com/hereliesaz/logkitty/feature/github/GitHubApi.kt
+++ b/feature/github/src/main/kotlin/com/hereliesaz/logkitty/feature/github/GitHubApi.kt
@@ -1,0 +1,95 @@
+package com.hereliesaz.logkitty.feature.github
+
+import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.json.JSONObject
+
+/**
+ * Minimal GitHub Actions REST client. OkHttp arrives transitively from `:app` (already a base dep);
+ * JSON is parsed with `org.json` so the module needs no serialization plugin.
+ *
+ * The PAT is read lazily via [tokenProvider] on each call (so a token edited in Settings is picked
+ * up immediately and the plaintext isn't retained). All calls are `suspend` + run on [Dispatchers.IO].
+ */
+class GitHubApi(private val tokenProvider: () -> String?) {
+
+    private val client = OkHttpClient.Builder()
+        .connectTimeout(15, TimeUnit.SECONDS)
+        .readTimeout(20, TimeUnit.SECONDS)
+        .callTimeout(30, TimeUnit.SECONDS)
+        .build()
+
+    suspend fun listRuns(owner: String, repo: String, perPage: Int = 20): GitHubResult<List<WorkflowRun>> =
+        get("$API/repos/$owner/$repo/actions/runs?per_page=$perPage") { body ->
+            val arr = JSONObject(body).optJSONArray("workflow_runs") ?: return@get emptyList()
+            buildList {
+                for (i in 0 until arr.length()) add(parseRun(arr.getJSONObject(i)))
+            }
+        }
+
+    suspend fun listJobs(owner: String, repo: String, runId: Long): GitHubResult<List<WorkflowJob>> =
+        get("$API/repos/$owner/$repo/actions/runs/$runId/jobs?per_page=100") { body ->
+            val arr = JSONObject(body).optJSONArray("jobs") ?: return@get emptyList()
+            buildList {
+                for (i in 0 until arr.length()) add(parseJob(arr.getJSONObject(i)))
+            }
+        }
+
+    /**
+     * Fetches a job's plain-text log. The endpoint 302-redirects to a short-lived signed URL on
+     * another host; OkHttp follows it and drops the `Authorization` header on the cross-host hop
+     * (correct — re-sending it would make the signed fetch fail), so we must NOT add a global auth
+     * interceptor. Returns the raw text (ANSI escapes intact — Phase 3 colorizes them).
+     */
+    suspend fun fetchJobLog(owner: String, repo: String, jobId: Long): GitHubResult<String> =
+        get("$API/repos/$owner/$repo/actions/jobs/$jobId/logs", parse = { it })
+
+    private suspend fun <T> get(url: String, parse: (String) -> T): GitHubResult<T> =
+        withContext(Dispatchers.IO) {
+            val builder = Request.Builder()
+                .url(url)
+                .header("Accept", "application/vnd.github+json")
+                .header("X-GitHub-Api-Version", "2022-11-28")
+            tokenProvider()?.takeIf { it.isNotBlank() }?.let { builder.header("Authorization", "Bearer $it") }
+            try {
+                client.newCall(builder.build()).execute().use { resp ->
+                    val body = resp.body?.string().orEmpty()
+                    when {
+                        resp.isSuccessful -> GitHubResult.Ok(parse(body))
+                        resp.code == 401 || resp.code == 403 ->
+                            GitHubResult.Err("Unauthorized — check your token and its scopes.", unauthorized = true)
+                        resp.code == 404 ->
+                            GitHubResult.Err("Not found — check the owner/repo (and token access for private repos).")
+                        else -> GitHubResult.Err("GitHub error ${resp.code}.")
+                    }
+                }
+            } catch (e: Exception) {
+                GitHubResult.Err(e.message ?: "Network error.")
+            }
+        }
+
+    private fun parseRun(o: JSONObject) = WorkflowRun(
+        id = o.optLong("id"),
+        name = o.optString("name").ifBlank { o.optString("display_title").ifBlank { "Workflow run" } },
+        status = o.optString("status"),
+        conclusion = o.optString("conclusion").takeIf { it.isNotBlank() && it != "null" },
+        branch = o.optString("head_branch"),
+        event = o.optString("event"),
+        runNumber = o.optInt("run_number"),
+        createdAt = o.optString("created_at"),
+    )
+
+    private fun parseJob(o: JSONObject) = WorkflowJob(
+        id = o.optLong("id"),
+        name = o.optString("name").ifBlank { "Job" },
+        status = o.optString("status"),
+        conclusion = o.optString("conclusion").takeIf { it.isNotBlank() && it != "null" },
+    )
+
+    private companion object {
+        const val API = "https://api.github.com"
+    }
+}

--- a/feature/github/src/main/kotlin/com/hereliesaz/logkitty/feature/github/GitHubFeatureImpl.kt
+++ b/feature/github/src/main/kotlin/com/hereliesaz/logkitty/feature/github/GitHubFeatureImpl.kt
@@ -1,25 +1,15 @@
 package com.hereliesaz.logkitty.feature.github
 
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
-import androidx.compose.ui.unit.sp
-import com.hereliesaz.logkitty.R
 import com.hereliesaz.logkitty.core.feature.GitHubFeature
 
 /**
  * Entry point the base app loads reflectively (see `FeatureModules.GITHUB_IMPL`) once this module is
- * installed. Fully self-contained: it will own the GitHub REST client, the ANSI/annotation log
- * parser, and the runs → jobs → job-log drill-down panel.
- *
- * Phase 0: a placeholder confirming the dynamic-feature graph builds and the slot wires up. The real
- * panel (runs list, job log, live polling, coloring) lands in later phases.
+ * installed. Fully self-contained: it owns the GitHub REST client ([GitHubApi]), the models, and the
+ * runs → jobs → job-log drill-down ([GitHubPanel]). The base passes in repo coordinates, a lazy PAT
+ * provider, and the watch/configure callbacks.
  */
 class GitHubFeatureImpl : GitHubFeature {
 
@@ -34,13 +24,15 @@ class GitHubFeatureImpl : GitHubFeature {
         onConfigure: () -> Unit,
         modifier: Modifier,
     ) {
-        Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-            Text(
-                stringResource(R.string.github_coming_soon),
-                color = Color.White.copy(alpha = 0.7f),
-                fontSize = fontSize.sp,
-                fontFamily = fontFamily,
-            )
-        }
+        GitHubActionsPanel(
+            owner = owner,
+            repo = repo,
+            tokenProvider = tokenProvider,
+            fontFamily = fontFamily,
+            fontSize = fontSize,
+            onWatchRun = onWatchRun,
+            onConfigure = onConfigure,
+            modifier = modifier,
+        )
     }
 }

--- a/feature/github/src/main/kotlin/com/hereliesaz/logkitty/feature/github/GitHubModels.kt
+++ b/feature/github/src/main/kotlin/com/hereliesaz/logkitty/feature/github/GitHubModels.kt
@@ -1,0 +1,40 @@
+package com.hereliesaz.logkitty.feature.github
+
+/**
+ * Plain data models for the GitHub Actions panel, populated by [GitHubApi] from REST JSON via
+ * `org.json` (so the module needs no serialization plugin/dependency).
+ */
+
+/** One workflow run (`/actions/runs`). */
+data class WorkflowRun(
+    val id: Long,
+    val name: String,
+    /** "queued" | "in_progress" | "completed" (and occasionally others). */
+    val status: String,
+    /** "success" | "failure" | "cancelled" | "skipped" | … ; null while not completed. */
+    val conclusion: String?,
+    val branch: String,
+    val event: String,
+    val runNumber: Int,
+    val createdAt: String,
+) {
+    /** True once the run has reached a terminal state (no more polling needed). */
+    val isTerminal: Boolean get() = status == "completed"
+}
+
+/** One job within a run (`/actions/runs/{id}/jobs`). */
+data class WorkflowJob(
+    val id: Long,
+    val name: String,
+    val status: String,
+    val conclusion: String?,
+) {
+    val isTerminal: Boolean get() = status == "completed"
+}
+
+/** Result wrapper so the UI can distinguish loading failures (auth, network, not-found) cleanly. */
+sealed interface GitHubResult<out T> {
+    data class Ok<T>(val value: T) : GitHubResult<T>
+    /** [message] is user-facing; [unauthorized] flags a bad/missing token so the UI can prompt re-auth. */
+    data class Err(val message: String, val unauthorized: Boolean = false) : GitHubResult<Nothing>
+}

--- a/feature/github/src/main/kotlin/com/hereliesaz/logkitty/feature/github/GitHubPanel.kt
+++ b/feature/github/src/main/kotlin/com/hereliesaz/logkitty/feature/github/GitHubPanel.kt
@@ -1,0 +1,230 @@
+package com.hereliesaz.logkitty.feature.github
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+/**
+ * The GitHub Actions drill-down: runs → jobs → job log. Phase 2 does a single fetch per screen with
+ * a manual refresh; live polling (Phase 4) and ANSI coloring (Phase 3) build on this.
+ */
+@Composable
+fun GitHubActionsPanel(
+    owner: String,
+    repo: String,
+    tokenProvider: () -> String?,
+    fontFamily: FontFamily?,
+    fontSize: Int,
+    onWatchRun: (owner: String, repo: String, runId: Long, runName: String) -> Unit,
+    onConfigure: () -> Unit,
+    modifier: Modifier,
+) {
+    if (owner.isBlank() || repo.isBlank()) {
+        Centered(modifier) {
+            Text(
+                "Set a GitHub owner and repository in Settings to see workflow runs.",
+                color = Color.White.copy(alpha = 0.85f), fontSize = fontSize.sp, fontFamily = fontFamily,
+            )
+            Button(onClick = onConfigure) { Text("Open Settings") }
+        }
+        return
+    }
+
+    // No key: the lambda always reads the current token via the ViewModel, so a stable instance is
+    // fine and avoids rebuilding the OkHttp client on every recomposition.
+    val api = remember { GitHubApi(tokenProvider) }
+    var selectedRun by remember(owner, repo) { mutableStateOf<WorkflowRun?>(null) }
+    var selectedJob by remember(owner, repo) { mutableStateOf<WorkflowJob?>(null) }
+
+    when {
+        selectedJob != null -> JobLogScreen(
+            api, owner, repo, selectedJob!!, fontFamily, fontSize, onBack = { selectedJob = null },
+        )
+        selectedRun != null -> JobsScreen(
+            api, owner, repo, selectedRun!!, fontFamily, fontSize,
+            onBack = { selectedRun = null },
+            onJob = { selectedJob = it },
+            onWatch = { onWatchRun(owner, repo, selectedRun!!.id, selectedRun!!.name) },
+            modifier = modifier,
+        )
+        else -> RunsScreen(api, owner, repo, fontFamily, fontSize, onRun = { selectedRun = it }, modifier = modifier)
+    }
+}
+
+@Composable
+private fun RunsScreen(
+    api: GitHubApi, owner: String, repo: String, ff: FontFamily?, fs: Int,
+    onRun: (WorkflowRun) -> Unit, modifier: Modifier,
+) {
+    var refresh by remember { mutableStateOf(0) }
+    val state by produceState<GitHubResult<List<WorkflowRun>>?>(null, owner, repo, refresh) {
+        value = null
+        value = api.listRuns(owner, repo)
+    }
+    Column(modifier = modifier.fillMaxSize()) {
+        Header("$owner/$repo", ff, fs, onBack = null, onRefresh = { refresh++ })
+        ResultBody(state, ff, fs, empty = "No workflow runs.") { runs ->
+            LazyColumn(modifier = Modifier.fillMaxSize()) {
+                items(runs, key = { it.id }) { run ->
+                    Row(
+                        modifier = Modifier.fillMaxWidth().clickable { onRun(run) }.padding(horizontal = 12.dp, vertical = 8.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Text(statusGlyph(run.status, run.conclusion), fontSize = (fs + 2).sp, modifier = Modifier.padding(end = 8.dp))
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(run.name, color = Color.White, fontSize = fs.sp, fontFamily = ff, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                            Text(
+                                "#${run.runNumber} · ${run.branch} · ${run.event}",
+                                color = Color.White.copy(alpha = 0.6f), fontSize = (fs - 3).sp, fontFamily = ff,
+                                maxLines = 1, overflow = TextOverflow.Ellipsis,
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun JobsScreen(
+    api: GitHubApi, owner: String, repo: String, run: WorkflowRun, ff: FontFamily?, fs: Int,
+    onBack: () -> Unit, onJob: (WorkflowJob) -> Unit, onWatch: () -> Unit, modifier: Modifier,
+) {
+    var refresh by remember { mutableStateOf(0) }
+    val state by produceState<GitHubResult<List<WorkflowJob>>?>(null, run.id, refresh) {
+        value = null
+        value = api.listJobs(owner, repo, run.id)
+    }
+    Column(modifier = modifier.fillMaxSize()) {
+        Header("${statusGlyph(run.status, run.conclusion)} ${run.name}", ff, fs, onBack = onBack, onRefresh = { refresh++ })
+        if (!run.isTerminal) {
+            TextButton(onClick = onWatch, modifier = Modifier.padding(horizontal = 8.dp)) {
+                Text("Notify me when this run finishes", fontSize = (fs - 2).sp)
+            }
+        }
+        ResultBody(state, ff, fs, empty = "No jobs.") { jobs ->
+            LazyColumn(modifier = Modifier.fillMaxSize()) {
+                items(jobs, key = { it.id }) { job ->
+                    Row(
+                        modifier = Modifier.fillMaxWidth().clickable { onJob(job) }.padding(horizontal = 12.dp, vertical = 8.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Text(statusGlyph(job.status, job.conclusion), fontSize = (fs + 2).sp, modifier = Modifier.padding(end = 8.dp))
+                        Text(job.name, color = Color.White, fontSize = fs.sp, fontFamily = ff, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun JobLogScreen(
+    api: GitHubApi, owner: String, repo: String, job: WorkflowJob, ff: FontFamily?, fs: Int, onBack: () -> Unit,
+) {
+    var refresh by remember { mutableStateOf(0) }
+    val state by produceState<GitHubResult<String>?>(null, job.id, refresh) {
+        value = null
+        value = api.fetchJobLog(owner, repo, job.id)
+    }
+    Column(modifier = Modifier.fillMaxSize()) {
+        Header("${statusGlyph(job.status, job.conclusion)} ${job.name}", ff, fs, onBack = onBack, onRefresh = { refresh++ })
+        ResultBody(state, ff, fs, empty = "No log output.") { log ->
+            // Cap to the most recent lines so a multi-MB log can't blow up the layout (Phase 3 adds
+            // ANSI coloring + smarter virtualization).
+            val lines = remember(log) { log.split('\n').let { if (it.size > MAX_LOG_LINES) it.takeLast(MAX_LOG_LINES) else it } }
+            LazyColumn(modifier = Modifier.fillMaxSize().padding(horizontal = 8.dp)) {
+                items(lines.size) { i ->
+                    Text(lines[i], color = Color.White.copy(alpha = 0.92f), fontSize = (fs - 1).sp, fontFamily = ff)
+                }
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------------------------
+
+@Composable
+private fun <T> ResultBody(
+    state: GitHubResult<T>?, ff: FontFamily?, fs: Int, empty: String,
+    content: @Composable (T) -> Unit,
+) {
+    when (state) {
+        null -> Centered(Modifier.fillMaxSize()) { CircularProgressIndicator() }
+        is GitHubResult.Err -> Centered(Modifier.fillMaxSize()) {
+            Text(state.message, color = Color(0xFFE57373), fontSize = fs.sp, fontFamily = ff)
+        }
+        is GitHubResult.Ok -> {
+            val v = state.value
+            if (v is List<*> && v.isEmpty()) {
+                Centered(Modifier.fillMaxSize()) { Text(empty, color = Color.Gray, fontSize = fs.sp, fontFamily = ff) }
+            } else {
+                content(v)
+            }
+        }
+    }
+}
+
+@Composable
+private fun Header(title: String, ff: FontFamily?, fs: Int, onBack: (() -> Unit)?, onRefresh: () -> Unit) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 8.dp, vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        if (onBack != null) {
+            TextButton(onClick = onBack) { Text("‹ Back", fontSize = (fs - 1).sp) }
+        }
+        Text(
+            title, color = Color.White, fontSize = fs.sp, fontFamily = ff, fontWeight = FontWeight.Bold,
+            maxLines = 1, overflow = TextOverflow.Ellipsis, modifier = Modifier.weight(1f).padding(horizontal = 4.dp),
+        )
+        TextButton(onClick = onRefresh) { Text("Refresh", fontSize = (fs - 1).sp) }
+    }
+}
+
+@Composable
+private fun Centered(modifier: Modifier, content: @Composable () -> Unit) {
+    Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally, verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            content()
+        }
+    }
+}
+
+/** Status emoji for a run/job's status + conclusion. */
+private fun statusGlyph(status: String, conclusion: String?): String = when {
+    status != "completed" && status.isNotBlank() -> if (status == "queued") "⚪" else "🟡"
+    conclusion == "success" -> "✅"
+    conclusion == "failure" || conclusion == "timed_out" -> "❌"
+    conclusion == "cancelled" -> "🚫"
+    conclusion == "skipped" -> "⏭️"
+    else -> "⚠️"
+}
+
+private const val MAX_LOG_LINES = 4000

--- a/feature/github/src/main/kotlin/com/hereliesaz/logkitty/feature/github/GitHubPanel.kt
+++ b/feature/github/src/main/kotlin/com/hereliesaz/logkitty/feature/github/GitHubPanel.kt
@@ -149,16 +149,13 @@ private fun JobLogScreen(
     api: GitHubApi, owner: String, repo: String, job: WorkflowJob, ff: FontFamily?, fs: Int, onBack: () -> Unit,
 ) {
     var refresh by remember { mutableStateOf(0) }
-    val state by produceState<GitHubResult<String>?>(null, job.id, refresh) {
+    val state by produceState<GitHubResult<List<String>>?>(null, job.id, refresh) {
         value = null
         value = api.fetchJobLog(owner, repo, job.id)
     }
     Column(modifier = Modifier.fillMaxSize()) {
         Header("${statusGlyph(job.status, job.conclusion)} ${job.name}", ff, fs, onBack = onBack, onRefresh = { refresh++ })
-        ResultBody(state, ff, fs, empty = "No log output.") { log ->
-            // Cap to the most recent lines so a multi-MB log can't blow up the layout (Phase 3 adds
-            // ANSI coloring + smarter virtualization).
-            val lines = remember(log) { log.split('\n').let { if (it.size > MAX_LOG_LINES) it.takeLast(MAX_LOG_LINES) else it } }
+        ResultBody(state, ff, fs, empty = "No log output.") { lines ->
             LazyColumn(modifier = Modifier.fillMaxSize().padding(horizontal = 8.dp)) {
                 items(lines.size) { i ->
                     Text(lines[i], color = Color.White.copy(alpha = 0.92f), fontSize = (fs - 1).sp, fontFamily = ff)
@@ -226,5 +223,3 @@ private fun statusGlyph(status: String, conclusion: String?): String = when {
     conclusion == "skipped" -> "⏭️"
     else -> "⚠️"
 }
-
-private const val MAX_LOG_LINES = 4000


### PR DESCRIPTION
## GitHub Actions feature — Phase 2 (runs → jobs → job log)

**Stacked on #155 (Phase 1), which is stacked on #152 (Phase 0).** Base is the Phase 1 branch so the diff is just Phase 2; it auto-retargets as the stack merges down.

Builds the actual GitHub REST client and the drill-down panel, and wires the real owner/repo/token into the slot.

### Module (`:feature:github`)
- **`GitHubApi`** — OkHttp client (declared in the module so it's on the compile classpath; same catalog version as the base, so AGP de-dupes it out of the split). JSON via **`org.json`** (built into Android — no serialization plugin/dep). `listRuns` / `listJobs` / `fetchJobLog`, all `suspend` on `Dispatchers.IO`. The PAT is read lazily per call via `tokenProvider`; 401/403/404 map to friendly errors. The job-log endpoint's 302 to a signed URL is followed by OkHttp **without** re-sending `Authorization` (correct for the cross-host hop).
- **`GitHubModels`** — `WorkflowRun` / `WorkflowJob` + a `GitHubResult` Ok/Err wrapper (so the UI distinguishes auth/network/not-found cleanly).
- **`GitHubActionsPanel`** — runs list (status glyphs ✅/❌/🟡/⚪) → jobs → job log, with back nav, manual **Refresh**, loading/error/empty states, and a "configure in Settings" prompt when no repo is set. Job log is capped to the last 4000 lines for now (Phase 3 adds ANSI coloring + smarter virtualization).
- `GitHubFeatureImpl` delegates to the panel.

### Base wiring
- Real `owner`/`repo` and a `tokenProvider = { viewModel.readGithubToken() }` (decrypts off-thread on demand) + `onConfigure` (opens Settings) flow from `MainViewModel` through `LogBottomSheet` → `ExpandedView` → `GitHubFeatureSlot`. `onWatchRun` is a no-op until Phase 5.

### Verification
- ❌ Not built here — relying on CI. Key things CI proves: OkHttp resolves/de-dupes in the feature split, the panel compiles against the module + base, and the bundle still builds.

### Next
Phase 3: ANSI + `##[group]/##[error]/##[warning]` coloring with collapsible groups in the job-log view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GSxjeuLJyBVyFhGXcxbkSe)_

## Summary by Sourcery

Implement the real GitHub Actions drill-down panel backed by a GitHub REST client and wire it into the app with actual repository and token configuration.

New Features:
- Add a GitHubActionsPanel composable that lets users browse workflow runs, drill into jobs, and view job logs with loading, error, empty, and refresh states.
- Introduce a minimal GitHubApi client and data models for GitHub Actions runs and jobs, including a result wrapper for surfacing user-friendly errors.

Enhancements:
- Replace the placeholder GitHub feature UI with the functional GitHub Actions panel implementation in the dynamic feature module.
- Plumb real GitHub owner, repo, token provider, and configuration/watch callbacks from the main view model through the UI into the GitHub feature slot.

Build:
- Add OkHttp as a dependency to the GitHub feature module for making GitHub REST API calls.