### PR TITLE
Add in-app "Manage ad consent" privacy options entry

### DIFF
--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/AdBannerSlot.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/AdBannerSlot.kt
@@ -80,7 +80,7 @@ fun AdBannerSlot(modifier: Modifier = Modifier, showTopDivider: Boolean = false)
 }
 
 /** Unwraps a [Context] to its hosting [Activity], or `null` (e.g. the overlay service's context). */
-private fun Context.findActivity(): Activity? {
+internal fun Context.findActivity(): Activity? {
     var ctx: Context? = this
     while (ctx is ContextWrapper) {
         if (ctx is Activity) return ctx

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/SettingsScreen.kt
@@ -76,6 +76,11 @@ import com.hereliesaz.aznavrail.AzButton
 import com.hereliesaz.aznavrail.model.AzButtonShape
 import com.hereliesaz.logkitty.BuildConfig
 import com.hereliesaz.logkitty.R
+import com.hereliesaz.logkitty.core.feature.AdsFeature
+import com.hereliesaz.logkitty.core.feature.FeatureLoader
+import com.hereliesaz.logkitty.core.feature.FeatureModules
+import com.hereliesaz.logkitty.feature.FeatureInstallStatus
+import com.hereliesaz.logkitty.feature.rememberFeatureInstall
 import com.hereliesaz.logkitty.utils.GitHubDeviceAuth
 import kotlinx.coroutines.Job
 import com.hereliesaz.logkitty.ui.theme.CodingFont
@@ -699,6 +704,8 @@ private fun SettingsMainScreen(
                 )
             }
 
+            PrivacyOptionsSlot()
+
             SettingsFooter(context)
 
             // Modest trailing margin so the footer clears the persistent bottom ad.
@@ -712,6 +719,47 @@ private fun appLabel(context: android.content.Context, pkg: String): String = tr
     val pm = context.packageManager
     pm.getApplicationLabel(pm.getApplicationInfo(pkg, 0)).toString()
 } catch (e: Exception) { pkg }
+
+/**
+ * Settings entry that lets the user revisit their ad-consent choices via the UMP privacy-options
+ * form (a Google UMP requirement: consent must be changeable later).
+ *
+ * Rendered only when the `:feature:ads` module is already installed AND UMP reports a privacy-options
+ * requirement — so users who never loaded ads, or for whom consent doesn't apply, see nothing (and we
+ * never install the module just to show this). The form needs an Activity, which Settings always has
+ * (it's hosted by MainActivity); the row is disabled if one can't be resolved.
+ */
+@Composable
+private fun PrivacyOptionsSlot() {
+    val handle = rememberFeatureInstall(FeatureModules.ADS)
+    if (handle.status !is FeatureInstallStatus.Installed) return
+    val context = LocalContext.current
+    val feature = remember { FeatureLoader.load<AdsFeature>(FeatureModules.ADS_IMPL, context) } ?: return
+    if (!remember { feature.isPrivacyOptionsRequired(context) }) return
+    val activity = remember(context) { context.findActivity() }
+
+    SettingsCard(stringResource(R.string.settings_section_privacy)) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable(enabled = activity != null) {
+                    activity?.let { act -> feature.showPrivacyOptions(act) {} }
+                }
+                .padding(vertical = 12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(stringResource(R.string.settings_ad_privacy), style = MaterialTheme.typography.bodyLarge)
+                Text(
+                    stringResource(R.string.settings_ad_privacy_desc),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}
 
 /**
  * Bottom-of-settings footer mirroring AzNavRail's footer: About (repo), Feedback (email),

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/SettingsScreen.kt
@@ -734,8 +734,8 @@ private fun PrivacyOptionsSlot() {
     val handle = rememberFeatureInstall(FeatureModules.ADS)
     if (handle.status !is FeatureInstallStatus.Installed) return
     val context = LocalContext.current
-    val feature = remember { FeatureLoader.load<AdsFeature>(FeatureModules.ADS_IMPL, context) } ?: return
-    if (!remember { feature.isPrivacyOptionsRequired(context) }) return
+    val feature = remember(context) { FeatureLoader.load<AdsFeature>(FeatureModules.ADS_IMPL, context) } ?: return
+    if (!remember(feature, context) { feature.isPrivacyOptionsRequired(context) }) return
     val activity = remember(context) { context.findActivity() }
 
     SettingsCard(stringResource(R.string.settings_section_privacy)) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -197,6 +197,11 @@
     <string name="notif_action_stop">Stop</string>
     <string name="notif_action_app_settings">App Settings</string>
 
+    <!-- Privacy / ad consent section -->
+    <string name="settings_section_privacy">Privacy</string>
+    <string name="settings_ad_privacy">Manage ad consent</string>
+    <string name="settings_ad_privacy_desc">Review or change your ad personalization choices.</string>
+
     <!-- Permissions section -->
     <string name="settings_section_permissions">Permissions</string>
     <string name="perm_granted">Granted</string>

--- a/core/src/main/kotlin/com/hereliesaz/logkitty/core/feature/Features.kt
+++ b/core/src/main/kotlin/com/hereliesaz/logkitty/core/feature/Features.kt
@@ -50,6 +50,19 @@ interface AdsFeature {
     /** Whether ads may be requested yet — consent obtained or not required. Reads UMP's persisted state. */
     fun canRequestAds(context: android.content.Context): Boolean
 
+    /**
+     * Whether a "privacy options" entry must be offered so the user can change consent later — i.e.
+     * UMP reports `privacyOptionsRequirementStatus == REQUIRED` (consent applies to this user). Used
+     * to decide whether to show the Settings entry at all.
+     */
+    fun isPrivacyOptionsRequired(context: android.content.Context): Boolean
+
+    /**
+     * Shows the UMP privacy-options form so the user can review/change consent, then invokes
+     * [onComplete]. Needs an [android.app.Activity]; safe to call when one is available (Settings).
+     */
+    fun showPrivacyOptions(activity: android.app.Activity, onComplete: () -> Unit)
+
     @Composable
     fun BannerAd(adUnitId: String, modifier: Modifier)
 }

--- a/feature/ads/src/main/kotlin/com/hereliesaz/logkitty/feature/ads/AdsFeatureImpl.kt
+++ b/feature/ads/src/main/kotlin/com/hereliesaz/logkitty/feature/ads/AdsFeatureImpl.kt
@@ -19,6 +19,7 @@ import com.google.android.gms.ads.AdRequest
 import com.google.android.gms.ads.AdSize
 import com.google.android.gms.ads.AdView
 import com.google.android.gms.ads.MobileAds
+import com.google.android.ump.ConsentInformation
 import com.google.android.ump.ConsentRequestParameters
 import com.google.android.ump.UserMessagingPlatform
 import com.hereliesaz.logkitty.core.feature.AdsFeature
@@ -72,6 +73,19 @@ class AdsFeatureImpl : AdsFeature {
                 onComplete()
             },
         )
+    }
+
+    override fun isPrivacyOptionsRequired(context: Context): Boolean = runCatching {
+        UserMessagingPlatform.getConsentInformation(context).privacyOptionsRequirementStatus ==
+            ConsentInformation.PrivacyOptionsRequirementStatus.REQUIRED
+    }.getOrDefault(false)
+
+    override fun showPrivacyOptions(activity: Activity, onComplete: () -> Unit) {
+        if (activity.isFinishing || activity.isDestroyed) {
+            onComplete()
+            return
+        }
+        UserMessagingPlatform.showPrivacyOptionsForm(activity) { onComplete() }
     }
 
     @Composable


