### PR TITLE
GitHub Actions Phase 6: full-screen view in the app

### DIFF
--- a/app/src/main/kotlin/com/hereliesaz/logkitty/MainActivity.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/MainActivity.kt
@@ -140,7 +140,9 @@ class MainActivity : ComponentActivity() {
                             GitHubScreen(
                                 viewModel = viewModel,
                                 onBack = { showGitHub = false },
-                                onConfigure = { showGitHub = false; showSettings = true },
+                                // Keep showGitHub=true: the when checks showSettings first, so Settings
+                                // shows on top and backing out of it returns here, not the dashboard.
+                                onConfigure = { showSettings = true },
                             )
                         else -> {
                             // Show the Main Dashboard / Permission Wizard.

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/MainActivity.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/MainActivity.kt
@@ -36,6 +36,7 @@ import com.google.android.play.core.install.model.UpdateAvailability
 import com.hereliesaz.aznavrail.AzButton
 import com.hereliesaz.aznavrail.model.AzButtonShape
 import com.hereliesaz.logkitty.services.LogKittyOverlayService
+import com.hereliesaz.logkitty.ui.GitHubScreen
 import com.hereliesaz.logkitty.ui.SettingsScreen
 import com.hereliesaz.logkitty.ui.theme.LogKittyTheme
 
@@ -58,6 +59,7 @@ class MainActivity : ComponentActivity() {
 
     // UI State for Navigation
     private var showSettings by mutableStateOf(false)
+    private var showGitHub by mutableStateOf(false)
 
     // Activity Result Launcher for the "Display Over Other Apps" system settings screen.
     private val overlayPermissionLauncher = registerForActivityResult(
@@ -125,28 +127,38 @@ class MainActivity : ComponentActivity() {
                 }
 
                 Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
-                    if (showSettings) {
-                        // Show the Settings Screen (Full Page).
-                        SettingsScreen(
-                            onBack = { showSettings = false },
-                            viewModel = (application as MainApplication).mainViewModel
-                        )
-                    } else {
-                        // Show the Main Dashboard / Permission Wizard.
-                        val viewModel = (application as MainApplication).mainViewModel
-                        val isRootEnabled by viewModel.isRootEnabled.collectAsState()
+                    val viewModel = (application as MainApplication).mainViewModel
+                    when {
+                        showSettings ->
+                            // Show the Settings Screen (Full Page).
+                            SettingsScreen(
+                                onBack = { showSettings = false },
+                                viewModel = viewModel
+                            )
+                        showGitHub ->
+                            // Full-screen GitHub Actions (same panel the overlay tab hosts).
+                            GitHubScreen(
+                                viewModel = viewModel,
+                                onBack = { showGitHub = false },
+                                onConfigure = { showGitHub = false; showSettings = true },
+                            )
+                        else -> {
+                            // Show the Main Dashboard / Permission Wizard.
+                            val isRootEnabled by viewModel.isRootEnabled.collectAsState()
 
-                        MainScreenContent(
-                            isOverlayGranted = isOverlayGranted,
-                            isReadLogsGranted = isReadLogsGranted,
-                            isRootEnabled = isRootEnabled,
-                            isServiceRunning = isServiceRunning,
-                            updateReadyToInstall = updateReadyToInstall,
-                            onCompleteUpdate = { appUpdateManager.completeUpdate() },
-                            onGrantOverlay = { requestOverlayPermission() },
-                            onToggleService = { toggleOverlayService() },
-                            onOpenSettings = { showSettings = true }
-                        )
+                            MainScreenContent(
+                                isOverlayGranted = isOverlayGranted,
+                                isReadLogsGranted = isReadLogsGranted,
+                                isRootEnabled = isRootEnabled,
+                                isServiceRunning = isServiceRunning,
+                                updateReadyToInstall = updateReadyToInstall,
+                                onCompleteUpdate = { appUpdateManager.completeUpdate() },
+                                onGrantOverlay = { requestOverlayPermission() },
+                                onToggleService = { toggleOverlayService() },
+                                onOpenSettings = { showSettings = true },
+                                onOpenGitHub = { showGitHub = true }
+                            )
+                        }
                     }
                 }
             }
@@ -298,7 +310,8 @@ fun MainScreenContent(
     onCompleteUpdate: () -> Unit,
     onGrantOverlay: () -> Unit,
     onToggleService: () -> Unit,
-    onOpenSettings: () -> Unit
+    onOpenSettings: () -> Unit,
+    onOpenGitHub: () -> Unit
 ) {
     val clipboardManager = LocalClipboardManager.current
     val scrollState = rememberScrollState()
@@ -377,6 +390,8 @@ fun MainScreenContent(
             }
             Spacer(modifier = Modifier.height(16.dp))
             AzButton(onClick = onOpenSettings, text = stringResource(R.string.settings), modifier = Modifier.fillMaxWidth().height(56.dp), shape = AzButtonShape.RECTANGLE)
+            Spacer(modifier = Modifier.height(8.dp))
+            AzButton(onClick = onOpenGitHub, text = stringResource(R.string.main_open_github), modifier = Modifier.fillMaxWidth().height(56.dp), shape = AzButtonShape.RECTANGLE)
         }
     }
 }

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/GitHubScreen.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/GitHubScreen.kt
@@ -1,0 +1,53 @@
+package com.hereliesaz.logkitty.ui
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import com.hereliesaz.logkitty.R
+
+/**
+ * Full-screen GitHub Actions host (launched from the dashboard). Reuses the same [GitHubFeatureSlot]
+ * the overlay tab hosts, so the runs → jobs → job-log drill-down, live polling, and watch
+ * notifications all behave identically here.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun GitHubScreen(viewModel: MainViewModel, onBack: () -> Unit, onConfigure: () -> Unit) {
+    val owner by viewModel.githubOwner.collectAsState()
+    val repo by viewModel.githubRepo.collectAsState()
+    val fontSize by viewModel.fontSize.collectAsState()
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.feature_github_title)) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.cd_back))
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        GitHubFeatureSlot(
+            owner = owner,
+            repo = repo,
+            tokenProvider = { viewModel.readGithubToken() },
+            onConfigure = onConfigure,
+            fontFamily = null,
+            fontSize = fontSize,
+            modifier = Modifier.fillMaxSize().padding(padding),
+        )
+    }
+}

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/GitHubScreen.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/GitHubScreen.kt
@@ -1,5 +1,6 @@
 package com.hereliesaz.logkitty.ui
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
@@ -25,6 +26,8 @@ import com.hereliesaz.logkitty.R
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun GitHubScreen(viewModel: MainViewModel, onBack: () -> Unit, onConfigure: () -> Unit) {
+    // System back / gesture returns to the dashboard rather than exiting the activity.
+    BackHandler(onBack = onBack)
     val owner by viewModel.githubOwner.collectAsState()
     val repo by viewModel.githubRepo.collectAsState()
     val fontSize by viewModel.fontSize.collectAsState()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -27,6 +27,7 @@
     <string name="main_ready_to_purr">Ready to Purr</string>
     <string name="main_stop_service">Stop Service</string>
     <string name="main_start_service">Start Service</string>
+    <string name="main_open_github">GitHub Actions</string>
     <string name="update_ready_title">Update ready</string>
     <string name="update_ready_desc">A new version has downloaded. Restart to finish updating.</string>
     <string name="update_restart">Restart &amp; update</string>


### PR DESCRIPTION
## GitHub Actions feature — Phase 6 (full-screen in the app)

**Stacked on #159 (Phase 5).** Auto-retargets to `main` when #159 merges.

Adds a full-screen GitHub Actions view in the app, alongside the overlay tab.

- **`GitHubScreen`** — a `Scaffold` + `TopAppBar` (with back) wrapping the **same `GitHubFeatureSlot`** the overlay tab hosts, so the runs → jobs → job-log drill-down, live polling, and watch notifications all behave identically. Fed `owner`/`repo` and the on-demand token reader from `MainViewModel`; its `onConfigure` jumps to Settings.
- **`MainActivity`** — a `showGitHub` nav state (parallel to `showSettings`), renders `GitHubScreen` in the `when`-branch, and a **"GitHub Actions"** button on the dashboard.

Because both surfaces reuse `GitHubFeatureSlot`, there's no duplicated GitHub logic — the full screen gets on-demand install, the panel, and completion notifications for free.

### Note on the stack
Carries the Phase 5 review fixes pushed to #159 (permanent-vs-transient HTTP error handling; no Long→Int notification-id collisions).

### Verification
- ❌ Not built here — relying on CI. On-device: tap "GitHub Actions" on the dashboard → drill into a run/job/log full-screen; "Open Settings" prompt routes to the GitHub settings section when no repo is set.

### Remaining (post-MVP)
Phase 7 (OAuth device flow) and Part 2 (Stats-tab drill-down diagnostics) from the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GSxjeuLJyBVyFhGXcxbkSe)_