### PR TITLE
GitHub Actions Phase 7: OAuth device-flow sign-in

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -85,6 +85,12 @@ android {
         // unit id to that module's banner. (Unit IDs are public — they ship in the APK.)
         buildConfigField("String", "ADMOB_BANNER_UNIT_ID", "\"ca-app-pub-3940256099942544/6300978111\"")
 
+        // GitHub OAuth app client id for the device-flow sign-in (optional; PAT works without it).
+        // Public value (no secret in device flow); supply via local.properties/env to enable the
+        // "Sign in with GitHub" button. Blank by default → the UI shows PAT entry only.
+        val githubOauthClientId = getLocalProperty("GITHUB_OAUTH_CLIENT_ID", rootProject.projectDir)
+        buildConfigField("String", "GITHUB_OAUTH_CLIENT_ID", "\"$githubOauthClientId\"")
+
         // Build Tools Config
         val toolsOwner = project.findProperty("build.tools.owner") as? String ?: "HereLiesAz"
         val toolsRepo = project.findProperty("build.tools.repo") as? String ?: "LogKitty-buildtools"

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/SettingsScreen.kt
@@ -74,6 +74,8 @@ import com.hereliesaz.aznavrail.AzButton
 import com.hereliesaz.aznavrail.model.AzButtonShape
 import com.hereliesaz.logkitty.BuildConfig
 import com.hereliesaz.logkitty.R
+import com.hereliesaz.logkitty.utils.GitHubDeviceAuth
+import kotlinx.coroutines.Job
 import com.hereliesaz.logkitty.ui.theme.CodingFont
 import com.hereliesaz.logkitty.utils.LogSources
 
@@ -528,8 +530,8 @@ private fun SettingsMainScreen(
             var showToken by remember { mutableStateOf(false) }
             // OAuth device-flow state (only used when an OAuth client id is configured).
             val githubAuthScope = rememberCoroutineScope()
-            var deviceCode by remember { mutableStateOf<com.hereliesaz.logkitty.utils.GitHubDeviceAuth.DeviceCode?>(null) }
-            var authJob by remember { mutableStateOf<kotlinx.coroutines.Job?>(null) }
+            var deviceCode by remember { mutableStateOf<GitHubDeviceAuth.DeviceCode?>(null) }
+            var authJob by remember { mutableStateOf<Job?>(null) }
             OutlinedTextField(
                 value = ownerField,
                 onValueChange = { ownerField = it },
@@ -595,9 +597,10 @@ private fun SettingsMainScreen(
             if (oauthClientId.isNotBlank()) {
                 AzButton(
                     onClick = {
-                        if (deviceCode != null) return@AzButton
+                        // Ignore taps while a request/poll is already running (avoids overlapping jobs).
+                        if (authJob?.isActive == true) return@AzButton
                         authJob = githubAuthScope.launch {
-                            val dc = com.hereliesaz.logkitty.utils.GitHubDeviceAuth.requestDeviceCode(oauthClientId)
+                            val dc = GitHubDeviceAuth.requestDeviceCode(oauthClientId)
                             if (dc == null) {
                                 Toast.makeText(context, context.getString(R.string.toast_github_signin_failed), Toast.LENGTH_SHORT).show()
                                 return@launch
@@ -609,7 +612,7 @@ private fun SettingsMainScreen(
                                         .addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK),
                                 )
                             }
-                            val token = com.hereliesaz.logkitty.utils.GitHubDeviceAuth.pollForToken(oauthClientId, dc)
+                            val token = GitHubDeviceAuth.pollForToken(oauthClientId, dc)
                             deviceCode = null
                             if (token != null) {
                                 viewModel.setGithubToken(token)

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/SettingsScreen.kt
@@ -526,6 +526,10 @@ private fun SettingsMainScreen(
             var repoField by remember(githubRepo) { mutableStateOf(githubRepo) }
             var tokenField by remember { mutableStateOf("") }
             var showToken by remember { mutableStateOf(false) }
+            // OAuth device-flow state (only used when an OAuth client id is configured).
+            val githubAuthScope = rememberCoroutineScope()
+            var deviceCode by remember { mutableStateOf<com.hereliesaz.logkitty.utils.GitHubDeviceAuth.DeviceCode?>(null) }
+            var authJob by remember { mutableStateOf<kotlinx.coroutines.Job?>(null) }
             OutlinedTextField(
                 value = ownerField,
                 onValueChange = { ownerField = it },
@@ -585,6 +589,69 @@ private fun SettingsMainScreen(
                 shape = AzButtonShape.RECTANGLE,
                 modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)
             )
+
+            // OAuth device-flow sign-in — only when a client id is configured at build time.
+            val oauthClientId = BuildConfig.GITHUB_OAUTH_CLIENT_ID
+            if (oauthClientId.isNotBlank()) {
+                AzButton(
+                    onClick = {
+                        if (deviceCode != null) return@AzButton
+                        authJob = githubAuthScope.launch {
+                            val dc = com.hereliesaz.logkitty.utils.GitHubDeviceAuth.requestDeviceCode(oauthClientId)
+                            if (dc == null) {
+                                Toast.makeText(context, context.getString(R.string.toast_github_signin_failed), Toast.LENGTH_SHORT).show()
+                                return@launch
+                            }
+                            deviceCode = dc
+                            runCatching {
+                                context.startActivity(
+                                    android.content.Intent(android.content.Intent.ACTION_VIEW, Uri.parse(dc.verificationUri))
+                                        .addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK),
+                                )
+                            }
+                            val token = com.hereliesaz.logkitty.utils.GitHubDeviceAuth.pollForToken(oauthClientId, dc)
+                            deviceCode = null
+                            if (token != null) {
+                                viewModel.setGithubToken(token)
+                                Toast.makeText(context, context.getString(R.string.toast_github_signed_in), Toast.LENGTH_SHORT).show()
+                            } else {
+                                Toast.makeText(context, context.getString(R.string.toast_github_signin_failed), Toast.LENGTH_SHORT).show()
+                            }
+                        }
+                    },
+                    text = stringResource(R.string.github_oauth_signin),
+                    shape = AzButtonShape.RECTANGLE,
+                    modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)
+                )
+            }
+            deviceCode?.let { dc ->
+                AlertDialog(
+                    onDismissRequest = { authJob?.cancel(); deviceCode = null },
+                    confirmButton = {
+                        TextButton(onClick = {
+                            runCatching {
+                                context.startActivity(
+                                    android.content.Intent(android.content.Intent.ACTION_VIEW, Uri.parse(dc.verificationUri))
+                                        .addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK),
+                                )
+                            }
+                        }) { Text(stringResource(R.string.github_oauth_open)) }
+                    },
+                    dismissButton = {
+                        TextButton(onClick = { authJob?.cancel(); deviceCode = null }) { Text(stringResource(R.string.cancel)) }
+                    },
+                    title = { Text(stringResource(R.string.github_oauth_title)) },
+                    text = {
+                        Column {
+                            Text(stringResource(R.string.github_oauth_instructions, dc.verificationUri))
+                            Spacer(modifier = Modifier.height(8.dp))
+                            Text(dc.userCode, style = MaterialTheme.typography.headlineSmall, color = MaterialTheme.colorScheme.primary)
+                            Spacer(modifier = Modifier.height(8.dp))
+                            Text(stringResource(R.string.github_oauth_waiting), style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                        }
+                    },
+                )
+            }
             HorizontalDivider(modifier = Modifier.padding(vertical = 16.dp))
 
             SettingsSectionHeader(stringResource(R.string.settings_section_filters))

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/utils/GitHubDeviceAuth.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/utils/GitHubDeviceAuth.kt
@@ -1,5 +1,6 @@
 package com.hereliesaz.logkitty.utils
 
+import java.io.IOException
 import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
@@ -7,6 +8,7 @@ import kotlinx.coroutines.withContext
 import okhttp3.FormBody
 import okhttp3.OkHttpClient
 import okhttp3.Request
+import org.json.JSONException
 import org.json.JSONObject
 
 /**
@@ -53,7 +55,9 @@ object GitHubDeviceAuth {
                         expiresInSec = o.optInt("expires_in", 900).coerceAtLeast(30),
                     )
                 }
-            } catch (e: Exception) {
+            } catch (e: IOException) {
+                null
+            } catch (e: JSONException) {
                 null
             }
         }
@@ -81,8 +85,10 @@ object GitHubDeviceAuth {
                 .build()
             val o = try {
                 client.newCall(req).execute().use { resp -> JSONObject(resp.body?.string().orEmpty()) }
-            } catch (e: Exception) {
-                continue // transient — try again next interval
+            } catch (e: IOException) {
+                continue // transient network error — try again next interval
+            } catch (e: JSONException) {
+                continue // malformed response — try again next interval
             }
             val token = o.optString("access_token")
             if (token.isNotBlank()) return@withContext token

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/utils/GitHubDeviceAuth.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/utils/GitHubDeviceAuth.kt
@@ -1,0 +1,102 @@
+package com.hereliesaz.logkitty.utils
+
+import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
+import okhttp3.FormBody
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.json.JSONObject
+
+/**
+ * GitHub OAuth **device flow** — an alternative to pasting a PAT. The user gets a short code to enter
+ * at github.com/login/device; we poll until they authorize, then hand back an access token that the
+ * caller stores in [GitHubCredentials] (same secure store the PAT uses).
+ *
+ * Needs a registered GitHub OAuth app **client id** (BuildConfig.GITHUB_OAUTH_CLIENT_ID); when that's
+ * blank the UI hides the option and only PAT entry is offered. No client secret is involved (device
+ * flow is for public clients). All calls are suspend + run on [Dispatchers.IO].
+ */
+object GitHubDeviceAuth {
+
+    /** The user-facing code + where to enter it, plus the polling parameters. */
+    data class DeviceCode(
+        val userCode: String,
+        val verificationUri: String,
+        val deviceCode: String,
+        val intervalSec: Int,
+        val expiresInSec: Int,
+    )
+
+    /** Step 1: ask GitHub for a device/user code pair. Returns null on failure. */
+    suspend fun requestDeviceCode(clientId: String, scope: String = "repo"): DeviceCode? =
+        withContext(Dispatchers.IO) {
+            val body = FormBody.Builder().add("client_id", clientId).add("scope", scope).build()
+            val req = Request.Builder()
+                .url("https://github.com/login/device/code")
+                .header("Accept", "application/json")
+                .post(body)
+                .build()
+            try {
+                client.newCall(req).execute().use { resp ->
+                    if (!resp.isSuccessful) return@withContext null
+                    val o = JSONObject(resp.body?.string().orEmpty())
+                    val userCode = o.optString("user_code")
+                    val deviceCode = o.optString("device_code")
+                    if (userCode.isBlank() || deviceCode.isBlank()) return@withContext null
+                    DeviceCode(
+                        userCode = userCode,
+                        verificationUri = o.optString("verification_uri").ifBlank { "https://github.com/login/device" },
+                        deviceCode = deviceCode,
+                        intervalSec = o.optInt("interval", 5).coerceAtLeast(1),
+                        expiresInSec = o.optInt("expires_in", 900).coerceAtLeast(30),
+                    )
+                }
+            } catch (e: Exception) {
+                null
+            }
+        }
+
+    /**
+     * Step 2: poll for the access token until the user authorizes (or it times out / is denied).
+     * Honors `authorization_pending` (keep waiting) and `slow_down` (lengthen the interval). Returns
+     * the token, or null on denial/expiry/error.
+     */
+    suspend fun pollForToken(clientId: String, code: DeviceCode): String? = withContext(Dispatchers.IO) {
+        var interval = code.intervalSec
+        var waited = 0
+        while (waited < code.expiresInSec) {
+            delay(interval * 1000L)
+            waited += interval
+            val body = FormBody.Builder()
+                .add("client_id", clientId)
+                .add("device_code", code.deviceCode)
+                .add("grant_type", "urn:ietf:params:oauth:grant-type:device_code")
+                .build()
+            val req = Request.Builder()
+                .url("https://github.com/login/oauth/access_token")
+                .header("Accept", "application/json")
+                .post(body)
+                .build()
+            val o = try {
+                client.newCall(req).execute().use { resp -> JSONObject(resp.body?.string().orEmpty()) }
+            } catch (e: Exception) {
+                continue // transient — try again next interval
+            }
+            val token = o.optString("access_token")
+            if (token.isNotBlank()) return@withContext token
+            when (o.optString("error")) {
+                "authorization_pending" -> { /* keep waiting */ }
+                "slow_down" -> interval += 5
+                else -> return@withContext null // expired_token / access_denied / unsupported
+            }
+        }
+        null
+    }
+
+    private val client = OkHttpClient.Builder()
+        .connectTimeout(15, TimeUnit.SECONDS)
+        .readTimeout(20, TimeUnit.SECONDS)
+        .build()
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -152,6 +152,14 @@
     <string name="github_clear_token">Clear token</string>
     <string name="toast_github_saved">GitHub settings saved</string>
     <string name="toast_github_token_cleared">GitHub token cleared</string>
+    <!-- GitHub OAuth device-flow sign-in -->
+    <string name="github_oauth_signin">Sign in with GitHub</string>
+    <string name="github_oauth_title">Authorize LogKitty</string>
+    <string name="github_oauth_instructions">Go to %1$s and enter this code:</string>
+    <string name="github_oauth_waiting">Waiting for you to authorize…</string>
+    <string name="github_oauth_open">Open page</string>
+    <string name="toast_github_signed_in">Signed in to GitHub</string>
+    <string name="toast_github_signin_failed">Sign-in didn\'t complete</string>
 
     <!-- Tabs -->
     <string name="tab_all">All</string>


### PR DESCRIPTION
## GitHub Actions — Phase 7: OAuth device-flow sign-in

Off a clean `main`. Adds a friendlier alternative to pasting a PAT, **without changing the rest of the feature** — the device flow just writes an access token into the same backup-excluded `GitHubCredentials` store, so everything still reads it via the existing `tokenProvider`.

### What's here
- **`GitHubDeviceAuth`** — the OAuth device flow: `requestDeviceCode` + `pollForToken` (OkHttp + `org.json`, **no client secret** — device flow is for public clients). Honors `authorization_pending` / `slow_down` and is bounded by the code's expiry.
- **`BuildConfig.GITHUB_OAUTH_CLIENT_ID`** — supplied via `local.properties`/env (same pattern as the AdMob unit id). **Blank by default**, so without a configured client id the OAuth button is hidden and only PAT entry shows — zero behavior change until you register an OAuth app and set the id.
- **Settings** — a "Sign in with GitHub" button (gated on the client id) that requests a device code, opens `github.com/login/device`, shows the user code in a dialog, polls to completion, and stores the token. Canceling the dialog cancels the poll job.

### Setup (to enable)
Register a GitHub OAuth app (enable Device Flow), then put `GITHUB_OAUTH_CLIENT_ID=...` in `local.properties` (or env). PAT entry remains available either way.

### Verification
- ❌ Not built here — relying on CI. With a client id set, on-device: tap "Sign in with GitHub" → enter the code on github.com → confirm the token is stored (status flips to "saved") and runs load.

That completes the planned GitHub work (Phases 0–7). Part 2 (Stats drill-down) Phase 1 is in #161.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GSxjeuLJyBVyFhGXcxbkSe)_