### PR TITLE
Publish a signed APK to GitHub Releases on every Play publish

### DIFF
--- a/.github/workflows/play-publish.yml
+++ b/.github/workflows/play-publish.yml
@@ -31,7 +31,8 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      # write so the post-publish step can push a tag and create a GitHub Release for the APK.
+      contents: write
 
     steps:
       - name: Checkout
@@ -141,6 +142,96 @@ jobs:
           mappingFile: app/build/outputs/mapping/release/mapping.txt
           track: ${{ inputs.track }}
           status: ${{ inputs.status }}
+
+      # When (and only when) the bundle actually went to Play, also produce a signed, sideloadable
+      # APK and attach it to a GitHub Release pinned to this exact build. Extract a single universal
+      # APK from the same bundle: each dynamic feature declares <dist:fusing include="true">, so
+      # --mode=universal fuses them all into one APK (Play still delivers the modules on-demand).
+      # Runs before "Destroy Keystore" so the same signing key is available.
+      - name: Build universal APK from bundle
+        if: ${{ inputs.publish && success() }}
+        env:
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+        run: |
+          set -e
+          BT_VERSION=1.17.2
+          curl -fsSL -o bundletool.jar \
+            "https://github.com/google/bundletool/releases/download/${BT_VERSION}/bundletool-all-${BT_VERSION}.jar"
+
+          AAB=$(find app/build/outputs/bundle -name "*.aab" | head -n 1)
+          if [ -z "$AAB" ]; then echo "Error: no .aab produced!"; exit 1; fi
+          echo "Bundle: $AAB"
+
+          java -jar bundletool.jar build-apks --bundle="$AAB" --output=universal.apks \
+            --mode=universal --overwrite \
+            --ks="$KEYSTORE_FILE" --ks-pass=pass:"$KEYSTORE_PASSWORD" \
+            --ks-key-alias="$KEY_ALIAS" --key-pass=pass:"$KEY_PASSWORD"
+
+          unzip -o -p universal.apks universal.apk > app-universal.apk
+          ls -la app-universal.apk
+          echo "UNIVERSAL_APK=$(pwd)/app-universal.apk" >> $GITHUB_ENV
+
+      # Create/refresh an immutable, per-version GitHub Release for the build that shipped to Play.
+      # Tagged v<version> (distinct from build-and-release.yml's rolling latest-release-* prerelease).
+      # Marked as a full release only for a completed production rollout; otherwise a prerelease.
+      - name: Publish APK to GitHub Releases
+        if: ${{ inputs.publish && success() }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -e
+          BUILD_NUMBER=$(git rev-list --count HEAD)
+
+          MAJOR=$(grep 'major=' version.properties | cut -d'=' -f2)
+          MINOR=$(grep 'minor=' version.properties | cut -d'=' -f2)
+          # Patch = commits since the minor= line last changed (matches build-and-release.yml).
+          MINOR_COMMIT=$(git blame -L '/minor=/',+1 version.properties | awk '{print $1}' | tr -d '^')
+          if [ -n "$MINOR_COMMIT" ]; then
+            PATCH=$(git rev-list --count "$MINOR_COMMIT"..HEAD)
+          else
+            PATCH=$(grep 'patch=' version.properties | cut -d'=' -f2)
+          fi
+          VERSION_NAME="$MAJOR.$MINOR.$PATCH.$BUILD_NUMBER"
+          TAG_NAME="v${VERSION_NAME}"
+
+          if [ -z "$UNIVERSAL_APK" ] || [ ! -f "$UNIVERSAL_APK" ]; then
+            echo "Error: universal APK not found!"; exit 1
+          fi
+          APK_FILE="LogKitty-${VERSION_NAME}.apk"
+          cp "$UNIVERSAL_APK" "$APK_FILE"
+
+          # A finished production rollout is a real release; everything else (internal/alpha/beta or
+          # a draft) is a prerelease.
+          PRERELEASE_FLAG="--prerelease"
+          if [ "${{ inputs.track }}" = "production" ] && [ "${{ inputs.status }}" = "completed" ]; then
+            PRERELEASE_FLAG=""
+          fi
+
+          NOTES="Signed APK for the build published to Google Play (track: ${{ inputs.track }}, status: ${{ inputs.status }}).
+
+          Built from commit ${GITHUB_SHA}."
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -fa "$TAG_NAME" -m "Play release $VERSION_NAME"
+          git push origin "$TAG_NAME" --force
+
+          if gh release view "$TAG_NAME" > /dev/null 2>&1; then
+            echo "Updating existing release..."
+            gh release edit "$TAG_NAME" $PRERELEASE_FLAG \
+              --title "LogKitty ${VERSION_NAME}" \
+              --notes "$NOTES" \
+              --target "$GITHUB_SHA"
+            gh release upload "$TAG_NAME" "$APK_FILE" --clobber
+          else
+            echo "Creating new release..."
+            gh release create "$TAG_NAME" "$APK_FILE" $PRERELEASE_FLAG \
+              --title "LogKitty ${VERSION_NAME}" \
+              --notes "$NOTES" \
+              --target "$GITHUB_SHA"
+          fi
 
       - name: Destroy Keystore
         if: always()


### PR DESCRIPTION
## Why

`play-publish.yml` built and pushed the signed `.aab` to Google Play but never produced a sideloadable, signed **APK**. The request: whenever an AAB is published to Play, also publish a signed APK to GitHub Releases, so each store release has a matching downloadable build.

## What

Extends `play-publish.yml` only (no Gradle changes — the existing `signingConfigs.release` + bundletool path already produce a correctly signed universal APK):

- **New step — Build universal APK from bundle**: extracts a single universal APK from the just-built bundle via bundletool (`--mode=universal`, fusing the dynamic features), signed with the same reconstructed release keystore. Runs **before** `Destroy Keystore` so the key is still available.
- **New step — Publish APK to GitHub Releases**: derives `v<version>` from `version.properties` + commit count (same scheme as `build-and-release.yml`), then `gh release create`/`edit` + uploads `LogKitty-<version>.apk`.
- **Gating**: both new steps run only on `inputs.publish && success()`. A dry run (`publish=false`) still just uploads the `.aab` artifact — **no** release or tag is created.
- **Release identity**: an immutable, per-version tag `v<version>` — distinct from `build-and-release.yml`'s rolling `latest-release-v<major>.<minor>` dev prerelease. Marked a **full** release for a completed production rollout; **prerelease** otherwise.
- **Permissions**: job bumped from `contents: read` → `contents: write` (tag push + release creation).

## Verify

- **Dry run** (`publish=false`): only the `.aab` artifact uploads; no GitHub release/tag.
- **Internal/draft** (`publish=true`, `track=internal`, `status=draft`): AAB → Play **and** a `v<version>` **prerelease** appears with `LogKitty-<version>.apk` attached; `adb install` it to confirm it's release-signed and installable.
- **Production** (`track=production`, `status=completed`): the GitHub release is a **full** release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GSxjeuLJyBVyFhGXcxbkSe)_