### PR TITLE
Update privacy policy to match current data practices

### DIFF
--- a/docs/PRIVACY_POLICY.md
+++ b/docs/PRIVACY_POLICY.md
@@ -36,7 +36,8 @@ server (there is no LogKitty server).
   apps via a scoped `<queries>` launcher filter, and on rooted devices lists the
   rest via `pm list packages`. This lookup happens on‑device and is not transmitted.
 - **Usage access (`PACKAGE_USAGE_STATS`).** Used, where available, to identify
-  the foreground app for context filtering. Processed on‑device only.
+  the foreground app for context filtering and, in the optional Developer Stats
+  module, to read per‑app network usage. Processed on‑device only.
 - **App preferences.** Your settings (colors, font, filters, monitored apps,
   prohibited tags, etc.) are stored locally in the app's private storage.
 
@@ -48,7 +49,7 @@ server (there is no LogKitty server).
 | `SYSTEM_ALERT_WINDOW` | Draw the floating log overlay over other apps. |
 | `FOREGROUND_SERVICE` / `FOREGROUND_SERVICE_SPECIAL_USE` | Keep the log capture running with a persistent notification. |
 | `POST_NOTIFICATIONS` | Show the persistent silent control notification. |
-| `PACKAGE_USAGE_STATS` | Detect the foreground app for context filtering. |
+| `PACKAGE_USAGE_STATS` | Detect the foreground app for context filtering; read per‑app network usage in the Developer Stats module. |
 | `INTERNET` | Required by the components below (fonts, ads, GitHub Actions, optional crash reporting). |
 | `AD_ID` | Declared by the on‑demand `:feature:ads` module and used by the Google Mobile Ads SDK (see "Advertising"). |
 

--- a/docs/PRIVACY_POLICY.md
+++ b/docs/PRIVACY_POLICY.md
@@ -1,6 +1,6 @@
 # Privacy Policy
 
-_Last updated: June 8, 2026_
+_Last updated: June 23, 2026_
 
 LogKitty ("the app") is an on-device Android log viewer. It overlays the system
 logcat output so you can read your device's logs in real time. This policy
@@ -30,9 +30,11 @@ server (there is no LogKitty server).
   or errors that other apps write to the log). LogKitty keeps the log only in
   memory (and a bounded in‑memory buffer you can size in Settings) for display.
   It does not transmit the log anywhere on its own.
-- **Installed app information (`QUERY_ALL_PACKAGES`).** Used to let you pick an
-  app to monitor and to classify log sources (user / system / Play Store /
-  category). This lookup happens on‑device and is not transmitted.
+- **Installed app information.** Used to let you pick an app to monitor and to
+  classify log sources (user / system / Play Store / category). LogKitty does
+  **not** request the broad `QUERY_ALL_PACKAGES` permission: it sees launchable
+  apps via a scoped `<queries>` launcher filter, and on rooted devices lists the
+  rest via `pm list packages`. This lookup happens on‑device and is not transmitted.
 - **Usage access (`PACKAGE_USAGE_STATS`).** Used, where available, to identify
   the foreground app for context filtering. Processed on‑device only.
 - **App preferences.** Your settings (colors, font, filters, monitored apps,
@@ -46,10 +48,9 @@ server (there is no LogKitty server).
 | `SYSTEM_ALERT_WINDOW` | Draw the floating log overlay over other apps. |
 | `FOREGROUND_SERVICE` / `FOREGROUND_SERVICE_SPECIAL_USE` | Keep the log capture running with a persistent notification. |
 | `POST_NOTIFICATIONS` | Show the persistent silent control notification. |
-| `QUERY_ALL_PACKAGES` | Resolve app names/sources for monitoring and filtering. |
 | `PACKAGE_USAGE_STATS` | Detect the foreground app for context filtering. |
-| `INTERNET` | Required by the components below (fonts, ads, optional crash reporting). |
-| `AD_ID` | Used by the Google Mobile Ads SDK (see "Advertising"). |
+| `INTERNET` | Required by the components below (fonts, ads, GitHub Actions, optional crash reporting). |
+| `AD_ID` | Declared by the on‑demand `:feature:ads` module and used by the Google Mobile Ads SDK (see "Advertising"). |
 
 You can review the live grant status of these permissions in
 **Settings → Permissions**.
@@ -70,6 +71,12 @@ measure ads. This processing is governed by Google's policies, not LogKitty:
 - How Google uses information from apps that use its services:
   https://policies.google.com/technologies/partner-sites
 
+Where consent is legally required (e.g. the EEA/UK), the app uses Google's
+**User Messaging Platform (UMP)** to show a consent form before requesting ads,
+and only requests ads once your choice allows it. You can review or change your
+choice at any time via **Settings → Privacy → Manage ad consent**, or opt out of
+ads personalization through your device's Google ad settings.
+
 > Note: development builds use Google's **test** ad unit IDs, which do not serve
 > real ads. Production builds use live AdMob units.
 
@@ -79,6 +86,21 @@ Code fonts are fetched on demand from Google's downloadable‑fonts provider. Wh
 a font is requested, the request is handled by Google Play services and is
 subject to Google's privacy policy (linked above). No LogKitty user data is
 attached to these requests.
+
+### GitHub Actions (optional, only if you configure it)
+
+If you use the optional GitHub Actions feature, the app talks to the **GitHub
+REST API** (`api.github.com`) to show workflow runs, jobs, and logs for the
+repository you configure. To do this you provide a Personal Access Token (PAT),
+which is stored **encrypted on your device** (Android Keystore, AES/GCM) in a
+backup‑excluded store — it is never included in settings backups/exports and is
+sent only to GitHub to authenticate your own requests.
+
+### On‑demand feature modules
+
+Ads, Developer Stats, and GitHub Actions ship as optional modules downloaded
+from **Google Play** the first time you use them. Fetching a module is a request
+to Google Play, governed by Google's privacy policy (linked above).
 
 ### Saving or sharing logs (only when you choose to)
 


### PR DESCRIPTION
## Summary
Brings `docs/PRIVACY_POLICY.md` in line with what the app actually does now, so it can be used as the **privacy policy URL** required by the AdMob UMP consent message.

The repo already had a solid privacy policy; it had just drifted from the code:

- **Removed `QUERY_ALL_PACKAGES`** (both the bullet and the permissions-table row) — the app no longer declares it; app visibility comes from a scoped `<queries>` launcher filter, with `pm list packages` under root. Noted that **`AD_ID`** is declared by the on-demand `:feature:ads` module.
- **Advertising** — documented the **UMP consent flow** (consent gathered before ads are requested where legally required) and the new in-app **Settings → Privacy → Manage ad consent** entry to review/change consent later.
- **GitHub Actions** — added the optional data flow: the PAT is stored **encrypted in the Android Keystore**, backup-excluded, and used only to call `api.github.com` for the repo you configure.
- **On-demand modules** — noted ads/stats/github are downloaded from Google Play on first use.
- Bumped "Last updated".

No code changes — docs only.

## Answering "what to put in the AdMob message"
The AdMob GDPR message is mostly templated; the field you must supply is a **privacy policy URL**, which this file provides once Pages serves it. See PR discussion for the field-by-field AdMob settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MsdbtsxKQbhDJDb6p61Mgj)_