### PR TITLE
GitHub Actions Phase 5: completion notifications (WorkManager)

### DIFF
--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/GitHubFeatureSlot.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/GitHubFeatureSlot.kt
@@ -51,7 +51,6 @@ fun GitHubFeatureSlot(
     repo: String,
     tokenProvider: () -> String?,
     onConfigure: () -> Unit,
-    onWatchRun: (owner: String, repo: String, runId: Long, runName: String) -> Unit,
     fontFamily: FontFamily?,
     fontSize: Int,
     modifier: Modifier = Modifier,
@@ -71,7 +70,11 @@ fun GitHubFeatureSlot(
                     tokenProvider = tokenProvider,
                     fontFamily = fontFamily,
                     fontSize = fontSize,
-                    onWatchRun = onWatchRun,
+                    // "Watch this run" → a WorkManager job that polls to completion (survives the
+                    // panel closing / process death) and posts a ✅/❌ notification.
+                    onWatchRun = { o, r, runId, runName ->
+                        com.hereliesaz.logkitty.work.RunWatchWorker.enqueue(context, o, r, runId, runName)
+                    },
                     onConfigure = onConfigure,
                     modifier = modifier,
                 )

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/LogBottomSheet.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/LogBottomSheet.kt
@@ -477,7 +477,6 @@ private fun ExpandedView(
                     repo = githubRepo,
                     tokenProvider = githubTokenProvider,
                     onConfigure = onSettingsClick,
-                    onWatchRun = { _, _, _, _ -> },
                     fontFamily = fontFamily,
                     fontSize = fontSize,
                     modifier = Modifier.fillMaxSize(),

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/work/RunWatchWorker.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/work/RunWatchWorker.kt
@@ -1,0 +1,156 @@
+package com.hereliesaz.logkitty.work
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import android.content.Intent
+import android.app.PendingIntent
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import androidx.work.BackoffPolicy
+import androidx.work.Constraints
+import androidx.work.Data
+import androidx.work.ExistingWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequest
+import androidx.work.WorkManager
+import androidx.work.Worker
+import androidx.work.WorkerParameters
+import com.hereliesaz.logkitty.MainActivity
+import com.hereliesaz.logkitty.R
+import com.hereliesaz.logkitty.utils.GitHubCredentials
+import java.util.concurrent.TimeUnit
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.json.JSONObject
+
+/**
+ * Watches one GitHub Actions run to completion and posts a ✅/❌ notification when it finishes.
+ *
+ * Runs in the base process (so it can read the PAT from [GitHubCredentials] directly) and survives
+ * the panel being closed and even process death — which `produceState` polling cannot. It's a plain
+ * [Worker] (synchronous `doWork` on WorkManager's background executor), so it can block on OkHttp and
+ * needs no `work-runtime-ktx`/coroutines. While the run is still going it returns [Result.retry] and
+ * WorkManager re-runs it with linear backoff, up to [MAX_ATTEMPTS].
+ */
+class RunWatchWorker(context: Context, params: WorkerParameters) : Worker(context, params) {
+
+    override fun doWork(): Result {
+        val owner = inputData.getString(KEY_OWNER) ?: return Result.failure()
+        val repo = inputData.getString(KEY_REPO) ?: return Result.failure()
+        val runId = inputData.getLong(KEY_RUN_ID, -1L).takeIf { it >= 0 } ?: return Result.failure()
+        val runName = inputData.getString(KEY_RUN_NAME) ?: "Workflow run"
+
+        val token = GitHubCredentials(applicationContext).readToken()
+        val status = fetchRunStatus(owner, repo, runId, token)
+            ?: return if (runAttemptCount < MAX_ATTEMPTS) Result.retry() else Result.success()
+
+        if (status.terminal) {
+            postCompletion(owner, repo, runId, runName, status.conclusion)
+            return Result.success()
+        }
+        // Still running — try again later (give up quietly after MAX_ATTEMPTS so we don't poll forever).
+        return if (runAttemptCount < MAX_ATTEMPTS) Result.retry() else Result.success()
+    }
+
+    private data class RunStatus(val terminal: Boolean, val conclusion: String?)
+
+    private fun fetchRunStatus(owner: String, repo: String, runId: Long, token: String?): RunStatus? {
+        val builder = Request.Builder()
+            .url("https://api.github.com/repos/$owner/$repo/actions/runs/$runId")
+            .header("Accept", "application/vnd.github+json")
+            .header("X-GitHub-Api-Version", "2022-11-28")
+        token?.takeIf { it.isNotBlank() }?.let { builder.header("Authorization", "Bearer $it") }
+        return try {
+            client.newCall(builder.build()).execute().use { resp ->
+                if (!resp.isSuccessful) return null
+                val o = JSONObject(resp.body?.string().orEmpty())
+                val statusStr = o.optString("status")
+                val conclusion = o.opt("conclusion")?.takeIf { it != JSONObject.NULL }?.toString()
+                RunStatus(terminal = statusStr == "completed", conclusion = conclusion)
+            }
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    private fun postCompletion(owner: String, repo: String, runId: Long, runName: String, conclusion: String?) {
+        val success = conclusion == "success"
+        val glyph = when (conclusion) {
+            "success" -> "✅"
+            "failure", "timed_out" -> "❌"
+            "cancelled" -> "🚫"
+            else -> "⚠️"
+        }
+        val title = applicationContext.getString(
+            if (success) R.string.github_notif_passed else R.string.github_notif_finished, glyph,
+        )
+        val text = applicationContext.getString(R.string.github_notif_run, "$owner/$repo", runName)
+
+        ensureChannel()
+        val tapIntent = Intent(applicationContext, MainActivity::class.java)
+            .apply { addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP) }
+        val pending = PendingIntent.getActivity(
+            applicationContext, runId.toInt(), tapIntent,
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+        )
+        val notification = NotificationCompat.Builder(applicationContext, CHANNEL_ID)
+            .setSmallIcon(android.R.drawable.ic_menu_view)
+            .setContentTitle(title)
+            .setContentText(text)
+            .setStyle(NotificationCompat.BigTextStyle().bigText(text))
+            .setContentIntent(pending)
+            .setAutoCancel(true)
+            .build()
+        // notify() throws nothing if POST_NOTIFICATIONS is missing; it's a silent no-op on 33+.
+        try {
+            NotificationManagerCompat.from(applicationContext).notify(runId.toInt(), notification)
+        } catch (e: SecurityException) {
+            // Notifications not permitted — nothing more to do.
+        }
+    }
+
+    private fun ensureChannel() {
+        val mgr = applicationContext.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        if (mgr.getNotificationChannel(CHANNEL_ID) == null) {
+            mgr.createNotificationChannel(
+                NotificationChannel(
+                    CHANNEL_ID,
+                    applicationContext.getString(R.string.github_notif_channel),
+                    NotificationManager.IMPORTANCE_DEFAULT,
+                ),
+            )
+        }
+    }
+
+    companion object {
+        private const val CHANNEL_ID = "logkitty_github_channel"
+        private const val KEY_OWNER = "owner"
+        private const val KEY_REPO = "repo"
+        private const val KEY_RUN_ID = "run_id"
+        private const val KEY_RUN_NAME = "run_name"
+        private const val MAX_ATTEMPTS = 80
+
+        private val client = OkHttpClient.Builder()
+            .connectTimeout(15, TimeUnit.SECONDS)
+            .readTimeout(20, TimeUnit.SECONDS)
+            .build()
+
+        /** Enqueues a watch for [runId]; KEEP so re-watching the same run doesn't stack duplicates. */
+        fun enqueue(context: Context, owner: String, repo: String, runId: Long, runName: String) {
+            val data = Data.Builder()
+                .putString(KEY_OWNER, owner)
+                .putString(KEY_REPO, repo)
+                .putLong(KEY_RUN_ID, runId)
+                .putString(KEY_RUN_NAME, runName)
+                .build()
+            val request = OneTimeWorkRequest.Builder(RunWatchWorker::class.java)
+                .setInputData(data)
+                .setConstraints(Constraints.Builder().setRequiredNetworkType(NetworkType.CONNECTED).build())
+                .setBackoffCriteria(BackoffPolicy.LINEAR, 30, TimeUnit.SECONDS)
+                .build()
+            WorkManager.getInstance(context)
+                .enqueueUniqueWork("watch_run_$runId", ExistingWorkPolicy.KEEP, request)
+        }
+    }
+}

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/work/RunWatchWorker.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/work/RunWatchWorker.kt
@@ -42,8 +42,12 @@ class RunWatchWorker(context: Context, params: WorkerParameters) : Worker(contex
         val runName = inputData.getString(KEY_RUN_NAME) ?: "Workflow run"
 
         val token = GitHubCredentials(applicationContext).readToken()
-        val status = fetchRunStatus(owner, repo, runId, token)
-            ?: return if (runAttemptCount < MAX_ATTEMPTS) Result.retry() else Result.success()
+        val status = when (val r = fetchRunStatus(owner, repo, runId, token)) {
+            is FetchResult.Success -> r.status
+            // Auth/not-found/bad-request won't fix themselves — fail instead of retrying 80×.
+            FetchResult.Permanent -> return Result.failure()
+            FetchResult.Transient -> return if (runAttemptCount < MAX_ATTEMPTS) Result.retry() else Result.success()
+        }
 
         if (status.terminal) {
             postCompletion(owner, repo, runId, runName, status.conclusion)
@@ -55,7 +59,15 @@ class RunWatchWorker(context: Context, params: WorkerParameters) : Worker(contex
 
     private data class RunStatus(val terminal: Boolean, val conclusion: String?)
 
-    private fun fetchRunStatus(owner: String, repo: String, runId: Long, token: String?): RunStatus? {
+    private sealed interface FetchResult {
+        data class Success(val status: RunStatus) : FetchResult
+        /** Retryable (network blip, 5xx, rate-limit). */
+        data object Transient : FetchResult
+        /** Won't change on retry (401/403/404/400) — stop. */
+        data object Permanent : FetchResult
+    }
+
+    private fun fetchRunStatus(owner: String, repo: String, runId: Long, token: String?): FetchResult {
         val builder = Request.Builder()
             .url("https://api.github.com/repos/$owner/$repo/actions/runs/$runId")
             .header("Accept", "application/vnd.github+json")
@@ -63,14 +75,19 @@ class RunWatchWorker(context: Context, params: WorkerParameters) : Worker(contex
         token?.takeIf { it.isNotBlank() }?.let { builder.header("Authorization", "Bearer $it") }
         return try {
             client.newCall(builder.build()).execute().use { resp ->
-                if (!resp.isSuccessful) return null
-                val o = JSONObject(resp.body?.string().orEmpty())
-                val statusStr = o.optString("status")
-                val conclusion = o.opt("conclusion")?.takeIf { it != JSONObject.NULL }?.toString()
-                RunStatus(terminal = statusStr == "completed", conclusion = conclusion)
+                when {
+                    resp.isSuccessful -> {
+                        val o = JSONObject(resp.body?.string().orEmpty())
+                        val statusStr = o.optString("status")
+                        val conclusion = o.opt("conclusion")?.takeIf { it != JSONObject.NULL }?.toString()
+                        FetchResult.Success(RunStatus(terminal = statusStr == "completed", conclusion = conclusion))
+                    }
+                    resp.code == 400 || resp.code == 401 || resp.code == 403 || resp.code == 404 -> FetchResult.Permanent
+                    else -> FetchResult.Transient
+                }
             }
         } catch (e: Exception) {
-            null
+            FetchResult.Transient
         }
     }
 
@@ -90,8 +107,10 @@ class RunWatchWorker(context: Context, params: WorkerParameters) : Worker(contex
         ensureChannel()
         val tapIntent = Intent(applicationContext, MainActivity::class.java)
             .apply { addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP) }
+        // Run IDs are Long and overflow Int, so don't truncate: hash for the request code, and tag the
+        // notification by run id (with a fixed numeric id) so distinct runs don't collide/overwrite.
         val pending = PendingIntent.getActivity(
-            applicationContext, runId.toInt(), tapIntent,
+            applicationContext, runId.hashCode(), tapIntent,
             PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
         )
         val notification = NotificationCompat.Builder(applicationContext, CHANNEL_ID)
@@ -104,7 +123,7 @@ class RunWatchWorker(context: Context, params: WorkerParameters) : Worker(contex
             .build()
         // notify() throws nothing if POST_NOTIFICATIONS is missing; it's a silent no-op on 33+.
         try {
-            NotificationManagerCompat.from(applicationContext).notify(runId.toInt(), notification)
+            NotificationManagerCompat.from(applicationContext).notify("watch_run_$runId", 0, notification)
         } catch (e: SecurityException) {
             // Notifications not permitted — nothing more to do.
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -152,6 +152,11 @@
     <string name="github_clear_token">Clear token</string>
     <string name="toast_github_saved">GitHub settings saved</string>
     <string name="toast_github_token_cleared">GitHub token cleared</string>
+    <!-- GitHub run-completion notifications -->
+    <string name="github_notif_channel">GitHub Actions</string>
+    <string name="github_notif_passed">%1$s Workflow run passed</string>
+    <string name="github_notif_finished">%1$s Workflow run finished</string>
+    <string name="github_notif_run">%1$s · %2$s</string>
 
     <!-- Tabs -->
     <string name="tab_all">All</string>


### PR DESCRIPTION
## GitHub Actions feature — Phase 5 (completion notifications)

Off a clean `main` (Phases 0–4 merged). Wires the previously no-op **"Watch this run"** action to a real background watcher.

### What's here
- **`RunWatchWorker`** (base `app`, package `…work`) — watches one run to completion and posts a **✅/❌ notification**. It runs in the base process so it reads the PAT straight from `GitHubCredentials`, and it survives the panel closing and even **process death** (which the `produceState` polling can't). It's a **plain `Worker`** (blocking OkHttp + `org.json`), so it needs no `work-runtime-ktx`/coroutines — `main` only has `work-runtime`. While the run is in progress it returns `Result.retry()` (linear 30s backoff) up to `MAX_ATTEMPTS`, then gives up quietly; on completion it posts to a new **default-importance `logkitty_github_channel`** and deep-links to `MainActivity` on tap.
- **`GitHubFeatureSlot`** now builds `onWatchRun` itself — enqueues the worker via `WorkManager` (unique work, `KEEP` so re-watching the same run doesn't stack duplicates). So both the overlay tab and the future full screen get notifications for free; dropped the `onWatchRun` param + the `ExpandedView` no-op.
- Notification strings added. Uses the already-declared `POST_NOTIFICATIONS`; `notify()` degrades to a no-op if it isn't granted.

WorkManager's default (androidx.startup) initializer is intact in the manifest, so `WorkManager.getInstance` works without extra setup.

### How to use
In a run's Jobs screen, tap **"Notify me when this run finishes"** (shown while the run is in progress). You'll get a ✅/❌ notification when it completes, even if you've closed the overlay.

### Verification
- ❌ Not built here — relying on CI. On-device: watch an in-progress run, background the app, confirm the completion notification fires and tapping it opens LogKitty.

### Next
Phase 6: the full in-app GitHub screen (reuses the same `GitHubFeatureSlot`). Then Phase 7 (OAuth) and Part 2 (Stats drill-down).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GSxjeuLJyBVyFhGXcxbkSe)_

## Summary by Sourcery

Add background GitHub Actions run completion monitoring via WorkManager and surface results through system notifications.

New Features:
- Introduce a RunWatchWorker WorkManager job that polls a single GitHub Actions run until completion and triggers a notification.
- Wire the GitHub feature UI's "watch run" action to enqueue the background worker so completion notifications work from the overlay.

Enhancements:
- Add localized strings and a notification channel for GitHub Actions run completion notifications.