### PR TITLE
Fix launch force-close: strip MobileAdsInitProvider from base manifest

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -40,6 +40,17 @@
             android:name="com.google.android.gms.fonts.API_KEY"
             android:value="${FONTS_API_KEY}" />
 
+        <!-- The Google Mobile Ads SDK lives in the on-demand :feature:ads split. AGP promotes its
+             auto-init MobileAdsInitProvider into the BASE manifest (tagged splitName="ads"), but some
+             devices still instantiate it at process start when the ads split isn't installed, hitting
+             a ClassNotFoundException and force-closing on launch. We initialize the SDK explicitly
+             (AdsFeatureImpl.initialize), so strip the auto-init provider from the base manifest. -->
+        <provider
+            android:name="com.google.android.gms.ads.MobileAdsInitProvider"
+            android:authorities="${applicationId}.mobileadsinitprovider"
+            tools:node="remove"
+            tools:ignore="MissingClass" />
+
         <!-- AdMob APPLICATION_ID meta-data now lives in the :feature:ads module manifest. -->
 
         <activity


### PR DESCRIPTION
## Summary
Fixes a **launch force-close** reported in a user crash log — almost certainly *the* "force close on some devices" symptom (it fires earlier and on more installs than the FGS crash fixed in #170).

```
RuntimeException: Unable to get provider com.google.android.gms.ads.MobileAdsInitProvider
  at ActivityThread.installContentProviders … handleBindApplication
Caused by: ClassNotFoundException: Didn't find class "…MobileAdsInitProvider"
  (base.apk + split_config.* only — no feature split)
```

## Root cause
AGP promotes the Google Mobile Ads SDK's auto-init `MobileAdsInitProvider` from the **on-demand** `:feature:ads` module into the **base** manifest (tagged `android:splitName="ads"`). On installs where the ads split isn't present — the default for an on-demand module — some devices still instantiate the provider during `handleBindApplication`, and since the class ships only in the absent split, the process dies at startup. The standalone/sideloaded GitHub APK fuses the feature in (`dist:fusing`), which is why it doesn't reproduce there — hence "some devices."

## Fix
The app already calls `MobileAds.initialize()` explicitly (`AdsFeatureImpl.initialize`, gated on consent), so the auto-init provider is unnecessary. Remove it from the **base** manifest:

```xml
<provider
    android:name="com.google.android.gms.ads.MobileAdsInitProvider"
    android:authorities="${applicationId}.mobileadsinitprovider"
    tools:node="remove"
    tools:ignore="MissingClass" />
```

`tools:ignore="MissingClass"` suppresses the (expected) lint complaint that the removed class isn't in the base module.

## Verification (merged-bundle manifest, the definitive check)
- **Before:** base bundle manifest declared `MobileAdsInitProvider` (with `splitName="ads"`).
- **After:** `MobileAdsInitProvider` count in the **base** bundle manifest = **0**; in the **ads split** manifest = **1**. So auto-init still works when the module is installed, and the fused universal/sideload APK is unaffected (the removal touches only the base manifest). The only remaining base provider is `androidx.startup.InitializationProvider`, whose class is in the base.
- `./gradlew :app:assembleDebug :app:bundleDebug :app:lintDebug :app:testDebugUnitTest` ✅ (lint: no new issues).

> bundletool/emulator aren't available in this environment, so I verified at the merged-manifest level rather than by installing a base-only split set on a device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MsdbtsxKQbhDJDb6p61Mgj)_