### PR TITLE
Stats Part 2.3: memory leak/ramp detection from rolling PSS history

### DIFF
--- a/feature/stats/src/main/kotlin/com/hereliesaz/logkitty/feature/stats/AppStats.kt
+++ b/feature/stats/src/main/kotlin/com/hereliesaz/logkitty/feature/stats/AppStats.kt
@@ -115,6 +115,21 @@ data class PowerStats(
 /** A named thing with an optional held/elapsed duration in milliseconds (e.g. a wakelock). */
 data class NamedDuration(val name: String, val ms: Long?)
 
+/**
+ * A thread's cumulative disk I/O (bytes that actually hit storage), produced by the on-demand disk
+ * drill-down [com.hereliesaz.logkitty.feature.stats.AppStatsCollector.probeIoTopThreads]. Lets the
+ * developer see *which* thread is the writer behind a high disk-write rate.
+ */
+data class ThreadIo(val tid: Int, val name: String, val readBytes: Long, val writeBytes: Long)
+
+/**
+ * One active network socket for the app, produced by the on-demand network drill-down
+ * [com.hereliesaz.logkitty.feature.stats.AppStatsCollector.probeSockets]. Decoded from
+ * `/proc/net/tcp{,6}` filtered to the app's uid (root). Tells the developer *who* the app is
+ * talking to behind a network rate.
+ */
+data class SocketConn(val proto: String, val state: String, val remote: String)
+
 data class HealthStats(
     val threadCount: Int?,
     val fdCount: Int?,

--- a/feature/stats/src/main/kotlin/com/hereliesaz/logkitty/feature/stats/AppStatsCollector.kt
+++ b/feature/stats/src/main/kotlin/com/hereliesaz/logkitty/feature/stats/AppStatsCollector.kt
@@ -192,9 +192,9 @@ class AppStatsCollector(private val context: Context) {
     }
 
     /**
-     * On-demand deep probe: per-thread cumulative disk I/O from `/proc/<pid>/task/*/io` (root), to
-     * find *which* thread is the writer behind a high disk-write rate. Best-effort and root-gated;
-     * returns the threads with non-zero write bytes, descending, or null when unavailable.
+     * On-demand deep probe: per-thread cumulative disk I/O from each `/proc/<pid>/task/<tid>/io`
+     * (root), to find which thread is the writer behind a high disk-write rate. Best-effort and
+     * root-gated; returns the threads with non-zero write bytes, descending, or null when unavailable.
      */
     suspend fun probeIoTopThreads(pid: Int, useRoot: Boolean): List<ThreadIo>? {
         if (!useRoot || pid <= 0) return null
@@ -476,8 +476,12 @@ class AppStatsCollector(private val context: Context) {
         while (i < lines.size) {
             if (lines[i].contains("FATAL EXCEPTION")) {
                 val limit = minOf(i + 6, lines.size)
+                // Match "Process: <pkg>" only when the next char ends the token (comma, space, or EOL),
+                // so we don't accept a prefix of a longer package and still match ROMs with no trailer.
+                val needle = "Process: $pkg"
                 val matched = (i + 1 until limit).any {
-                    lines[it].contains("Process: $pkg,") || lines[it].contains("Process: $pkg ")
+                    val at = lines[it].indexOf(needle)
+                    at >= 0 && lines[it].getOrNull(at + needle.length).let { c -> c == null || c == ',' || c.isWhitespace() }
                 }
                 if (matched) start = i
             }
@@ -541,7 +545,9 @@ class AppStatsCollector(private val context: Context) {
         val parts = token.split(":")
         if (parts.size != 2) return null
         val port = parts[1].toIntOrNull(16) ?: return null
-        val ip = if (ipv6) decodeIpv6(parts[0]) else decodeIpv4(parts[0]) ?: return null
+        // Parens matter: `?:` binds tighter than if/else, so without them the fallback would only
+        // apply to the v4 branch and a null v6 decode would yield a malformed "[null]:port".
+        val ip = (if (ipv6) decodeIpv6(parts[0]) else decodeIpv4(parts[0])) ?: return null
         return if (ipv6) "[$ip]:$port" else "$ip:$port"
     }
 
@@ -900,7 +906,8 @@ class AppStatsCollector(private val context: Context) {
         private val TCP_STATES = mapOf(
             "01" to "ESTABLISHED", "02" to "SYN_SENT", "03" to "SYN_RECV",
             "04" to "FIN_WAIT1", "05" to "FIN_WAIT2", "06" to "TIME_WAIT",
-            "08" to "CLOSE_WAIT", "0A" to "LISTEN",
+            "07" to "CLOSE", "08" to "CLOSE_WAIT", "09" to "LAST_ACK",
+            "0A" to "LISTEN", "0B" to "CLOSING",
         )
         // Captures the class name from `ServiceRecord{hash u0 pkg/<Name> ...}` (running service).
         private val SERVICE_RECORD = Regex("""ServiceRecord\{[^}]*/([^\s}]+)""")

--- a/feature/stats/src/main/kotlin/com/hereliesaz/logkitty/feature/stats/AppStatsCollector.kt
+++ b/feature/stats/src/main/kotlin/com/hereliesaz/logkitty/feature/stats/AppStatsCollector.kt
@@ -176,6 +176,60 @@ class AppStatsCollector(private val context: Context) {
         return lines.takeIf { it.isNotEmpty() }
     }
 
+    /**
+     * On-demand deep probe: the *full* stack trace of the most recent crash for the package, read
+     * straight from the logcat **crash** buffer. Like [parseCrashes] this needs only `READ_LOGS`, so
+     * it works **without root** — it's the drill-down behind the one-line crash summary, giving the
+     * developer the whole call chain. Returns null when no readable trace is found.
+     */
+    suspend fun probeCrashStack(pkg: String): List<String>? {
+        val raw = RootShell.run(
+            "logcat -b crash -d -v threadtime -t 1000 2>/dev/null",
+            useRoot = false,
+            timeoutMs = 6000,
+        ) ?: return null
+        return extractLastCrashStack(raw, pkg).takeIf { it.isNotEmpty() }
+    }
+
+    /**
+     * On-demand deep probe: per-thread cumulative disk I/O from `/proc/<pid>/task/*/io` (root), to
+     * find *which* thread is the writer behind a high disk-write rate. Best-effort and root-gated;
+     * returns the threads with non-zero write bytes, descending, or null when unavailable.
+     */
+    suspend fun probeIoTopThreads(pid: Int, useRoot: Boolean): List<ThreadIo>? {
+        if (!useRoot || pid <= 0) return null
+        val script = """
+            for t in /proc/$pid/task/*; do
+              echo "@@TIO ${'$'}(basename ${'$'}t)@@"
+              cat ${'$'}t/comm 2>/dev/null
+              cat ${'$'}t/io 2>/dev/null
+            done
+        """.trimIndent()
+        val raw = RootShell.run(script, useRoot = useRoot, timeoutMs = 5000) ?: return null
+        return parseThreadIo(raw).takeIf { it.isNotEmpty() }
+    }
+
+    /**
+     * On-demand deep probe: the app's active TCP sockets, decoded from `/proc/net/tcp{,6}` filtered to
+     * the app's uid (root). Tells the developer *who* the app is connected to behind a network rate.
+     * Best-effort: many ROMs hide other uids' entries (hidepid), in which case this returns null.
+     */
+    suspend fun probeSockets(pid: Int, useRoot: Boolean): List<SocketConn>? {
+        if (!useRoot || pid <= 0) return null
+        val script = """
+            echo "@@UID@@"; cat /proc/$pid/status 2>/dev/null | grep '^Uid:'
+            echo "@@TCP@@"; cat /proc/net/tcp 2>/dev/null
+            echo "@@TCP6@@"; cat /proc/net/tcp6 2>/dev/null
+        """.trimIndent()
+        val raw = RootShell.run(script, useRoot = useRoot, timeoutMs = 5000) ?: return null
+        val sections = splitSections(raw)
+        val uid = sections["UID"]?.trim()?.split(Regex("\\s+"))?.getOrNull(1)?.toIntOrNull() ?: return null
+        val conns = ArrayList<SocketConn>()
+        parseNetSockets(sections["TCP"], uid, ipv6 = false, into = conns)
+        parseNetSockets(sections["TCP6"], uid, ipv6 = true, into = conns)
+        return conns.distinctBy { it.proto + it.remote + it.state }.take(20).takeIf { it.isNotEmpty() }
+    }
+
     // ---------------------------------------------------------------------------------------------
     // Shell scripts
     // ---------------------------------------------------------------------------------------------
@@ -409,6 +463,111 @@ class AppStatsCollector(private val context: Context) {
     /** Extracts the leading `MM-DD HH:MM:SS` from a `-v threadtime` logcat line, or null. */
     private fun parseLogTime(line: String): String? =
         LOG_TIME.find(line.trimStart())?.groupValues?.get(1)
+
+    /**
+     * Pulls the full stack trace of the *most recent* `FATAL EXCEPTION` belonging to [pkg] out of the
+     * raw crash-buffer dump. Strips the threadtime + `AndroidRuntime:` tag from each line so only the
+     * trace text remains, and bounds the block to the next FATAL so two crashes never bleed together.
+     */
+    private fun extractLastCrashStack(crashLog: String, pkg: String): List<String> {
+        val lines = crashLog.lines()
+        var start = -1
+        var i = 0
+        while (i < lines.size) {
+            if (lines[i].contains("FATAL EXCEPTION")) {
+                val limit = minOf(i + 6, lines.size)
+                val matched = (i + 1 until limit).any {
+                    lines[it].contains("Process: $pkg,") || lines[it].contains("Process: $pkg ")
+                }
+                if (matched) start = i
+            }
+            i++
+        }
+        if (start < 0) return emptyList()
+        val tag = "AndroidRuntime:"
+        val out = ArrayList<String>()
+        var k = start
+        while (k < lines.size && out.size < 140) {
+            val l = lines[k]
+            if (k > start && l.contains("FATAL EXCEPTION")) break // next crash → stop
+            val idx = l.indexOf(tag)
+            if (idx < 0) {
+                if (out.isNotEmpty()) break // left the trace block
+            } else {
+                out.add(l.substring(idx + tag.length).removePrefix(" "))
+            }
+            k++
+        }
+        return out
+    }
+
+    /** Per-thread cumulative disk I/O from the `@@TIO <tid>@@` sections; top writers first. */
+    private fun parseThreadIo(raw: String): List<ThreadIo> {
+        val out = ArrayList<ThreadIo>()
+        for ((key, body) in splitSections(raw)) {
+            if (!key.startsWith("TIO ")) continue
+            val tid = key.removePrefix("TIO ").trim().toIntOrNull() ?: continue
+            val bodyLines = body.lines()
+            val name = bodyLines.firstOrNull { it.isNotBlank() }?.trim() ?: "tid $tid"
+            var rb = 0L
+            var wb = 0L
+            for (l in bodyLines) {
+                val t = l.trim()
+                when {
+                    t.startsWith("read_bytes:") -> rb = t.substringAfter(':').trim().toLongOrNull() ?: rb
+                    t.startsWith("write_bytes:") -> wb = t.substringAfter(':').trim().toLongOrNull() ?: wb
+                }
+            }
+            if (rb > 0 || wb > 0) out.add(ThreadIo(tid, name, rb, wb))
+        }
+        return out.sortedByDescending { it.writeBytes }.take(8)
+    }
+
+    /** Decodes `/proc/net/tcp{,6}` rows for [uid] into [SocketConn]s, skipping the header and others. */
+    private fun parseNetSockets(section: String?, uid: Int, ipv6: Boolean, into: MutableList<SocketConn>) {
+        if (section.isNullOrBlank()) return
+        for (line in section.lineSequence()) {
+            val cols = line.trim().split(Regex("\\s+"))
+            if (cols.size < 8 || !cols[0].endsWith(":")) continue // data rows look like "0: ...", header is "sl"
+            if (cols[7].toIntOrNull() != uid) continue
+            val state = TCP_STATES[cols[3]] ?: continue
+            val remote = decodeNetAddr(cols[2], ipv6) ?: continue
+            into.add(SocketConn(if (ipv6) "tcp6" else "tcp", state, remote))
+        }
+    }
+
+    /** Decodes a `HEXIP:HEXPORT` token from `/proc/net/tcp{,6}` to a readable `ip:port`. */
+    private fun decodeNetAddr(token: String, ipv6: Boolean): String? {
+        val parts = token.split(":")
+        if (parts.size != 2) return null
+        val port = parts[1].toIntOrNull(16) ?: return null
+        val ip = if (ipv6) decodeIpv6(parts[0]) else decodeIpv4(parts[0]) ?: return null
+        return if (ipv6) "[$ip]:$port" else "$ip:$port"
+    }
+
+    /** `/proc/net` stores the v4 address as a little-endian 32-bit hex word → reverse the octets. */
+    private fun decodeIpv4(hex: String): String? {
+        if (hex.length != 8) return null
+        return try {
+            val b = (0 until 4).map { hex.substring(it * 2, it * 2 + 2).toInt(16) }
+            "${b[3]}.${b[2]}.${b[1]}.${b[0]}"
+        } catch (e: NumberFormatException) {
+            null
+        }
+    }
+
+    /** v6 is four little-endian 32-bit words → reverse bytes within each word, then group as hextets. */
+    private fun decodeIpv6(hex: String): String? {
+        if (hex.length != 32) return null
+        return try {
+            val bytes = IntArray(16) { hex.substring(it * 2, it * 2 + 2).toInt(16) }
+            val ordered = IntArray(16)
+            for (w in 0 until 4) for (i in 0 until 4) ordered[w * 4 + i] = bytes[w * 4 + (3 - i)]
+            (0 until 8).joinToString(":") { g -> "%02x%02x".format(ordered[g * 2], ordered[g * 2 + 1]) }
+        } catch (e: NumberFormatException) {
+            null
+        }
+    }
 
     private fun parseCpu(sections: Map<String, String>, pids: List<Int>): CpuStats? {
         val cpuLine = sections["CPU"]?.trim() ?: return null
@@ -735,7 +894,14 @@ class AppStatsCollector(private val context: Context) {
     }
 
     companion object {
-        private val MARKER = Regex("""@@([A-Z]+(?: \d+)?)@@""")
+        // Section name (letters/digits, e.g. TCP6) optionally followed by a numeric id (e.g. PSTAT 1234).
+        private val MARKER = Regex("""@@([A-Z0-9]+(?: \d+)?)@@""")
+        // Linux TCP socket states we surface, keyed by the hex `st` column of /proc/net/tcp{,6}.
+        private val TCP_STATES = mapOf(
+            "01" to "ESTABLISHED", "02" to "SYN_SENT", "03" to "SYN_RECV",
+            "04" to "FIN_WAIT1", "05" to "FIN_WAIT2", "06" to "TIME_WAIT",
+            "08" to "CLOSE_WAIT", "0A" to "LISTEN",
+        )
         // Captures the class name from `ServiceRecord{hash u0 pkg/<Name> ...}` (running service).
         private val SERVICE_RECORD = Regex("""ServiceRecord\{[^}]*/([^\s}]+)""")
         // `<provider> provider:` section header in `dumpsys location`.

--- a/feature/stats/src/main/kotlin/com/hereliesaz/logkitty/feature/stats/StatsFeatureImpl.kt
+++ b/feature/stats/src/main/kotlin/com/hereliesaz/logkitty/feature/stats/StatsFeatureImpl.kt
@@ -84,6 +84,9 @@ class StatsFeatureImpl : StatsFeature {
             fontSize = fontSize,
             modifier = modifier,
             onProbeThreadStack = { pid, tid -> probeCollector.probeThreadStack(pid, tid, useRoot) },
+            onProbeCrashStack = { probeCollector.probeCrashStack(packageName) },
+            onProbeIoThreads = { pid -> probeCollector.probeIoTopThreads(pid, useRoot) },
+            onProbeSockets = { pid -> probeCollector.probeSockets(pid, useRoot) },
         )
     }
 

--- a/feature/stats/src/main/kotlin/com/hereliesaz/logkitty/feature/stats/StatsView.kt
+++ b/feature/stats/src/main/kotlin/com/hereliesaz/logkitty/feature/stats/StatsView.kt
@@ -360,7 +360,7 @@ private fun MemoryTrend(pssHistory: List<Long>, ff: FontFamily?, fs: Int, lc: Co
     val last = pssHistory.last()
     val deltaKb = last - first
     if (deltaKb < LEAK_THRESHOLD_KB) return // not a meaningful rise
-    val peak = pssHistory.max()
+    val peak = pssHistory.maxOrNull() ?: 0L
     val climbing = last >= peak - peak / 50 // within ~2% of the peak → still at/near the top
     val windowSec = pssHistory.size * 2 // ~2s sampling cadence
     val msg = "PSS +${kb(deltaKb)} over ~${windowSec}s" + if (climbing) " — still climbing (possible leak)" else ""

--- a/feature/stats/src/main/kotlin/com/hereliesaz/logkitty/feature/stats/StatsView.kt
+++ b/feature/stats/src/main/kotlin/com/hereliesaz/logkitty/feature/stats/StatsView.kt
@@ -49,6 +49,12 @@ fun StatsView(
     modifier: Modifier = Modifier,
     /** On-demand kernel-stack probe for a (pid, tid); null disables the CPU thread drill-down. */
     onProbeThreadStack: (suspend (Int, Int) -> List<String>?)? = null,
+    /** On-demand full crash-stack probe (rootless); null disables the crash drill-down. */
+    onProbeCrashStack: (suspend () -> List<String>?)? = null,
+    /** On-demand per-thread disk-I/O probe for a pid; null disables the disk-writer drill-down. */
+    onProbeIoThreads: (suspend (Int) -> List<ThreadIo>?)? = null,
+    /** On-demand active-socket probe for a pid; null disables the network connections drill-down. */
+    onProbeSockets: (suspend (Int) -> List<SocketConn>?)? = null,
 ) {
     val stats = history.lastOrNull()
     if (stats == null) {
@@ -103,14 +109,15 @@ fun StatsView(
         stats.memory?.let {
             MemorySection(it, history.mapNotNull { s -> s.memory?.totalPssKb }, fontFamily, fontSize, labelColor, valueColor)
         }
+        val pid = stats.pids.firstOrNull() ?: 0
         stats.gpu?.let { GpuSection(it, fontFamily, fontSize, labelColor, valueColor) }
-        stats.network?.let { NetworkSection(it, fontFamily, fontSize, labelColor, valueColor) }
+        stats.network?.let { NetworkSection(it, pid, fontFamily, fontSize, labelColor, valueColor, onProbeSockets) }
         stats.power?.let { PowerSection(stats.packageName, it, stats.cpu, stats.sensors, fontFamily, fontSize, labelColor, valueColor) }
-        stats.health?.let { HealthSection(it, fontFamily, fontSize, labelColor, valueColor) }
+        stats.health?.let { HealthSection(it, pid, fontFamily, fontSize, labelColor, valueColor, onProbeIoThreads) }
         stats.sensors?.let { SensorSection(it, fontFamily, fontSize, labelColor, valueColor) }
         stats.binder?.let { BinderSection(it, fontFamily, fontSize, labelColor, valueColor) }
         stats.components?.let { ComponentsSection(it, fontFamily, fontSize, labelColor, valueColor) }
-        stats.crashes?.let { CrashSection(it, fontFamily, fontSize, labelColor, valueColor) }
+        stats.crashes?.let { CrashSection(it, fontFamily, fontSize, labelColor, valueColor, onProbeCrashStack) }
 
         Spacer(Modifier.height(16.dp))
     }
@@ -227,7 +234,10 @@ private fun BinderSection(b: BinderStats, ff: FontFamily?, fs: Int, lc: Color, v
 }
 
 @Composable
-private fun CrashSection(c: CrashStats, ff: FontFamily?, fs: Int, lc: Color, vc: Color) {
+private fun CrashSection(
+    c: CrashStats, ff: FontFamily?, fs: Int, lc: Color, vc: Color,
+    onProbeCrashStack: (suspend () -> List<String>?)? = null,
+) {
     StatCard("Crashes & ANRs", ff, fs) {
         StatRow("Recent crashes", c.crashCount.toString(), ff, fs, lc, vc, emphasize = true)
         c.lastCrashWhen?.let { StatRow("Last crash", it, ff, fs, lc, vc) }
@@ -246,6 +256,12 @@ private fun CrashSection(c: CrashStats, ff: FontFamily?, fs: Int, lc: Color, vc:
                 maxLines = 2, overflow = TextOverflow.Ellipsis,
                 modifier = Modifier.fillMaxWidth().padding(top = 1.dp),
             )
+        }
+        // Drill-down: the full stack of the most recent crash, straight from the crash buffer (rootless).
+        if (onProbeCrashStack != null && c.crashCount > 0) {
+            ExpandableProbe("Investigate: full crash stack", c.lastCrashWhen ?: c.crashCount, { onProbeCrashStack() }, ff, fs, lc) { frames ->
+                StackFrames(frames, ff, fs, vc)
+            }
         }
     }
 }
@@ -386,16 +402,51 @@ private fun GpuSection(g: GpuStats, ff: FontFamily?, fs: Int, lc: Color, vc: Col
         StatRow("Slow UI thread", g.slowUiThread?.toString() ?: "—", ff, fs, lc, vc)
         StatRow("Slow draw cmds", g.slowDrawCommands?.toString() ?: "—", ff, fs, lc, vc)
         g.gpuBusyPercent?.let { StatRow("GPU busy (device)", pct(it), ff, fs, lc, vc) }
+        // Interpretive hint: when there's meaningful jank, point at the dominant cause from the
+        // slow-frame breakdown already collected, so the developer knows where to look.
+        JankHint(g, ff, fs)
     }
 }
 
+/** Turns the gfxinfo slow-frame counters into a one-line "where the jank is coming from" pointer. */
 @Composable
-private fun NetworkSection(n: NetworkStats, ff: FontFamily?, fs: Int, lc: Color, vc: Color) {
+private fun JankHint(g: GpuStats, ff: FontFamily?, fs: Int) {
+    if ((g.jankPercent ?: 0f) < 5f) return
+    val ui = g.slowUiThread ?: 0L
+    val draw = g.slowDrawCommands ?: 0L
+    val vsync = g.missedVsync ?: 0L
+    val worst = maxOf(ui, draw, vsync)
+    if (worst <= 0L) return
+    val cause = when (worst) {
+        ui -> "UI-thread work — move heavy work off the main thread"
+        draw -> "draw commands — overdraw or complex layouts"
+        else -> "missed vsync — work is overrunning the frame budget"
+    }
+    Spacer(Modifier.height(2.dp))
+    Text(
+        "Jank mostly from: $cause", color = Color(0xFFFFB74D), fontSize = (fs - 2).sp, fontFamily = ff,
+        fontWeight = FontWeight.Medium, modifier = Modifier.fillMaxWidth(),
+    )
+}
+
+@Composable
+private fun NetworkSection(
+    n: NetworkStats, pid: Int, ff: FontFamily?, fs: Int, lc: Color, vc: Color,
+    onProbeSockets: (suspend (Int) -> List<SocketConn>?)? = null,
+) {
     StatCard("Network", ff, fs) {
         StatRow("Down / Up now", "${rate(n.rxBytesPerSec)} / ${rate(n.txBytesPerSec)}", ff, fs, lc, vc, emphasize = true)
         StatRow("Received (24h)", bytes(n.totalRxBytes), ff, fs, lc, vc)
         StatRow("Sent (24h)", bytes(n.totalTxBytes), ff, fs, lc, vc)
         StatRow("Wi-Fi / Mobile", "${bytes(n.wifiBytes)} / ${bytes(n.mobileBytes)}", ff, fs, lc, vc)
+        // Drill-down: who the app is actually connected to, from /proc/net/tcp{,6} ∩ uid (root).
+        if (onProbeSockets != null && pid > 0) {
+            ExpandableProbe("Investigate: active connections", pid, { onProbeSockets(pid) }, ff, fs, lc) { conns ->
+                conns.forEach { s ->
+                    WrapStatRow("${s.proto} · ${s.state}", s.remote, ff, fs, lc, vc)
+                }
+            }
+        }
     }
 }
 
@@ -491,13 +542,87 @@ private fun BatteryInvestigation(
 }
 
 @Composable
-private fun HealthSection(h: HealthStats, ff: FontFamily?, fs: Int, lc: Color, vc: Color) {
+private fun HealthSection(
+    h: HealthStats, pid: Int, ff: FontFamily?, fs: Int, lc: Color, vc: Color,
+    onProbeIoThreads: (suspend (Int) -> List<ThreadIo>?)? = null,
+) {
     StatCard("Process Health", ff, fs) {
         StatRow("Threads", h.threadCount?.toString() ?: "—", ff, fs, lc, vc)
         StatRow("Open file descriptors", h.fdCount?.toString() ?: "—", ff, fs, lc, vc)
         StatRow("Disk read / write now", "${rate(h.ioReadBytesPerSec)} / ${rate(h.ioWriteBytesPerSec)}", ff, fs, lc, vc, emphasize = true)
         StatRow("Disk read total", bytes(h.totalIoReadBytes), ff, fs, lc, vc)
         StatRow("Disk write total", bytes(h.totalIoWriteBytes), ff, fs, lc, vc)
+        // Drill-down: which thread is the writer behind the disk-write rate (per-thread /proc io, root).
+        if (onProbeIoThreads != null && pid > 0) {
+            ExpandableProbe("Investigate: top disk writers", pid, { onProbeIoThreads(pid) }, ff, fs, lc) { threads ->
+                threads.forEach { t ->
+                    WrapStatRow(t.name, "✎ ${bytes(t.writeBytes)}  ·  ${bytes(t.readBytes)} read", ff, fs, lc, vc)
+                }
+            }
+        }
+    }
+}
+
+/**
+ * A tappable "Investigate" affordance that lazily runs an on-demand [probe] when first expanded and
+ * renders its result with [content]. Mirrors the CPU thread-stack drill-down: state is keyed on
+ * [resetKey] so it survives the 2s poll but resets when the target changes, and closing drops the
+ * cached result so reopening refetches a fresh sample.
+ */
+@Composable
+private fun <T> ExpandableProbe(
+    label: String,
+    resetKey: Any?,
+    probe: suspend () -> T?,
+    ff: FontFamily?, fs: Int, lc: Color,
+    content: @Composable (T) -> Unit,
+) {
+    var expanded by remember(resetKey) { mutableStateOf(false) }
+    var loading by remember(resetKey) { mutableStateOf(false) }
+    var result by remember(resetKey) { mutableStateOf<T?>(null) }
+    Spacer(Modifier.height(4.dp))
+    Row(
+        modifier = Modifier.fillMaxWidth().clickable {
+            expanded = !expanded
+            if (!expanded) result = null // closing drops the cache so reopening refetches
+        }.padding(vertical = 2.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            "${if (expanded) "▾" else "▸"}  $label",
+            color = Color(0xFF4DD0E1), fontSize = (fs - 1).sp, fontFamily = ff, fontWeight = FontWeight.Medium,
+            modifier = Modifier.weight(1f), maxLines = 1, overflow = TextOverflow.Ellipsis,
+        )
+    }
+    if (!expanded) return
+    // Launch keyed only on (resetKey, expanded) — NOT on `loading` — so flipping `loading` inside the
+    // effect doesn't drop the effect from composition and cancel the probe mid-flight. `result == null`
+    // keeps it composed across the run and is reset to null on close so reopening refetches.
+    if (result == null) {
+        LaunchedEffect(resetKey, expanded) {
+            loading = true
+            result = probe()
+            loading = false
+        }
+    }
+    when {
+        loading -> Text("Investigating…", color = lc, fontSize = (fs - 2).sp, fontFamily = ff,
+            modifier = Modifier.padding(start = 8.dp, top = 2.dp))
+        result == null -> Text("Nothing to show (restricted, none active, or non-root).",
+            color = lc, fontSize = (fs - 2).sp, fontFamily = ff, modifier = Modifier.padding(start = 8.dp, top = 2.dp))
+        else -> content(result!!)
+    }
+}
+
+/** Renders a captured stack/trace as monospace-ish lines (one ellipsized frame per row). */
+@Composable
+private fun StackFrames(frames: List<String>, ff: FontFamily?, fs: Int, vc: Color) {
+    frames.forEach { frame ->
+        Text(
+            frame, color = vc.copy(alpha = 0.85f), fontSize = (fs - 3).sp, fontFamily = ff,
+            maxLines = 1, overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.fillMaxWidth().padding(start = 8.dp),
+        )
     }
 }
 

--- a/feature/stats/src/main/kotlin/com/hereliesaz/logkitty/feature/stats/StatsView.kt
+++ b/feature/stats/src/main/kotlin/com/hereliesaz/logkitty/feature/stats/StatsView.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -580,6 +581,9 @@ private fun <T> ExpandableProbe(
     var expanded by remember(resetKey) { mutableStateOf(false) }
     var loading by remember(resetKey) { mutableStateOf(false) }
     var result by remember(resetKey) { mutableStateOf<T?>(null) }
+    // probe is intentionally NOT a LaunchedEffect key (we don't want to restart on every recomposition's
+    // new lambda); rememberUpdatedState keeps the effect calling the latest probe without restarting it.
+    val latestProbe by rememberUpdatedState(probe)
     Spacer(Modifier.height(4.dp))
     Row(
         modifier = Modifier.fillMaxWidth().clickable {
@@ -601,7 +605,7 @@ private fun <T> ExpandableProbe(
     if (result == null) {
         LaunchedEffect(resetKey, expanded) {
             loading = true
-            result = probe()
+            result = latestProbe()
             loading = false
         }
     }

--- a/feature/stats/src/main/kotlin/com/hereliesaz/logkitty/feature/stats/StatsView.kt
+++ b/feature/stats/src/main/kotlin/com/hereliesaz/logkitty/feature/stats/StatsView.kt
@@ -100,7 +100,9 @@ fun StatsView(
         if (history.size >= 2) TrendsSection(history, fontFamily, fontSize, labelColor, valueColor)
 
         stats.cpu?.let { CpuSection(it, fontFamily, fontSize, labelColor, valueColor, onProbeThreadStack) }
-        stats.memory?.let { MemorySection(it, fontFamily, fontSize, labelColor, valueColor) }
+        stats.memory?.let {
+            MemorySection(it, history.mapNotNull { s -> s.memory?.totalPssKb }, fontFamily, fontSize, labelColor, valueColor)
+        }
         stats.gpu?.let { GpuSection(it, fontFamily, fontSize, labelColor, valueColor) }
         stats.network?.let { NetworkSection(it, fontFamily, fontSize, labelColor, valueColor) }
         stats.power?.let { PowerSection(stats.packageName, it, stats.cpu, stats.sensors, fontFamily, fontSize, labelColor, valueColor) }
@@ -328,7 +330,9 @@ private fun CpuSection(
 }
 
 @Composable
-private fun MemorySection(m: MemoryStats, ff: FontFamily?, fs: Int, lc: Color, vc: Color) {
+private fun MemorySection(
+    m: MemoryStats, pssHistory: List<Long>, ff: FontFamily?, fs: Int, lc: Color, vc: Color,
+) {
     StatCard("Memory", ff, fs) {
         StatRow("Total PSS", kb(m.totalPssKb), ff, fs, lc, vc, emphasize = true)
         StatRow("Java heap", kb(m.javaHeapKb), ff, fs, lc, vc)
@@ -341,7 +345,32 @@ private fun MemorySection(m: MemoryStats, ff: FontFamily?, fs: Int, lc: Color, v
             val used = m.deviceTotalRamKb - (m.deviceAvailRamKb ?: 0)
             StatRow("Device RAM", "${kb(used)} / ${kb(m.deviceTotalRamKb)} used", ff, fs, lc, vc)
         }
+        MemoryTrend(pssHistory, ff, fs, lc)
     }
+}
+
+/**
+ * Leak/ramp hint from the rolling PSS history: if total PSS has climbed by more than a threshold over
+ * the window and is still near its peak, flag it. Turns the point-in-time number into "is it growing?"
+ */
+@Composable
+private fun MemoryTrend(pssHistory: List<Long>, ff: FontFamily?, fs: Int, lc: Color) {
+    if (pssHistory.size < MIN_TREND_SAMPLES) return
+    val first = pssHistory.first()
+    val last = pssHistory.last()
+    val deltaKb = last - first
+    if (deltaKb < LEAK_THRESHOLD_KB) return // not a meaningful rise
+    val peak = pssHistory.max()
+    val climbing = last >= peak - peak / 50 // within ~2% of the peak → still at/near the top
+    val windowSec = pssHistory.size * 2 // ~2s sampling cadence
+    val msg = "PSS +${kb(deltaKb)} over ~${windowSec}s" + if (climbing) " — still climbing (possible leak)" else ""
+    Spacer(Modifier.height(2.dp))
+    Text(
+        msg,
+        color = if (climbing) Color(0xFFFFB74D) else lc,
+        fontSize = (fs - 2).sp, fontFamily = ff, fontWeight = FontWeight.Medium,
+        modifier = Modifier.fillMaxWidth(),
+    )
 }
 
 @Composable
@@ -615,3 +644,9 @@ private fun accentFor(library: String): Color {
     val idx = (library.hashCode() and 0x7FFFFFFF) % palette.size
     return palette[idx]
 }
+
+// --- Memory leak/ramp heuristics (used by MemoryTrend) ---
+/** Need at least this many PSS samples (~10s at the 2s cadence) before a trend is meaningful. */
+private const val MIN_TREND_SAMPLES = 5
+/** Only flag a rise once PSS has climbed by more than this (in KB ≈ 4 MB) over the window. */
+private const val LEAK_THRESHOLD_KB = 4096L


### PR DESCRIPTION
## What

Part 2.3 of the Stats drill-down series. The Memory card already shows a point-in-time PSS number; this turns it into **"is it growing?"** by reusing the ~90s rolling history the module already keeps for sparklines.

- `MemorySection` now receives the recent `totalPssKb` series.
- New `MemoryTrend` composable: once there are enough samples (~10s) and PSS has risen past a ~4 MB threshold over the window, it reports the delta (`PSS +N over ~Ns`) and, when the latest reading is still within ~2% of the peak, marks it **"still climbing (possible leak)"** in amber.

No new permissions, no new probes — purely derived from data already collected. Null/short-history degrades to showing nothing.

## Stacking

Based on `claude/stats-cpu-stack` (#163). Review/merge that first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GSxjeuLJyBVyFhGXcxbkSe)_