### PR TITLE
Stats Part 2 (1): "what's draining battery" drill-down

### DIFF
--- a/feature/stats/src/main/kotlin/com/hereliesaz/logkitty/feature/stats/AppStats.kt
+++ b/feature/stats/src/main/kotlin/com/hereliesaz/logkitty/feature/stats/AppStats.kt
@@ -101,7 +101,17 @@ data class PowerStats(
     val batteryLevelPercent: Int?,
     val batteryTempC: Float?,
     val charging: Boolean?,
+    // --- Battery drill-down detail ("what's draining battery"), best-effort, root only ---
+    /** Top partial wakelocks by held time. */
+    val topWakelocks: List<NamedDuration> = emptyList(),
+    /** Scheduled-job components attributed to the app. */
+    val jobComponents: List<String> = emptyList(),
+    /** Alarm receivers/actions attributed to the app. */
+    val alarmComponents: List<String> = emptyList(),
 )
+
+/** A named thing with an optional held/elapsed duration in milliseconds (e.g. a wakelock). */
+data class NamedDuration(val name: String, val ms: Long?)
 
 data class HealthStats(
     val threadCount: Int?,

--- a/feature/stats/src/main/kotlin/com/hereliesaz/logkitty/feature/stats/AppStatsCollector.kt
+++ b/feature/stats/src/main/kotlin/com/hereliesaz/logkitty/feature/stats/AppStatsCollector.kt
@@ -137,9 +137,16 @@ class AppStatsCollector(private val context: Context) {
             val bs = sections["BATTERYSTATS"].orEmpty()
             val wakelockCount = Regex("Wake lock", RegexOption.IGNORE_CASE).findAll(bs).count().takeIf { it > 0 }
             val partialMs = parsePartialWakelockMs(bs)
-            val jobs = sections["JOBS"]?.trim()?.toIntOrNull()?.takeIf { it >= 0 }
-            val alarms = sections["ALARMS"]?.trim()?.toIntOrNull()?.takeIf { it >= 0 }
-            PowerStats(wakelockCount, partialMs, jobs, alarms, level, temp, charging)
+            val wakelocks = parseWakelocks(bs)
+            val jobComponents = parseComponentTokens(sections["JOBS"], pkg)
+            val alarmComponents = parseComponentTokens(sections["ALARMS"], pkg)
+            // Registered counts now derive from the captured lines (was a `grep -c`).
+            val jobs = jobLineCount(sections["JOBS"])
+            val alarms = jobLineCount(sections["ALARMS"])
+            PowerStats(
+                wakelockCount, partialMs, jobs, alarms, level, temp, charging,
+                topWakelocks = wakelocks, jobComponents = jobComponents, alarmComponents = alarmComponents,
+            )
         } else {
             PowerStats(null, null, null, null, level, temp, charging)
         }
@@ -192,8 +199,8 @@ class AppStatsCollector(private val context: Context) {
         if (!useRoot) return crashLogs
         return """
             echo "@@BATTERYSTATS@@"; dumpsys batterystats $p 2>/dev/null
-            echo "@@JOBS@@"; dumpsys jobscheduler 2>/dev/null | grep -c $p
-            echo "@@ALARMS@@"; dumpsys alarm 2>/dev/null | grep -c $p
+            echo "@@JOBS@@"; dumpsys jobscheduler 2>/dev/null | grep -F $p | head -n 60
+            echo "@@ALARMS@@"; dumpsys alarm 2>/dev/null | grep -F $p | head -n 60
             echo "@@SENSORS@@"; dumpsys sensorservice 2>/dev/null
             echo "@@LOCATION@@"; dumpsys location 2>/dev/null
         """.trimIndent() + "\n" + crashLogs
@@ -659,12 +666,54 @@ class AppStatsCollector(private val context: Context) {
         return if (matched) total else null
     }
 
+    /** Number of non-blank lines (the captured `grep` output for jobs/alarms), or null if absent. */
+    private fun jobLineCount(section: String?): Int? =
+        section?.lineSequence()?.count { it.isNotBlank() }?.takeIf { it > 0 }
+
+    /**
+     * Top partial wakelocks by held time, name + ms, from `dumpsys batterystats`. Same line shape as
+     * [parsePartialWakelockMs] but keeping the name so the drill-down can show *which* lock.
+     */
+    private fun parseWakelocks(bs: String): List<NamedDuration> {
+        val out = ArrayList<NamedDuration>()
+        for (m in WAKELOCK_NAMED.findAll(bs)) {
+            val name = m.groupValues[1].trim()
+            val h = m.groupValues[2].toLongOrNull() ?: 0
+            val min = m.groupValues[3].toLongOrNull() ?: 0
+            val s = m.groupValues[4].toLongOrNull() ?: 0
+            val ms = m.groupValues[5].toLongOrNull() ?: 0
+            val sum = ((h * 60 + min) * 60 + s) * 1000 + ms
+            if (name.isNotEmpty() && sum > 0) out.add(NamedDuration(name, sum))
+        }
+        return out.sortedByDescending { it.ms ?: 0 }.distinctBy { it.name }.take(6)
+    }
+
+    /**
+     * Best-effort `package/Component`-style tokens from grepped jobscheduler/alarm output, for the
+     * battery drill-down. Returns distinct components (capped); empty if the format isn't recognized.
+     */
+    private fun parseComponentTokens(section: String?, pkg: String): List<String> {
+        if (section.isNullOrBlank()) return emptyList()
+        return COMPONENT_TOKEN.findAll(section)
+            .map { it.value }
+            .filter { it.contains(pkg) }
+            .map { it.substringAfterLast('/') }
+            .filter { it.isNotBlank() }
+            .distinct()
+            .take(8)
+            .toList()
+    }
+
     companion object {
         private val MARKER = Regex("""@@([A-Z]+(?: \d+)?)@@""")
         // Captures the class name from `ServiceRecord{hash u0 pkg/<Name> ...}` (running service).
         private val SERVICE_RECORD = Regex("""ServiceRecord\{[^}]*/([^\s}]+)""")
         // `<provider> provider:` section header in `dumpsys location`.
         private val PROVIDER_HEADER = Regex("""(?m)^\s*(\w+) provider:""")
+        // Named partial wakelock: "Wake lock <name>: 1h 2m 3s 4ms partial".
+        private val WAKELOCK_NAMED = Regex("""Wake lock\s+([^:]+):\s*(?:(\d+)h)?\s*(?:(\d+)m)?\s*(?:(\d+)s)?\s*(?:(\d+)ms)?\s+partial""")
+        // A `package/Component` token (job service / alarm receiver), e.g. com.x.app/.MyService.
+        private val COMPONENT_TOKEN = Regex("""[\w.]+/[\w.${'$'}]+""")
         // Leading timestamp of a `-v threadtime` logcat line: "MM-DD HH:MM:SS".
         private val LOG_TIME = Regex("""^(\d{2}-\d{2} \d{2}:\d{2}:\d{2})""")
         // Common sensor type names to look for inside a connection block (format-tolerant).

--- a/feature/stats/src/main/kotlin/com/hereliesaz/logkitty/feature/stats/AppStatsCollector.kt
+++ b/feature/stats/src/main/kotlin/com/hereliesaz/logkitty/feature/stats/AppStatsCollector.kt
@@ -666,9 +666,15 @@ class AppStatsCollector(private val context: Context) {
         return if (matched) total else null
     }
 
-    /** Number of non-blank lines (the captured `grep` output for jobs/alarms), or null if absent. */
-    private fun jobLineCount(section: String?): Int? =
-        section?.lineSequence()?.count { it.isNotBlank() }?.takeIf { it > 0 }
+    /**
+     * Non-blank line count of the captured jobs/alarms grep output. 0 when present-but-empty
+     * (genuinely none registered); null only when the section is absent (root off) — so the UI shows
+     * "0" rather than "—" when there simply are none.
+     */
+    private fun jobLineCount(section: String?): Int? {
+        if (section == null) return null
+        return section.lineSequence().count { it.isNotBlank() }
+    }
 
     /**
      * Top partial wakelocks by held time, name + ms, from `dumpsys batterystats`. Same line shape as
@@ -696,7 +702,9 @@ class AppStatsCollector(private val context: Context) {
         if (section.isNullOrBlank()) return emptyList()
         return COMPONENT_TOKEN.findAll(section)
             .map { it.value }
-            .filter { it.contains(pkg) }
+            // Exact package match on the `package/Component` token — avoids matching another package
+            // that merely has ours as a substring (e.g. com.example vs com.example.helper).
+            .filter { it.substringBefore('/') == pkg }
             .map { it.substringAfterLast('/') }
             .filter { it.isNotBlank() }
             .distinct()

--- a/feature/stats/src/main/kotlin/com/hereliesaz/logkitty/feature/stats/StatsView.kt
+++ b/feature/stats/src/main/kotlin/com/hereliesaz/logkitty/feature/stats/StatsView.kt
@@ -2,6 +2,7 @@ package com.hereliesaz.logkitty.feature.stats
 
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -18,6 +19,10 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -94,7 +99,7 @@ fun StatsView(
         stats.memory?.let { MemorySection(it, fontFamily, fontSize, labelColor, valueColor) }
         stats.gpu?.let { GpuSection(it, fontFamily, fontSize, labelColor, valueColor) }
         stats.network?.let { NetworkSection(it, fontFamily, fontSize, labelColor, valueColor) }
-        stats.power?.let { PowerSection(it, fontFamily, fontSize, labelColor, valueColor) }
+        stats.power?.let { PowerSection(it, stats.cpu, stats.sensors, fontFamily, fontSize, labelColor, valueColor) }
         stats.health?.let { HealthSection(it, fontFamily, fontSize, labelColor, valueColor) }
         stats.sensors?.let { SensorSection(it, fontFamily, fontSize, labelColor, valueColor) }
         stats.binder?.let { BinderSection(it, fontFamily, fontSize, labelColor, valueColor) }
@@ -315,7 +320,10 @@ private fun NetworkSection(n: NetworkStats, ff: FontFamily?, fs: Int, lc: Color,
 }
 
 @Composable
-private fun PowerSection(p: PowerStats, ff: FontFamily?, fs: Int, lc: Color, vc: Color) {
+private fun PowerSection(
+    p: PowerStats, cpu: CpuStats?, sensors: SensorStats?,
+    ff: FontFamily?, fs: Int, lc: Color, vc: Color,
+) {
     StatCard("Power & Scheduling", ff, fs) {
         StatRow("Wakelocks held", p.wakelockCount?.toString() ?: "—", ff, fs, lc, vc)
         StatRow("Partial wakelock time", p.partialWakelockMs?.let { ms(it) } ?: "—", ff, fs, lc, vc)
@@ -324,6 +332,80 @@ private fun PowerSection(p: PowerStats, ff: FontFamily?, fs: Int, lc: Color, vc:
         val batt = p.batteryLevelPercent?.let { "$it%${if (p.charging == true) " ⚡" else ""}" } ?: "—"
         StatRow("Battery", batt, ff, fs, lc, vc)
         StatRow("Battery temp", p.batteryTempC?.let { "${"%.1f".format(it)}°C" } ?: "—", ff, fs, lc, vc)
+
+        // Drill-down: aggregate the concrete causes (top CPU threads, wakelocks, jobs/alarms, sensors)
+        // into one "what's draining battery" view. Tap to expand; lazily shown so it's out of the way.
+        BatteryInvestigation(p, cpu, sensors, ff, fs, lc, vc)
+    }
+}
+
+/** Expandable "what's draining battery" breakdown that ranks the concrete causes from each section. */
+@Composable
+private fun BatteryInvestigation(
+    p: PowerStats, cpu: CpuStats?, sensors: SensorStats?,
+    ff: FontFamily?, fs: Int, lc: Color, vc: Color,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    Spacer(Modifier.height(4.dp))
+    Row(
+        modifier = Modifier.fillMaxWidth().clickable { expanded = !expanded }.padding(vertical = 2.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            "${if (expanded) "▾" else "▸"}  Investigate: what's draining battery",
+            color = Color(0xFF4DD0E1), fontSize = (fs - 1).sp, fontFamily = ff, fontWeight = FontWeight.Medium,
+            modifier = Modifier.weight(1f), maxLines = 1, overflow = TextOverflow.Ellipsis,
+        )
+    }
+    if (!expanded) return
+
+    var anything = false
+    // 1) Active CPU work — usually the real cost; already attributed to a library.
+    val threads = cpu?.threads.orEmpty().filter { it.percent > 0.05f }.take(3)
+    if (threads.isNotEmpty()) {
+        anything = true
+        Text("Active work (CPU)", color = lc, fontSize = (fs - 2).sp, fontFamily = ff, fontWeight = FontWeight.Medium,
+            modifier = Modifier.padding(top = 4.dp))
+        threads.forEach { t ->
+            val lib = t.library?.let { " · $it" } ?: ""
+            StatRow(t.name + lib, pct(t.percent), ff, fs, lc, vc)
+        }
+    }
+    // 2) Wakelocks holding the CPU awake.
+    if (p.topWakelocks.isNotEmpty()) {
+        anything = true
+        Text("Wakelocks", color = lc, fontSize = (fs - 2).sp, fontFamily = ff, fontWeight = FontWeight.Medium,
+            modifier = Modifier.padding(top = 4.dp))
+        p.topWakelocks.forEach { w -> StatRow(w.name, w.ms?.let { ms(it) } ?: "—", ff, fs, lc, vc) }
+    }
+    // 3) Sensors / GPS quietly held.
+    val sensorList = sensors?.activeSensors.orEmpty()
+    val providers = sensors?.locationProviders.orEmpty()
+    if (sensorList.isNotEmpty() || providers.isNotEmpty()) {
+        anything = true
+        Text("Sensors & location", color = lc, fontSize = (fs - 2).sp, fontFamily = ff, fontWeight = FontWeight.Medium,
+            modifier = Modifier.padding(top = 4.dp))
+        if (sensorList.isNotEmpty()) WrapStatRow("Sensors", sensorList.joinToString(", "), ff, fs, lc, vc)
+        if (providers.isNotEmpty()) WrapStatRow("Location", providers.joinToString(", "), ff, fs, lc, vc)
+    }
+    // 4) Scheduled wakeups.
+    if (p.jobComponents.isNotEmpty()) {
+        anything = true
+        Text("Jobs", color = lc, fontSize = (fs - 2).sp, fontFamily = ff, fontWeight = FontWeight.Medium,
+            modifier = Modifier.padding(top = 4.dp))
+        p.jobComponents.forEach { WrapStatRow("Job", it, ff, fs, lc, vc) }
+    }
+    if (p.alarmComponents.isNotEmpty()) {
+        anything = true
+        Text("Alarms", color = lc, fontSize = (fs - 2).sp, fontFamily = ff, fontWeight = FontWeight.Medium,
+            modifier = Modifier.padding(top = 4.dp))
+        p.alarmComponents.forEach { WrapStatRow("Alarm", it, ff, fs, lc, vc) }
+    }
+    if (!anything) {
+        Text(
+            "No specific causes detected. (Full detail needs root — wakelock, job and alarm names come from dumpsys.)",
+            color = lc, fontSize = (fs - 2).sp, fontFamily = ff, modifier = Modifier.padding(top = 4.dp),
+        )
     }
 }
 

--- a/feature/stats/src/main/kotlin/com/hereliesaz/logkitty/feature/stats/StatsView.kt
+++ b/feature/stats/src/main/kotlin/com/hereliesaz/logkitty/feature/stats/StatsView.kt
@@ -99,7 +99,7 @@ fun StatsView(
         stats.memory?.let { MemorySection(it, fontFamily, fontSize, labelColor, valueColor) }
         stats.gpu?.let { GpuSection(it, fontFamily, fontSize, labelColor, valueColor) }
         stats.network?.let { NetworkSection(it, fontFamily, fontSize, labelColor, valueColor) }
-        stats.power?.let { PowerSection(it, stats.cpu, stats.sensors, fontFamily, fontSize, labelColor, valueColor) }
+        stats.power?.let { PowerSection(stats.packageName, it, stats.cpu, stats.sensors, fontFamily, fontSize, labelColor, valueColor) }
         stats.health?.let { HealthSection(it, fontFamily, fontSize, labelColor, valueColor) }
         stats.sensors?.let { SensorSection(it, fontFamily, fontSize, labelColor, valueColor) }
         stats.binder?.let { BinderSection(it, fontFamily, fontSize, labelColor, valueColor) }
@@ -321,7 +321,7 @@ private fun NetworkSection(n: NetworkStats, ff: FontFamily?, fs: Int, lc: Color,
 
 @Composable
 private fun PowerSection(
-    p: PowerStats, cpu: CpuStats?, sensors: SensorStats?,
+    packageName: String, p: PowerStats, cpu: CpuStats?, sensors: SensorStats?,
     ff: FontFamily?, fs: Int, lc: Color, vc: Color,
 ) {
     StatCard("Power & Scheduling", ff, fs) {
@@ -335,17 +335,18 @@ private fun PowerSection(
 
         // Drill-down: aggregate the concrete causes (top CPU threads, wakelocks, jobs/alarms, sensors)
         // into one "what's draining battery" view. Tap to expand; lazily shown so it's out of the way.
-        BatteryInvestigation(p, cpu, sensors, ff, fs, lc, vc)
+        BatteryInvestigation(packageName, p, cpu, sensors, ff, fs, lc, vc)
     }
 }
 
 /** Expandable "what's draining battery" breakdown that ranks the concrete causes from each section. */
 @Composable
 private fun BatteryInvestigation(
-    p: PowerStats, cpu: CpuStats?, sensors: SensorStats?,
+    packageName: String, p: PowerStats, cpu: CpuStats?, sensors: SensorStats?,
     ff: FontFamily?, fs: Int, lc: Color, vc: Color,
 ) {
-    var expanded by remember { mutableStateOf(false) }
+    // Key on the package so the expanded state resets when switching apps but persists across polls.
+    var expanded by remember(packageName) { mutableStateOf(false) }
     Spacer(Modifier.height(4.dp))
     Row(
         modifier = Modifier.fillMaxWidth().clickable { expanded = !expanded }.padding(vertical = 2.dp),


### PR DESCRIPTION
## Stats drill-down diagnostics — Part 2, Phase 1: "what's draining battery"

Off a clean `main` (independent of the open GitHub PRs — different module). Implements the symptom-→-cause flow you asked for: see high battery use → tap → find exactly what's responsible.

### What's here
The Power card gains an expandable **"Investigate: what's draining battery"** drill-down that aggregates the concrete causes into one ranked view:
1. **Active work (CPU)** — the top CPU threads, already attributed to a library (usually the real battery cost).
2. **Wakelocks** — the specific partial wakelocks holding the CPU awake, by held time.
3. **Sensors & location** — sensors/GPS quietly held.
4. **Jobs / Alarms** — the app's scheduled wakeups.

It degrades to a "needs root for full detail" hint when nothing is attributable.

### How
- **`PowerStats`** gains `topWakelocks` (name+ms), `jobComponents`, `alarmComponents` (+ a small `NamedDuration`).
- **Collector** — the slow batch now captures the actual `jobscheduler`/`alarm` lines for the package (was `grep -c`) and parses `package/Component` tokens; `batterystats` wakelocks are parsed **with their names** (top by held time). Counts derive from the captured lines. Still root-only and **null-degrading** — a bad parse only hides the drill-down.
- **`StatsView`** — `PowerSection` gets the expandable block, cross-linking CPU threads + sensors + power so the answer is assembled from data the module already gathers (no new permissions, no steady-state overhead — the detail just renders on expand).

This is Phase 1 of Part 2. Later increments (per the plan): CPU-thread → stack capture, memory-leak detection from the rolling history, and disk/network/crash drill-downs.

### Verification
- ❌ Not built here — relying on CI. On-device (root): open an app's Stats tab → Power card → "Investigate" → confirm wakelock/job/alarm names and the CPU/sensor cross-links populate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GSxjeuLJyBVyFhGXcxbkSe)_