### PR TITLE
Host privacy policy + permissions on GitHub Pages

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -2,9 +2,12 @@
 name: Deploy Jekyll with GitHub Pages dependencies preinstalled
 
 on:
-  # Runs on pushes targeting the default branch
+  # Runs on pushes to the default branch that touch the published docs or this workflow.
   push:
-    branches: ["master"]
+    branches: ["main"]
+    paths:
+      - "docs/**"
+      - ".github/workflows/jekyll-gh-pages.yml"
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -33,7 +36,7 @@ jobs:
       - name: Build with Jekyll
         uses: actions/jekyll-build-pages@v1
         with:
-          source: ./
+          source: ./docs
           destination: ./_site
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ LogKitty is a developer tool that puts your system logs right where you need the
 
 ## Documentation
 
-Comprehensive documentation is available in the `docs/` directory:
+The [Privacy Policy](https://hereliesaz.github.io/LogKitty/privacy/) and
+[Permissions](https://hereliesaz.github.io/LogKitty/permissions/) are published on the
+web. Comprehensive documentation is available in the `docs/` directory:
 
 *   **[Setup Guide](docs/SETUP.md):** Build instructions, prerequisites, and installation.
 *   **[Releasing](docs/RELEASING.md):** Signed App Bundle, versionCode, dynamic feature modules, and Play Console publishing.

--- a/docs/PERMISSIONS.md
+++ b/docs/PERMISSIONS.md
@@ -1,3 +1,8 @@
+---
+title: Permissions
+permalink: /permissions/
+---
+
 # Permissions
 
 This document explains every permission LogKitty declares, why it's needed, and

--- a/docs/PRIVACY_POLICY.md
+++ b/docs/PRIVACY_POLICY.md
@@ -1,3 +1,8 @@
+---
+title: Privacy Policy
+permalink: /privacy/
+---
+
 # Privacy Policy
 
 _Last updated: June 23, 2026_
@@ -143,6 +148,8 @@ This policy may be updated as the app changes. Material changes will be
 reflected by updating the "Last updated" date above and committing the revised
 policy to the project repository:
 https://github.com/HereLiesAz/LogKitty
+
+The current policy is published at **https://hereliesaz.github.io/LogKitty/privacy/**.
 
 ## Contact
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,38 @@
+# GitHub Pages configuration for the public LogKitty docs site.
+# The Jekyll build (see .github/workflows/jekyll-gh-pages.yml) uses ./docs as its
+# source, so this file lives alongside the documents it publishes.
+title: LogKitty
+description: The always-on logcat overlay for Android.
+theme: jekyll-theme-cayman
+
+url: "https://hereliesaz.github.io"
+baseurl: "/LogKitty"
+
+# Only the landing page and the user-facing policy/permissions docs are published.
+# The internal development docs are excluded so they don't appear on the public site.
+# (Jekyll only renders files that carry YAML front matter; everything else would be
+# copied verbatim — excluding them keeps the site clean.)
+exclude:
+  - API.md
+  - AZNAVRAIL_COMPLETE_GUIDE.md
+  - PRE_RELEASE_CHECKLIST.md
+  - RELEASING.md
+  - SETUP.md
+  - TODO.md
+  - UI_UX.md
+  - architecture.md
+  - auth.md
+  - blueprint.md
+  - build_pipeline.md
+  - conduct.md
+  - data_layer.md
+  - error_handling.md
+  - fauxpas.md
+  - file_descriptions.md
+  - manifest.md
+  - misc.md
+  - performance.md
+  - screens.md
+  - task_flow.md
+  - testing.md
+  - workflow.md

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,10 +13,10 @@ on your device.
 
 ## Documents
 
-- [Privacy Policy](/LogKitty/privacy/) — what data the app accesses, what stays on
-  your device, and the limited cases where data leaves it.
-- [Permissions](/LogKitty/permissions/) — every permission the app declares and why
-  it's needed.
+- [Privacy Policy]({{ '/privacy/' | relative_url }}) — what data the app accesses, what
+  stays on your device, and the limited cases where data leaves it.
+- [Permissions]({{ '/permissions/' | relative_url }}) — every permission the app declares
+  and why it's needed.
 
 ## Project
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,24 @@
+---
+title: LogKitty
+permalink: /
+---
+
+# LogKitty
+
+**The always-on logcat overlay for Android.**
+
+LogKitty is a developer tool that puts your system logs right where you need them:
+floating above your target app, in real time. It reads and displays logs entirely
+on your device.
+
+## Documents
+
+- [Privacy Policy](/LogKitty/privacy/) — what data the app accesses, what stays on
+  your device, and the limited cases where data leaves it.
+- [Permissions](/LogKitty/permissions/) — every permission the app declares and why
+  it's needed.
+
+## Project
+
+Source code, releases, and issues live on GitHub:
+[github.com/HereLiesAz/LogKitty](https://github.com/HereLiesAz/LogKitty).


### PR DESCRIPTION
## Summary
Publishes the **Privacy Policy** and **Permissions** docs to GitHub Pages so there's a stable public URL to paste into the **AdMob app settings** and the **Play Console** listing (required now that the app serves AdMob ads).

Once Pages is enabled (see manual step below):
- Privacy: `https://hereliesaz.github.io/LogKitty/privacy/`
- Permissions: `https://hereliesaz.github.io/LogKitty/permissions/`
- Landing: `https://hereliesaz.github.io/LogKitty/`

## Why it wasn't already working
The repo had a `jekyll-gh-pages.yml` workflow, but it only triggered on a **`master`** branch that doesn't exist (the default branch is **`main`**), so it had **never run**. It also built from `./` — the entire Android project — which is fragile.

## Changes
- **`.github/workflows/jekyll-gh-pages.yml`** — trigger on `main` with a `docs/**` path filter (keeps `workflow_dispatch`); build from `./docs` instead of `./`.
- **`docs/_config.yml`** (new) — Cayman theme, `baseurl: /LogKitty`, and an `exclude:` list for the internal dev docs so only the user-facing pages are published. (Jekyll only renders files with YAML front matter; excluding the rest keeps the site clean and avoids Liquid-parsing code-heavy docs.)
- **`docs/PRIVACY_POLICY.md`, `docs/PERMISSIONS.md`** — minimal front matter for clean permalinks (`/privacy/`, `/permissions/`); bodies unchanged.
- **`docs/index.md`** (new) — small landing page linking to the two docs.
- **`docs/PRIVACY_POLICY.md` + `README.md`** — reference the hosted policy URL.

## ⚠️ One-time manual step (required)
GitHub Pages must be enabled once — I can't toggle repo settings from here:

> **Settings → Pages → Build and deployment → Source = "GitHub Actions"**

After that, the workflow deploys on the next push to `main` touching `docs/**`, or via **Actions → Deploy Jekyll… → Run workflow**.

## Verification
- YAML + front matter parse-checked locally (all valid).
- Full end-to-end (the live URLs rendering) can only be confirmed after Pages is enabled and a run completes — no Pages/site access from the build sandbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MsdbtsxKQbhDJDb6p61Mgj)_