### PR TITLE
GitHub Actions Phase 4: live polling

### DIFF
--- a/feature/github/src/main/kotlin/com/hereliesaz/logkitty/feature/github/GitHubApi.kt
+++ b/feature/github/src/main/kotlin/com/hereliesaz/logkitty/feature/github/GitHubApi.kt
@@ -39,6 +39,10 @@ class GitHubApi(private val tokenProvider: () -> String?) {
             }
         }
 
+    /** Current status of a single job — used to detect when a live log can stop polling. */
+    suspend fun getJob(owner: String, repo: String, jobId: Long): GitHubResult<WorkflowJob> =
+        get("$API/repos/$owner/$repo/actions/jobs/$jobId") { body -> parseJob(JSONObject(body.string())) }
+
     /**
      * Fetches a job's plain-text log as lines. The endpoint 302-redirects to a short-lived signed URL
      * on another host; OkHttp follows it and drops the `Authorization` header on the cross-host hop

--- a/feature/github/src/main/kotlin/com/hereliesaz/logkitty/feature/github/GitHubPanel.kt
+++ b/feature/github/src/main/kotlin/com/hereliesaz/logkitty/feature/github/GitHubPanel.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import kotlinx.coroutines.delay
 
 /**
  * The GitHub Actions drill-down: runs → jobs → job log. Phase 2 does a single fetch per screen with
@@ -82,9 +83,16 @@ private fun RunsScreen(
     onRun: (WorkflowRun) -> Unit, modifier: Modifier,
 ) {
     var refresh by remember { mutableStateOf(0) }
+    // Live polling: refresh fast while any run is in progress, slowly otherwise. produceState cancels
+    // the loop when this screen leaves composition (e.g. drilling into a run).
     val state by produceState<GitHubResult<List<WorkflowRun>>?>(null, owner, repo, refresh) {
         value = null
-        value = api.listRuns(owner, repo)
+        while (true) {
+            val result = api.listRuns(owner, repo)
+            value = result
+            val active = result is GitHubResult.Ok && result.value.any { !it.isTerminal }
+            delay(if (active) ACTIVE_POLL_MS else IDLE_POLL_MS)
+        }
     }
     Column(modifier = modifier.fillMaxSize()) {
         Header("$owner/$repo", ff, fs, onBack = null, onRefresh = { refresh++ })
@@ -119,7 +127,12 @@ private fun JobsScreen(
     var refresh by remember { mutableStateOf(0) }
     val state by produceState<GitHubResult<List<WorkflowJob>>?>(null, run.id, refresh) {
         value = null
-        value = api.listJobs(owner, repo, run.id)
+        while (true) {
+            val result = api.listJobs(owner, repo, run.id)
+            value = result
+            val active = result is GitHubResult.Ok && result.value.any { !it.isTerminal }
+            delay(if (active) ACTIVE_POLL_MS else IDLE_POLL_MS)
+        }
     }
     Column(modifier = modifier.fillMaxSize()) {
         Header("${statusGlyph(run.status, run.conclusion)} ${run.name}", ff, fs, onBack = onBack, onRefresh = { refresh++ })
@@ -151,7 +164,12 @@ private fun JobLogScreen(
     var refresh by remember { mutableStateOf(0) }
     val state by produceState<GitHubResult<List<String>>?>(null, job.id, refresh) {
         value = null
-        value = api.fetchJobLog(owner, repo, job.id)
+        // A running job's log grows, so re-fetch on a cadence until the job is terminal.
+        while (true) {
+            value = api.fetchJobLog(owner, repo, job.id)
+            if (job.isTerminal) break
+            delay(ACTIVE_POLL_MS)
+        }
     }
     Column(modifier = Modifier.fillMaxSize()) {
         Header("${statusGlyph(job.status, job.conclusion)} ${job.name}", ff, fs, onBack = onBack, onRefresh = { refresh++ })
@@ -220,3 +238,7 @@ private fun statusGlyph(status: String, conclusion: String?): String = when {
     conclusion == "skipped" -> "⏭️"
     else -> "⚠️"
 }
+
+// Poll cadence: brisk while something is in progress, relaxed when everything is terminal.
+private const val ACTIVE_POLL_MS = 5000L
+private const val IDLE_POLL_MS = 30000L

--- a/feature/github/src/main/kotlin/com/hereliesaz/logkitty/feature/github/GitHubPanel.kt
+++ b/feature/github/src/main/kotlin/com/hereliesaz/logkitty/feature/github/GitHubPanel.kt
@@ -164,11 +164,15 @@ private fun JobLogScreen(
     var refresh by remember { mutableStateOf(0) }
     val state by produceState<GitHubResult<List<String>>?>(null, job.id, refresh) {
         value = null
-        // A running job's log grows, so re-fetch on a cadence until the job is terminal.
+        // A running job's log grows, so re-fetch on a cadence until the job is terminal. The passed-in
+        // `job` is a snapshot, so re-check the live status each round rather than trusting it — else a
+        // job opened while running would poll forever.
+        var terminal = job.isTerminal
         while (true) {
             value = api.fetchJobLog(owner, repo, job.id)
-            if (job.isTerminal) break
+            if (terminal) break
             delay(ACTIVE_POLL_MS)
+            terminal = (api.getJob(owner, repo, job.id) as? GitHubResult.Ok)?.value?.isTerminal ?: false
         }
     }
     Column(modifier = Modifier.fillMaxSize()) {


### PR DESCRIPTION
## GitHub Actions feature — Phase 4 (live polling)

**Stacked on #157 (Phase 3).** Module-only change.

While a run/job is in progress, the panel now refreshes itself instead of needing a manual tap.

- Each screen's fetch (runs, jobs, job log) runs in a `produceState` loop that polls **fast (5s)** while anything is in progress and **slowly (30s)** once everything is terminal. The job-log loop re-fetches the growing log until the job completes, then stops.
- `produceState` ties each loop to composition, so polling **cancels automatically** when you leave the screen (drill in/out or close the sheet) — no leaked loops.
- Manual **Refresh** still works (it just resets the loop).

This mirrors the `StatsFeatureImpl` polling pattern. (Rate-limit/ETag refinements from the plan can layer on later; the stop-on-terminal + slow-idle cadence already keeps request volume modest.)

### Verification
- ❌ Not built here — relying on CI. On-device: open a repo with a running workflow and watch the status glyph flip and the log grow without tapping Refresh.

### Note on the stack
Carries the Phase 3 review fixes pushed to #157 (truecolor RGB coercion; keyless collapse map + `derivedStateOf`).

### Next
Phase 5: completion notifications via WorkManager (wires the `onWatchRun` callback that's currently a no-op).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GSxjeuLJyBVyFhGXcxbkSe)_

## Summary by Sourcery

Implement live polling for GitHub Actions runs, jobs, and job logs so the panel updates automatically while workflows are in progress.

New Features:
- Add automatic polling of workflow runs and jobs with faster cadence while any item is in progress and slower cadence once all are terminal.
- Add continuous polling of job logs while a job is running, stopping once the job reaches a terminal state.

Enhancements:
- Introduce a GitHub API endpoint to fetch the current status of a single job to support stopping log polling when the job completes.
- Centralize configurable polling intervals for active and idle states used across the GitHub Actions panel screens.