### PR TITLE
GitHub Actions Phase 3: ANSI + annotation coloring, collapsible groups

### DIFF
--- a/feature/github/src/main/kotlin/com/hereliesaz/logkitty/feature/github/GitHubApi.kt
+++ b/feature/github/src/main/kotlin/com/hereliesaz/logkitty/feature/github/GitHubApi.kt
@@ -39,6 +39,10 @@ class GitHubApi(private val tokenProvider: () -> String?) {
             }
         }
 
+    /** Current status of a single job — used to detect when a live log can stop polling. */
+    suspend fun getJob(owner: String, repo: String, jobId: Long): GitHubResult<WorkflowJob> =
+        get("$API/repos/$owner/$repo/actions/jobs/$jobId") { body -> parseJob(JSONObject(body.string())) }
+
     /**
      * Fetches a job's plain-text log as lines. The endpoint 302-redirects to a short-lived signed URL
      * on another host; OkHttp follows it and drops the `Authorization` header on the cross-host hop

--- a/feature/github/src/main/kotlin/com/hereliesaz/logkitty/feature/github/GitHubLogView.kt
+++ b/feature/github/src/main/kotlin/com/hereliesaz/logkitty/feature/github/GitHubLogView.kt
@@ -1,0 +1,101 @@
+package com.hereliesaz.logkitty.feature.github
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.produceState
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * Renders a GitHub Actions job log with ANSI/annotation coloring and collapsible `##[group]` blocks.
+ *
+ * [logLines] is already capped by the API layer (streamed, last N lines). Parsing runs off the main
+ * thread, and the list is virtualized via [LazyColumn]; text is wrapped in a [SelectionContainer] so
+ * it can be selected/copied.
+ */
+@Composable
+fun GitHubLogView(logLines: List<String>, fontFamily: FontFamily?, fontSize: Int, modifier: Modifier = Modifier) {
+    val parsed by produceState<List<ParsedLogLine>?>(null, logLines) {
+        value = withContext(Dispatchers.Default) { LogAnsiClassifier.parse(logLines) }
+    }
+
+    val lines = parsed
+    if (lines == null) {
+        Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) { CircularProgressIndicator() }
+        return
+    }
+
+    // groupId -> collapsed. Reading it during the filter below subscribes to toggles.
+    val collapsed = remember(logLines) { mutableStateMapOf<Int, Boolean>() }
+    val visible = lines.filter { line ->
+        val g = line.groupId
+        g == null || line.isGroupHeader || collapsed[g] != true
+    }
+
+    val listState = rememberLazyListState()
+    SelectionContainer {
+        LazyColumn(state = listState, modifier = modifier.fillMaxSize().padding(horizontal = 8.dp)) {
+            items(visible.size) { idx ->
+                val line = visible[idx]
+                if (line.isGroupHeader && line.groupId != null) {
+                    val isCollapsed = collapsed[line.groupId] == true
+                    Text(
+                        text = buildAnnotatedString {
+                            withStyle(SpanStyle(color = Color(0xFF4DD0E1), fontWeight = FontWeight.Bold)) {
+                                append(if (isCollapsed) "▸ " else "▾ ")
+                                append(line.plain)
+                            }
+                        },
+                        fontSize = (fontSize - 1).sp,
+                        fontFamily = fontFamily,
+                        modifier = Modifier.fillMaxWidth()
+                            .clickable { collapsed[line.groupId] = !isCollapsed }
+                            .padding(vertical = 1.dp),
+                    )
+                } else {
+                    Text(
+                        text = line.toAnnotated(),
+                        fontSize = (fontSize - 1).sp,
+                        fontFamily = fontFamily,
+                        modifier = Modifier.fillMaxWidth().padding(vertical = 1.dp),
+                    )
+                }
+            }
+        }
+    }
+}
+
+private fun ParsedLogLine.toAnnotated() = buildAnnotatedString {
+    for (span in spans) {
+        withStyle(
+            SpanStyle(
+                color = span.color ?: DEFAULT_TEXT,
+                fontWeight = if (span.bold) FontWeight.Bold else FontWeight.Normal,
+            ),
+        ) { append(span.text) }
+    }
+}
+
+private val DEFAULT_TEXT = Color.White.copy(alpha = 0.92f)