### PR DESCRIPTION
## Summary
Completes the consent work from #171. Google's UMP policy requires apps to let users **change their consent later** — #171 only gathered consent on first run, so this adds the revisit path as a Settings entry.

- **`AdsFeature` (`:core`)** gains:
  - `isPrivacyOptionsRequired(context)` — true when UMP reports `privacyOptionsRequirementStatus == REQUIRED`.
  - `showPrivacyOptions(activity, onComplete)` — shows `UserMessagingPlatform.showPrivacyOptionsForm(...)`, with the same finishing/destroyed-Activity guard as the consent flow.
- **`AdsFeatureImpl`** implements both via UMP.
- **`SettingsScreen`** shows a new **"Manage ad consent"** entry (`PrivacyOptionsSlot`) **only when** the `:feature:ads` module is already installed **and** a privacy-options requirement exists — so it never triggers a module install and stays hidden where consent doesn't apply. It reuses the existing `rememberFeatureInstall` + `FeatureLoader` slot pattern and the `Context.findActivity()` helper (promoted `private` → `internal` for reuse; the row is disabled if no Activity resolves).

## Behavior
- Outside consent regions / when ads were never loaded: nothing shown.
- In consent regions: a "Manage ad consent" row opens the UMP privacy form so users can change their choices.
- Still requires a privacy message configured in the AdMob console (same prerequisite as #171); without it UMP reports no requirement and the entry stays hidden.

## Verification
- `./gradlew :app:assembleDebug` ✅
- `./gradlew :app:lintDebug` ✅ — no new issues
- `./gradlew :app:testDebugUnitTest` ✅
- On-device: in EEA/debug-geography, after consent, Settings shows "Manage ad consent" → tapping opens the UMP privacy form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MsdbtsxKQbhDJDb6p61Mgj)_