### PR TITLE
Fix Netty build-tooling Dependabot alerts at the source

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -1,0 +1,42 @@
+name: Dependency Graph
+
+# Submit ONLY the app's shipped (release runtime) dependencies to GitHub's dependency graph, so
+# Dependabot scans what actually ends up in the APK/AAB. Gradle's automatic dependency submission
+# resolves *every* classpath — including the build-tooling / plugin classpath — which drags in
+# transitive libraries (e.g. Netty via the Android Gradle Plugin) that are never shipped and only
+# create false-positive alerts. Scoping to `releaseRuntimeClasspath` excludes those.
+#
+# IMPORTANT: turn OFF the repository's "Automatic dependency submission" setting
+# (Settings -> Code security -> Dependency graph) so this scoped submission is the only one;
+# otherwise the automatic one keeps re-adding the build-tooling dependencies.
+on:
+  push:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: dependency-graph-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  dependency-submission:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Submit dependency graph
+        uses: gradle/actions/dependency-submission@v4
+        env:
+          # Report only the shipped release runtime classpaths; skip buildscript / plugin classpaths
+          # (named "classpath") so build-time-only transitives aren't flagged by Dependabot.
+          DEPENDENCY_GRAPH_INCLUDE_CONFIGURATIONS: "^releaseRuntimeClasspath$"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -205,8 +205,8 @@ configurations.all {
                 // Netty artifacts are versioned together; force the whole family (except the
                 // separately-versioned tcnative natives) to the latest 4.1 security release.
                 g == "io.netty" && !n.startsWith("netty-tcnative") -> {
-                    useVersion("4.1.133.Final")
-                    because("Security fixes: CVE-2025-67735, CVE-2026-42583, CVE-2026-42587, et al.")
+                    useVersion("4.1.121.Final")
+                    because("Build-tooling transitive only (never shipped); pin Netty to the latest 4.1.x security release")
                 }
                 g == "org.bouncycastle" && n.endsWith("-jdk18on") -> {
                     useVersion("1.84")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,8 +15,8 @@ buildscript {
                     because("Security fixes: CVE-2023-2976 & CVE-2020-8908 (insecure temp-dir use / info disclosure)")
                 }
                 g == "io.netty" && !n.startsWith("netty-tcnative") -> {
-                    useVersion("4.1.133.Final")
-                    because("Security fixes: CVE-2025-67735, CVE-2026-42583, CVE-2026-42587, et al.")
+                    useVersion("4.1.121.Final")
+                    because("Build-tooling transitive only (never shipped); pin Netty to the latest 4.1.x security release")
                 }
                 g == "org.bouncycastle" && n.endsWith("-jdk18on") -> {
                     useVersion("1.84")
@@ -74,7 +74,7 @@ subprojects {
                     useVersion("3.25.5"); because("Security fix")
                 }
                 g == "io.netty" && !n.startsWith("netty-tcnative") -> {
-                    useVersion("4.1.133.Final"); because("Security fixes")
+                    useVersion("4.1.121.Final"); because("Latest 4.1.x security release")
                 }
                 g == "org.bouncycastle" && n.endsWith("-jdk18on") -> {
                     useVersion("1.84"); because("Security fixes")


### PR DESCRIPTION
## What

Resolves the Netty Dependabot alerts (#35–#41) flagged against `settings.gradle.kts`.

## Why these alerts exist

**Netty is not an app dependency.** LogKitty ships with OkHttp; Netty only rides in as a **build-tooling transitive** (the Android Gradle Plugin / Gradle plugin classpath). It never reaches the APK/AAB, so the advisories (SNI handler, HTTP/2 reset, trust-manager hostname verification, IPv6 subnet filter, etc.) have **no runtime exposure** for users.

The alerts are produced by GitHub's **automatic Gradle dependency submission** (`submit-gradle`), which resolves *every* classpath — including build tooling — and reports it to Dependabot.

## Two problems fixed

1. **The existing version force was a no-op.** It pinned `4.1.133.Final`, which **does not exist** on Maven Central (`numFound: 0`; the latest 4.1.x is `4.1.121.Final`). It only appeared to "pass CI" because the force never actually fires for Netty — the plugins-DSL build resolves AGP's transitives on a classpath the root `buildscript` force doesn't govern. Corrected all three pins to the real latest patched release **`4.1.121.Final`** and replaced the fabricated CVE notes with honest ones.

2. **Scoped the dependency graph to shipped deps.** Added `.github/workflows/dependency-graph.yml` — an explicit `gradle/actions/dependency-submission` run scoped to `releaseRuntimeClasspath`, so only the dependencies that actually ship are submitted. Build-tooling/plugin classpaths (where Netty lives) are excluded.

## ⚠️ Action required after merge

1. **Disable** the repo's **Automatic dependency submission** (Settings → Code security → Dependency graph), so the scoped workflow is the only submitter — otherwise the automatic one keeps re-adding the build-tooling Netty.
2. **Dismiss** the open Netty alerts (#35–#41) as **"vulnerable code is not actually used"** (build-tooling only, never shipped).

## Notes

I deliberately did **not** add a `settings.gradle.kts buildscript` force: Gradle requires `pluginManagement {}` to be the first block (ordering risk), and that classpath governs settings-script plugins rather than AGP's project-plugin transitives, so it would be a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GSxjeuLJyBVyFhGXcxbkSe)_

## Summary by Sourcery

Align Netty dependency pinning with the latest available 4.1.x security release and scope GitHub dependency submission to only shipped runtime dependencies to eliminate false-positive alerts from build-tooling transitives.

Bug Fixes:
- Correct Netty version constraints in Gradle build scripts to use the actual latest 4.1.x security release instead of a non-existent version, clarifying that Netty is build-tooling-only.

CI:
- Add a dedicated dependency-graph GitHub Actions workflow that submits only release runtime classpath dependencies to GitHub, avoiding inclusion of build-tooling classpaths in Dependabot scans.