--- a/feature/github/src/main/kotlin/com/hereliesaz/logkitty/feature/github/GitHubLogView.kt
+++ b/feature/github/src/main/kotlin/com/hereliesaz/logkitty/feature/github/GitHubLogView.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.produceState
@@ -47,11 +48,18 @@ fun GitHubLogView(logLines: List<String>, fontFamily: FontFamily?, fontSize: Int
         return
     }
 
-    // groupId -> collapsed. Reading it during the filter below subscribes to toggles.
-    val collapsed = remember(logLines) { mutableStateMapOf<Int, Boolean>() }
-    val visible = lines.filter { line ->
-        val g = line.groupId
-        g == null || line.isGroupHeader || collapsed[g] != true
+    // groupId -> collapsed. Keyless so a poll/refresh of the same job's log doesn't re-expand folded
+    // groups (the view is disposed/recreated when switching jobs, so state doesn't leak across jobs).
+    val collapsed = remember { mutableStateMapOf<Int, Boolean>() }
+    // derivedStateOf so the filter only re-runs when the lines or collapsed set change — not on every
+    // recomposition (scroll/animation) over potentially thousands of lines.
+    val visible by remember(lines) {
+        derivedStateOf {
+            lines.filter { line ->
+                val g = line.groupId
+                g == null || line.isGroupHeader || collapsed[g] != true
+            }
+        }
     }
 
     val listState = rememberLazyListState()

--- a/feature/github/src/main/kotlin/com/hereliesaz/logkitty/feature/github/GitHubPanel.kt
+++ b/feature/github/src/main/kotlin/com/hereliesaz/logkitty/feature/github/GitHubPanel.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import kotlinx.coroutines.delay
 
 /**
  * The GitHub Actions drill-down: runs → jobs → job log. Phase 2 does a single fetch per screen with
@@ -82,9 +83,16 @@ private fun RunsScreen(
     onRun: (WorkflowRun) -> Unit, modifier: Modifier,
 ) {
     var refresh by remember { mutableStateOf(0) }
+    // Live polling: refresh fast while any run is in progress, slowly otherwise. produceState cancels
+    // the loop when this screen leaves composition (e.g. drilling into a run).
     val state by produceState<GitHubResult<List<WorkflowRun>>?>(null, owner, repo, refresh) {
         value = null
-        value = api.listRuns(owner, repo)
+        while (true) {
+            val result = api.listRuns(owner, repo)
+            value = result
+            val active = result is GitHubResult.Ok && result.value.any { !it.isTerminal }
+            delay(if (active) ACTIVE_POLL_MS else IDLE_POLL_MS)
+        }
     }
     Column(modifier = modifier.fillMaxSize()) {
         Header("$owner/$repo", ff, fs, onBack = null, onRefresh = { refresh++ })
@@ -119,7 +127,12 @@ private fun JobsScreen(
     var refresh by remember { mutableStateOf(0) }
     val state by produceState<GitHubResult<List<WorkflowJob>>?>(null, run.id, refresh) {
         value = null
-        value = api.listJobs(owner, repo, run.id)
+        while (true) {
+            val result = api.listJobs(owner, repo, run.id)
+            value = result
+            val active = result is GitHubResult.Ok && result.value.any { !it.isTerminal }
+            delay(if (active) ACTIVE_POLL_MS else IDLE_POLL_MS)
+        }
     }
     Column(modifier = modifier.fillMaxSize()) {
         Header("${statusGlyph(run.status, run.conclusion)} ${run.name}", ff, fs, onBack = onBack, onRefresh = { refresh++ })
@@ -151,7 +164,12 @@ private fun JobLogScreen(
     var refresh by remember { mutableStateOf(0) }
     val state by produceState<GitHubResult<List<String>>?>(null, job.id, refresh) {
         value = null
-        value = api.fetchJobLog(owner, repo, job.id)
+        // A running job's log grows, so re-fetch on a cadence until the job is terminal.
+        while (true) {
+            value = api.fetchJobLog(owner, repo, job.id)
+            if (job.isTerminal) break
+            delay(ACTIVE_POLL_MS)
+        }
     }
     Column(modifier = Modifier.fillMaxSize()) {
         Header("${statusGlyph(job.status, job.conclusion)} ${job.name}", ff, fs, onBack = onBack, onRefresh = { refresh++ })
@@ -220,3 +238,7 @@ private fun statusGlyph(status: String, conclusion: String?): String = when {
     conclusion == "skipped" -> "⏭️"
     else -> "⚠️"
 }
+
+// Poll cadence: brisk while something is in progress, relaxed when everything is terminal.
+private const val ACTIVE_POLL_MS = 5000L
+private const val IDLE_POLL_MS = 30000L

--- a/feature/github/src/main/kotlin/com/hereliesaz/logkitty/feature/github/GitHubPanel.kt
+++ b/feature/github/src/main/kotlin/com/hereliesaz/logkitty/feature/github/GitHubPanel.kt
@@ -164,11 +164,15 @@ private fun JobLogScreen(
     var refresh by remember { mutableStateOf(0) }
     val state by produceState<GitHubResult<List<String>>?>(null, job.id, refresh) {
         value = null
-        // A running job's log grows, so re-fetch on a cadence until the job is terminal.
+        // A running job's log grows, so re-fetch on a cadence until the job is terminal. The passed-in
+        // `job` is a snapshot, so re-check the live status each round rather than trusting it — else a
+        // job opened while running would poll forever.
+        var terminal = job.isTerminal
         while (true) {
             value = api.fetchJobLog(owner, repo, job.id)
-            if (job.isTerminal) break
+            if (terminal) break
             delay(ACTIVE_POLL_MS)
+            terminal = (api.getJob(owner, repo, job.id) as? GitHubResult.Ok)?.value?.isTerminal ?: false
         }
     }
     Column(modifier = Modifier.fillMaxSize()) {

--- a/feature/github/src/main/kotlin/com/hereliesaz/logkitty/feature/github/GitHubPanel.kt
+++ b/feature/github/src/main/kotlin/com/hereliesaz/logkitty/feature/github/GitHubPanel.kt
@@ -156,11 +156,8 @@ private fun JobLogScreen(
     Column(modifier = Modifier.fillMaxSize()) {
         Header("${statusGlyph(job.status, job.conclusion)} ${job.name}", ff, fs, onBack = onBack, onRefresh = { refresh++ })
         ResultBody(state, ff, fs, empty = "No log output.") { lines ->
-            LazyColumn(modifier = Modifier.fillMaxSize().padding(horizontal = 8.dp)) {
-                items(lines.size) { i ->
-                    Text(lines[i], color = Color.White.copy(alpha = 0.92f), fontSize = (fs - 1).sp, fontFamily = ff)
-                }
-            }
+            // Colored, collapsible, selectable rendering (ANSI + ##[group]/##[error]/…).
+            GitHubLogView(logLines = lines, fontFamily = ff, fontSize = fs, modifier = Modifier.fillMaxSize())
         }
     }
 }

--- a/feature/github/src/main/kotlin/com/hereliesaz/logkitty/feature/github/LogAnsiClassifier.kt
+++ b/feature/github/src/main/kotlin/com/hereliesaz/logkitty/feature/github/LogAnsiClassifier.kt
@@ -170,7 +170,13 @@ object LogAnsiClassifier {
                     // 38;5;n (256) or 38;2;r;g;b (truecolor)
                     when (codes.getOrNull(k + 1)) {
                         5 -> { c = xterm256(codes.getOrNull(k + 2) ?: 0); k += 2 }
-                        2 -> { c = Color(codes.getOrNull(k + 2) ?: 0, codes.getOrNull(k + 3) ?: 0, codes.getOrNull(k + 4) ?: 0); k += 4 }
+                        2 -> {
+                            // Coerce — Color(Int,Int,Int) throws if a malformed escape gives out-of-range channels.
+                            val r = (codes.getOrNull(k + 2) ?: 0).coerceIn(0, 255)
+                            val g = (codes.getOrNull(k + 3) ?: 0).coerceIn(0, 255)
+                            val b = (codes.getOrNull(k + 4) ?: 0).coerceIn(0, 255)
+                            c = Color(r, g, b); k += 4
+                        }
                     }
                 }
                 // Backgrounds (40-49, 100-107) and other codes are ignored.

--- a/feature/github/src/main/kotlin/com/hereliesaz/logkitty/feature/github/LogAnsiClassifier.kt
+++ b/feature/github/src/main/kotlin/com/hereliesaz/logkitty/feature/github/LogAnsiClassifier.kt
@@ -1,0 +1,206 @@
+package com.hereliesaz.logkitty.feature.github
+
+import androidx.compose.ui.graphics.Color
+
+/** Severity of a parsed log line, from GitHub's `##[...]` workflow-command annotations. */
+enum class LogSeverity { NORMAL, ERROR, WARNING, NOTICE, DEBUG, GROUP, COMMAND }
+
+/** A run of text sharing one style. */
+data class LogSpan(val text: String, val color: Color?, val bold: Boolean)
+
+/**
+ * One parsed log line: styled [spans] for rendering, the [plain] text for copy/select, a [severity]
+ * (from `##[error]` etc.), and group membership so the view can collapse `##[group]…##[endgroup]`.
+ */
+data class ParsedLogLine(
+    val spans: List<LogSpan>,
+    val plain: String,
+    val severity: LogSeverity,
+    val groupId: Int?,
+    val isGroupHeader: Boolean,
+)
+
+/**
+ * Parses raw GitHub Actions job-log text into styled, group-aware lines.
+ *
+ * Handles: the leading ISO-8601 timestamp GitHub prefixes to every line (optionally stripped); the
+ * `##[group]/##[endgroup]/##[error]/##[warning]/##[notice]/##[debug]/##[command]` workflow commands;
+ * and inline ANSI SGR escapes (reset/bold + 8/16/256/truecolor foreground). Background and unknown
+ * codes are ignored; malformed escapes are dropped rather than rendered as garbage. Pure function —
+ * call it off the main thread.
+ */
+object LogAnsiClassifier {
+
+    private val TIMESTAMP = Regex("""^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z\s""")
+    private val COMMAND = Regex("""^##\[(group|endgroup|error|warning|notice|debug|command|section)](.*)$""")
+
+    fun parse(lines: List<String>, stripTimestamps: Boolean = true): List<ParsedLogLine> {
+        val out = ArrayList<ParsedLogLine>()
+        var groupCounter = 0
+        var currentGroup: Int? = null
+        for (rawLine in lines) {
+            var line = rawLine
+            if (stripTimestamps) line = TIMESTAMP.replaceFirst(line, "")
+
+            val cmd = COMMAND.find(line)
+            if (cmd != null) {
+                val kind = cmd.groupValues[1]
+                val rest = cmd.groupValues[2]
+                when (kind) {
+                    "group" -> {
+                        currentGroup = ++groupCounter
+                        out.add(headerLine(rest, currentGroup))
+                        continue
+                    }
+                    "endgroup" -> {
+                        currentGroup = null
+                        continue // the endgroup marker itself isn't shown
+                    }
+                    else -> {
+                        val severity = when (kind) {
+                            "error" -> LogSeverity.ERROR
+                            "warning" -> LogSeverity.WARNING
+                            "notice" -> LogSeverity.NOTICE
+                            "debug" -> LogSeverity.DEBUG
+                            else -> LogSeverity.COMMAND
+                        }
+                        val plain = stripAnsi(rest)
+                        out.add(ParsedLogLine(listOf(LogSpan(plain, severityColor(severity), severity == LogSeverity.ERROR)), plain, severity, currentGroup, false))
+                        continue
+                    }
+                }
+            }
+
+            val spans = parseAnsi(line)
+            val plain = spans.joinToString("") { it.text }
+            out.add(ParsedLogLine(spans, plain, LogSeverity.NORMAL, currentGroup, false))
+        }
+        return out
+    }
+
+    private fun headerLine(title: String, groupId: Int): ParsedLogLine {
+        val plain = stripAnsi(title)
+        return ParsedLogLine(
+            spans = listOf(LogSpan(plain, severityColor(LogSeverity.GROUP), bold = true)),
+            plain = plain,
+            severity = LogSeverity.GROUP,
+            groupId = groupId,
+            isGroupHeader = true,
+        )
+    }
+
+    private fun severityColor(s: LogSeverity): Color? = when (s) {
+        LogSeverity.ERROR -> Color(0xFFE57373)
+        LogSeverity.WARNING -> Color(0xFFFFB74D)
+        LogSeverity.NOTICE -> Color(0xFF64B5F6)
+        LogSeverity.DEBUG -> Color(0xFF90A4AE)
+        LogSeverity.GROUP -> Color(0xFF4DD0E1)
+        LogSeverity.COMMAND -> Color(0xFF4DD0E1)
+        LogSeverity.NORMAL -> null
+    }
+
+    // --- ANSI SGR ---
+
+    private const val ESC = '\u001b'
+
+    /** Strips all ANSI escape sequences, returning plain text. */
+    private fun stripAnsi(s: String): String {
+        if (s.indexOf(ESC) < 0) return s
+        return parseAnsi(s).joinToString("") { it.text }
+    }
+
+    /**
+     * Splits [s] into styled spans, tracking a per-line SGR state (GitHub resets styling per line, so
+     * we start fresh each call). Recognizes `ESC [ params m`; other escape kinds are skipped.
+     */
+    private fun parseAnsi(s: String): List<LogSpan> {
+        if (s.indexOf(ESC) < 0) return listOf(LogSpan(s, null, false))
+        val spans = ArrayList<LogSpan>()
+        val buf = StringBuilder()
+        var color: Color? = null
+        var bold = false
+        var i = 0
+        fun flush() {
+            if (buf.isNotEmpty()) {
+                spans.add(LogSpan(buf.toString(), color, bold))
+                buf.setLength(0)
+            }
+        }
+        while (i < s.length) {
+            val c = s[i]
+            if (c == ESC && i + 1 < s.length && s[i + 1] == '[') {
+                val m = i + 2
+                var j = m
+                while (j < s.length && s[j] != 'm' && (s[j].isDigit() || s[j] == ';')) j++
+                if (j < s.length && s[j] == 'm') {
+                    flush()
+                    val params = s.substring(m, j)
+                    val (nc, nb) = applySgr(params, color, bold)
+                    color = nc; bold = nb
+                    i = j + 1
+                    continue
+                }
+                // Not an SGR sequence we understand — skip the ESC and continue literally.
+                i++
+                continue
+            }
+            buf.append(c)
+            i++
+        }
+        flush()
+        return if (spans.isEmpty()) listOf(LogSpan("", null, false)) else spans
+    }
+
+    /** Applies one SGR parameter list to the current (color, bold) state. */
+    private fun applySgr(params: String, color: Color?, bold: Boolean): Pair<Color?, Boolean> {
+        val codes = params.split(';').mapNotNull { it.toIntOrNull() }
+        if (codes.isEmpty()) return null to false // bare ESC[m == reset
+        var c = color
+        var b = bold
+        var k = 0
+        while (k < codes.size) {
+            when (val code = codes[k]) {
+                0 -> { c = null; b = false }
+                1 -> b = true
+                22 -> b = false
+                39 -> c = null
+                in 30..37 -> c = standard(code - 30, bright = false)
+                in 90..97 -> c = standard(code - 90, bright = true)
+                38 -> {
+                    // 38;5;n (256) or 38;2;r;g;b (truecolor)
+                    when (codes.getOrNull(k + 1)) {
+                        5 -> { c = xterm256(codes.getOrNull(k + 2) ?: 0); k += 2 }
+                        2 -> { c = Color(codes.getOrNull(k + 2) ?: 0, codes.getOrNull(k + 3) ?: 0, codes.getOrNull(k + 4) ?: 0); k += 4 }
+                    }
+                }
+                // Backgrounds (40-49, 100-107) and other codes are ignored.
+            }
+            k++
+        }
+        return c to b
+    }
+
+    // Palette tuned for a dark background (no pure black).
+    private fun standard(index: Int, bright: Boolean): Color = when (index) {
+        0 -> if (bright) Color(0xFF9E9E9E) else Color(0xFF6E6E6E) // black/gray
+        1 -> Color(0xFFE57373) // red
+        2 -> Color(0xFF81C784) // green
+        3 -> if (bright) Color(0xFFFFD54F) else Color(0xFFFFB74D) // yellow
+        4 -> Color(0xFF64B5F6) // blue
+        5 -> Color(0xFFBA68C8) // magenta
+        6 -> Color(0xFF4DD0E1) // cyan
+        else -> if (bright) Color(0xFFFFFFFF) else Color(0xFFE0E0E0) // white
+    }
+
+    private fun xterm256(n: Int): Color = when (n) {
+        in 0..7 -> standard(n, bright = false)
+        in 8..15 -> standard(n - 8, bright = true)
+        in 16..231 -> {
+            val v = n - 16
+            fun ch(c: Int) = if (c == 0) 0 else 55 + 40 * c
+            Color(ch(v / 36), ch((v / 6) % 6), ch(v % 6))
+        }
+        in 232..255 -> { val g = 8 + 10 * (n - 232); Color(g, g, g) }
+        else -> Color(0xFFE0E0E0)
+    }
+}


### PR DESCRIPTION
## GitHub Actions feature — Phase 3 (ANSI + annotation coloring, collapsible groups)

**Stacked on #156 (Phase 2).** Base is the Phase 2 branch so the diff is just Phase 3; auto-retargets as the stack merges down.

Turns the plain job-log view into a colored, foldable one.

### What's here
- **`LogAnsiClassifier`** — parses job-log lines into styled, group-aware lines:
  - strips GitHub's leading ISO-8601 timestamp (toggleable),
  - recognizes the `##[group]/endgroup/error/warning/notice/debug/command]` workflow annotations (severity colors),
  - parses inline **ANSI SGR** escapes: reset/bold + 8/16/**256**/**truecolor** foreground (backgrounds and unknown codes ignored; malformed escapes dropped, not rendered as garbage).
  - Pure function; consumes the `List<String>` the API streams (no extra splitting).
- **`GitHubLogView`** — colored, virtualized (`LazyColumn`), **selectable** (`SelectionContainer`) log with **collapsible `##[group]` blocks** (tap a header ▸/▾ to fold) and distinct error/warning/notice/debug colors. Parses off the main thread.
- `JobLogScreen` now renders `GitHubLogView`.

### Note on the stack
This branch's history also carries the Phase 2 review fixes I pushed to #156 in response to Gemini (streaming `fetchJobLog` → `List<String>` to avoid OOM; `optStringSafe` for Android's `optString`-returns-`"null"` quirk). Phase 3 builds directly on that streamed `List<String>`.

### Verification
- ❌ Not built here — relying on CI. On-device: trigger a workflow with grouped/colored output and confirm groups fold and colors render.

### Next
Phase 4: live polling while a run is in progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GSxjeuLJyBVyFhGXcxbkSe)_

## Summary by Sourcery

Add live polling and enhanced GitHub Actions job log rendering with ANSI styling and collapsible groups.

New Features:
- Introduce GitHubLogView to render job logs with ANSI and GitHub annotation coloring, selectable text, and collapsible group sections.
- Parse raw GitHub Actions log lines into styled, group-aware structures via LogAnsiClassifier, including severity detection and ANSI SGR color support.
- Add API support to fetch an individual job's status for determining when log polling can stop.

Enhancements:
- Change runs, jobs, and job-log screens to live-poll GitHub Actions data with different cadences for active versus idle states, while preserving manual refresh.
- Replace the plain text job log list with a virtualized, styled view that offloads parsing from the main thread for better performance on large logs.