### PR TITLE
Add UMP (GDPR) consent flow gating AdMob requests

### DIFF
--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/AdBannerSlot.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/AdBannerSlot.kt
@@ -57,7 +57,7 @@ fun AdBannerSlot(modifier: Modifier = Modifier, showTopDivider: Boolean = false)
             val activity = remember(context) { context.findActivity() }
             // Seed from UMP's persisted state (true on the overlay path after a prior Activity
             // session, or when consent isn't required); the Activity path may flip it after the form.
-            var consentReady by remember { mutableStateOf(ads.canRequestAds(context)) }
+            var consentReady by remember(ads, context) { mutableStateOf(ads.canRequestAds(context)) }
             LaunchedEffect(ads, activity) {
                 if (!consentReady && activity != null) {
                     ads.gatherConsent(activity) { consentReady = ads.canRequestAds(activity) }

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/AdBannerSlot.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/AdBannerSlot.kt
@@ -1,11 +1,17 @@
 package com.hereliesaz.logkitty.ui
 
+import android.app.Activity
+import android.content.Context
+import android.content.ContextWrapper
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
@@ -31,12 +37,11 @@ import com.hereliesaz.logkitty.feature.rememberFeatureInstall
  * unit for release when configured in local.properties/env. The app ID lives in AndroidManifest;
  * SDK init happens here via [AdsFeature.initialize].
  *
- * Known limitation — no UMP (User Messaging Platform) consent flow yet. A compliant GDPR/UMP gate
- * can't live here as-is: `UserMessagingPlatform.loadAndShowConsentFormIfRequired` needs an *Activity*,
- * but this banner is also hosted by the overlay foreground service, which has none. Adding it
- * properly means a new `user-messaging-platform` dependency in `:feature:ads`, an Activity-only
- * consent entry point on [AdsFeature], and gating ad init on the returned consent state. Tracked as a
- * deliberate follow-up rather than shipped half-implemented (a wrong consent gate is a policy risk).
+ * UMP consent: ads are gated on [AdsFeature.canRequestAds]. When this slot is hosted by an Activity
+ * (e.g. the launcher), it runs [AdsFeature.gatherConsent] to request consent info and show the form
+ * if required. When hosted by the overlay service (no Activity), it relies on the consent state UMP
+ * persisted during an earlier Activity session. The banner — and thus any ad request — appears only
+ * once consent permits it.
  *
  * @param showTopDivider draws a hairline divider above the banner — but only once the banner is
  *   actually rendered, so no stray line is left behind when ads aren't available.
@@ -49,15 +54,37 @@ fun AdBannerSlot(modifier: Modifier = Modifier, showTopDivider: Boolean = false)
     if (handle.status is FeatureInstallStatus.Installed) {
         val ads = remember { FeatureLoader.load<AdsFeature>(FeatureModules.ADS_IMPL, context) }
         if (ads != null) {
-            LaunchedEffect(ads) { ads.initialize(context.applicationContext) }
-            if (showTopDivider) {
-                Column(modifier = modifier) {
-                    HorizontalDivider(color = Color.White.copy(alpha = 0.08f))
-                    ads.BannerAd(BuildConfig.ADMOB_BANNER_UNIT_ID, Modifier.fillMaxWidth())
+            val activity = remember(context) { context.findActivity() }
+            // Seed from UMP's persisted state (true on the overlay path after a prior Activity
+            // session, or when consent isn't required); the Activity path may flip it after the form.
+            var consentReady by remember { mutableStateOf(ads.canRequestAds(context)) }
+            LaunchedEffect(ads, activity) {
+                if (!consentReady && activity != null) {
+                    ads.gatherConsent(activity) { consentReady = ads.canRequestAds(activity) }
                 }
-            } else {
-                ads.BannerAd(BuildConfig.ADMOB_BANNER_UNIT_ID, modifier)
+            }
+            if (consentReady) {
+                // Initialize the SDK only once consent allows requesting ads.
+                LaunchedEffect(ads) { ads.initialize(context.applicationContext) }
+                if (showTopDivider) {
+                    Column(modifier = modifier) {
+                        HorizontalDivider(color = Color.White.copy(alpha = 0.08f))
+                        ads.BannerAd(BuildConfig.ADMOB_BANNER_UNIT_ID, Modifier.fillMaxWidth())
+                    }
+                } else {
+                    ads.BannerAd(BuildConfig.ADMOB_BANNER_UNIT_ID, modifier)
+                }
             }
         }
     }
+}
+
+/** Unwraps a [Context] to its hosting [Activity], or `null` (e.g. the overlay service's context). */
+private fun Context.findActivity(): Activity? {
+    var ctx: Context? = this
+    while (ctx is ContextWrapper) {
+        if (ctx is Activity) return ctx
+        ctx = ctx.baseContext
+    }
+    return null
 }

--- a/core/src/main/kotlin/com/hereliesaz/logkitty/core/feature/Features.kt
+++ b/core/src/main/kotlin/com/hereliesaz/logkitty/core/feature/Features.kt
@@ -27,9 +27,28 @@ interface StatsFeature {
     )
 }
 
-/** Ads feature (`:feature:ads`). Renders the AdMob banner; owns play-services-ads + AD_ID. */
+/**
+ * Ads feature (`:feature:ads`). Renders the AdMob banner; owns play-services-ads, the AD_ID
+ * permission, and the UMP (User Messaging Platform) consent flow.
+ *
+ * Consent must be gathered before ads are requested. The UMP form needs an [android.app.Activity],
+ * but the banner is also hosted by the overlay foreground service (no Activity) — so the contract is
+ * split: [gatherConsent] runs the form from an Activity host (e.g. the launcher Activity), while the
+ * service-hosted banner relies on the consent state UMP persists across the process, queried via
+ * [canRequestAds]. [BannerAd] only loads an ad once consent allows it.
+ */
 interface AdsFeature {
     fun initialize(appContext: android.content.Context)
+
+    /**
+     * Runs the UMP consent flow (requests the latest consent info and shows the form if required),
+     * then invokes [onComplete] regardless of outcome. Must be called with an [android.app.Activity]
+     * because the form needs one. Idempotent and safe to call repeatedly.
+     */
+    fun gatherConsent(activity: android.app.Activity, onComplete: () -> Unit)
+
+    /** Whether ads may be requested yet — consent obtained or not required. Reads UMP's persisted state. */
+    fun canRequestAds(context: android.content.Context): Boolean
 
     @Composable
     fun BannerAd(adUnitId: String, modifier: Modifier)

--- a/feature/ads/build.gradle.kts
+++ b/feature/ads/build.gradle.kts
@@ -29,6 +29,8 @@ dependencies {
 
     // The ad SDK + AD_ID permission live in this module so they're only pulled in with it.
     implementation(libs.play.services.ads)
+    // UMP (User Messaging Platform) for the GDPR/consent flow gating ad requests.
+    implementation(libs.user.messaging.platform)
 
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.compose.ui)

--- a/feature/ads/src/main/kotlin/com/hereliesaz/logkitty/feature/ads/AdsFeatureImpl.kt
+++ b/feature/ads/src/main/kotlin/com/hereliesaz/logkitty/feature/ads/AdsFeatureImpl.kt
@@ -1,5 +1,6 @@
 package com.hereliesaz.logkitty.feature.ads
 
+import android.app.Activity
 import android.content.Context
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -18,16 +19,48 @@ import com.google.android.gms.ads.AdRequest
 import com.google.android.gms.ads.AdSize
 import com.google.android.gms.ads.AdView
 import com.google.android.gms.ads.MobileAds
+import com.google.android.ump.ConsentRequestParameters
+import com.google.android.ump.UserMessagingPlatform
 import com.hereliesaz.logkitty.core.feature.AdsFeature
 
 /**
- * Entry point the base loads reflectively once this module is installed. Holds the AdMob SDK and the
- * banner view, so `play-services-ads` and the AD_ID permission ship only with this module.
+ * Entry point the base loads reflectively once this module is installed. Holds the AdMob SDK, the
+ * banner view, and the UMP consent flow, so `play-services-ads`, the UMP library, and the AD_ID
+ * permission ship only with this module.
  */
 class AdsFeatureImpl : AdsFeature {
 
+    @Volatile
+    private var initialized = false
+
+    /** Initializes the Mobile Ads SDK once. Call only after consent permits requesting ads. */
     override fun initialize(appContext: Context) {
+        if (initialized) return
+        initialized = true
         runCatching { MobileAds.initialize(appContext) }
+    }
+
+    override fun canRequestAds(context: Context): Boolean = runCatching {
+        UserMessagingPlatform.getConsentInformation(context).canRequestAds()
+    }.getOrDefault(false)
+
+    override fun gatherConsent(activity: Activity, onComplete: () -> Unit) {
+        val consentInfo = UserMessagingPlatform.getConsentInformation(activity)
+        val params = ConsentRequestParameters.Builder().build()
+        consentInfo.requestConsentInfoUpdate(
+            activity,
+            params,
+            {
+                // Info updated: show the consent form if one is required/available. The dismissal
+                // callback fires whether the form was shown, dismissed, or wasn't needed.
+                UserMessagingPlatform.loadAndShowConsentFormIfRequired(activity) { onComplete() }
+            },
+            {
+                // Update failed (e.g. offline). Proceed — canRequestAds() may still be true from a
+                // prior session, and BannerAd re-checks it before loading anything.
+                onComplete()
+            },
+        )
     }
 
     @Composable

--- a/feature/ads/src/main/kotlin/com/hereliesaz/logkitty/feature/ads/AdsFeatureImpl.kt
+++ b/feature/ads/src/main/kotlin/com/hereliesaz/logkitty/feature/ads/AdsFeatureImpl.kt
@@ -45,15 +45,26 @@ class AdsFeatureImpl : AdsFeature {
     }.getOrDefault(false)
 
     override fun gatherConsent(activity: Activity, onComplete: () -> Unit) {
+        // requestConsentInfoUpdate is async; the Activity could go away before it returns, and
+        // showing a form on a finishing/destroyed Activity would crash (bad window token).
+        if (activity.isFinishing || activity.isDestroyed) {
+            onComplete()
+            return
+        }
         val consentInfo = UserMessagingPlatform.getConsentInformation(activity)
         val params = ConsentRequestParameters.Builder().build()
         consentInfo.requestConsentInfoUpdate(
             activity,
             params,
             {
-                // Info updated: show the consent form if one is required/available. The dismissal
-                // callback fires whether the form was shown, dismissed, or wasn't needed.
-                UserMessagingPlatform.loadAndShowConsentFormIfRequired(activity) { onComplete() }
+                // Info updated: show the consent form if one is required/available, but only while
+                // the Activity is still valid. The dismissal callback fires whether the form was
+                // shown, dismissed, or wasn't needed.
+                if (activity.isFinishing || activity.isDestroyed) {
+                    onComplete()
+                } else {
+                    UserMessagingPlatform.loadAndShowConsentFormIfRequired(activity) { onComplete() }
+                }
             },
             {
                 // Update failed (e.g. offline). Proceed — canRequestAds() may still be true from a

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,7 @@ agp = "9.2.1"
 aetherTransportFile = "2.0.14"
 aznavrail = "10.1"
 playServicesAds = "25.3.0"
+userMessagingPlatform = "4.0.0"
 coreKtx = "1.19.0"
 kotlinxCoroutinesCore = "1.11.0"
 junit = "4.13.2"
@@ -34,6 +35,7 @@ androidx-localbroadcastmanager = { module = "androidx.localbroadcastmanager:loca
 androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "navigationCompose" }
 aznavrail = { module = "com.github.HereLiesAz:AzNavRail", version.ref = "aznavrail" }
 play-services-ads = { module = "com.google.android.gms:play-services-ads", version.ref = "playServicesAds" }
+user-messaging-platform = { module = "com.google.android.ump:user-messaging-platform", version.ref = "userMessagingPlatform" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }


### PR DESCRIPTION
## Summary
Implements the UMP (User Messaging Platform) consent gate that was previously documented as a known limitation in `AdBannerSlot` after the force-close audit (#170).

The tricky part: the UMP consent form requires an **Activity**, but the banner is also hosted by the overlay **foreground service** (no Activity). This splits the contract so both paths are correct:

- **`AdsFeature` (`:core`)** gains:
  - `gatherConsent(activity, onComplete)` — requests the latest consent info and shows the form if required.
  - `canRequestAds(context)` — reads UMP's persisted consent state.
- **`AdsFeatureImpl` (`:feature:ads`)** runs `requestConsentInfoUpdate` → `loadAndShowConsentFormIfRequired`, and initializes the Mobile Ads SDK **only once consent permits requesting ads**.
- **`AdBannerSlot`** gates the banner (and therefore any ad request) behind `canRequestAds`: when hosted by an Activity (launcher) it gathers consent and shows the form; when hosted by the overlay service it relies on the state UMP persisted during an earlier Activity session (the user always passes through the launcher first). Adds a small `Context.findActivity()` unwrap helper.
- Adds `com.google.android.ump:user-messaging-platform:4.0.0` via the **version catalog**.

## Graceful degradation
If no consent message is configured in the AdMob/UMP console, `requestConsentInfoUpdate` succeeds, no form is shown, and `canRequestAds()` returns `true` — so ad behavior is unchanged for that case. UMP errors (e.g. offline) fall through to the persisted `canRequestAds` state.

## Verification
- `./gradlew :app:assembleDebug` ✅ (UMP 4.0.0 resolves & compiles)
- `./gradlew :app:lintDebug` ✅ — no new issues
- `./gradlew :app:testDebugUnitTest` ✅
- Runtime check to do on-device: first launch in an EEA/debug-geography test shows the consent form before the banner; declining keeps the banner hidden; the overlay banner appears only after consent was granted in the Activity.

> Note: showing a real consent form also requires configuring a privacy message in the AdMob console; without it the flow is a no-op (ads as before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MsdbtsxKQbhDJDb6p61Mgj)_