### PR TITLE
Add in-app About/Help screen rendering the project docs

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -62,6 +62,11 @@ android {
     // standalone APK (see each module's <dist:fusing>) for the sideloaded GitHub build.
     dynamicFeatures += setOf(":feature:stats", ":feature:ads", ":feature:github")
 
+    // The in-app About/Help reader (InfoScreen) displays the project's own docs. They're copied from
+    // the canonical README + docs/ into a generated assets directory at build time, so there's a
+    // single source of truth and no committed duplicates. Wired via the Variant API below
+    // (androidComponents.onVariants) so the task dependency reaches every consumer (merge + lint).
+
     defaultConfig {
         applicationId = "com.hereliesaz.logkitty"
         minSdk = 30
@@ -177,6 +182,45 @@ android {
             pickFirsts.add("misc/registry.properties")
             pickFirsts.add("**/libjnidispatch.so")
         }
+    }
+}
+
+// Copies the canonical README + user-facing docs into a generated assets directory for the in-app
+// About/Help reader (InfoScreen). A typed task with a declared output directory lets the Variant API
+// (below) carry the task dependency to every consumer automatically.
+abstract class CopyInAppDocsTask : DefaultTask() {
+    @get:InputFiles
+    @get:PathSensitive(PathSensitivity.NAME_ONLY)
+    abstract val docFiles: ConfigurableFileCollection
+
+    @get:OutputDirectory
+    abstract val outputDir: DirectoryProperty
+
+    @TaskAction
+    fun run() {
+        val root = outputDir.get().asFile
+        root.deleteRecursively()
+        val docs = File(root, "docs").apply { mkdirs() }
+        docFiles.files.forEach { src ->
+            if (src.exists()) src.copyTo(File(docs, src.name), overwrite = true)
+        }
+    }
+}
+
+val copyInAppDocs = tasks.register<CopyInAppDocsTask>("copyInAppDocs") {
+    description = "Bundles README + user-facing docs into assets for the in-app About/Help reader."
+    docFiles.from(
+        rootProject.file("README.md"),
+        rootProject.file("docs/PRIVACY_POLICY.md"),
+        rootProject.file("docs/PERMISSIONS.md"),
+        rootProject.file("docs/conduct.md"),
+    )
+    outputDir.set(layout.buildDirectory.dir("generated/inAppDocs"))
+}
+
+androidComponents {
+    onVariants { variant ->
+        variant.sources.assets?.addGeneratedSourceDirectory(copyInAppDocs, CopyInAppDocsTask::outputDir)
     }
 }
 

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/InfoScreen.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/InfoScreen.kt
@@ -155,8 +155,12 @@ private val InfoDocuments = listOf(
 
 /** Opens a URL with the app's standard pattern: an ACTION_VIEW intent, toast on failure. */
 private fun openUrl(context: Context, url: String) {
-    runCatching { context.startActivity(Intent(Intent.ACTION_VIEW, url.toUri())) }
-        .onFailure {
-            Toast.makeText(context, context.getString(R.string.toast_no_app_to_handle), Toast.LENGTH_SHORT).show()
-        }
+    runCatching {
+        // NEW_TASK so the link still opens if the context is ever non-Activity (matches the app's
+        // other launch sites in LogBottomSheet / the GitHub OAuth flow).
+        val intent = Intent(Intent.ACTION_VIEW, url.toUri()).apply { addFlags(Intent.FLAG_ACTIVITY_NEW_TASK) }
+        context.startActivity(intent)
+    }.onFailure {
+        Toast.makeText(context, context.getString(R.string.toast_no_app_to_handle), Toast.LENGTH_SHORT).show()
+    }
 }

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/InfoScreen.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/InfoScreen.kt
@@ -1,0 +1,162 @@
+package com.hereliesaz.logkitty.ui
+
+import android.content.Context
+import android.content.Intent
+import android.widget.Toast
+import androidx.activity.compose.BackHandler
+import androidx.annotation.StringRes
+import androidx.core.net.toUri
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.hereliesaz.logkitty.R
+import com.hereliesaz.logkitty.ui.markdown.MdBlock
+import com.hereliesaz.logkitty.ui.markdown.MarkdownText
+import com.hereliesaz.logkitty.ui.markdown.parseMarkdownBlocks
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * In-app reader for the project's own documentation. Shows an index of the docs bundled into the
+ * app's assets (README, Privacy Policy, Permissions, Code of Conduct); selecting one renders its
+ * Markdown natively. The documents are copied from the repo's `README.md` / `docs/` at build time
+ * (see the `copyInAppDocs` task in app/build.gradle.kts), so there's a single source of truth.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun InfoScreen(onBack: () -> Unit) {
+    val context = LocalContext.current
+    var selected by remember { mutableStateOf<InfoDoc?>(null) }
+
+    // While viewing a document, the system back gesture returns to the index rather than leaving.
+    BackHandler(enabled = selected != null) { selected = null }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(selected?.titleRes ?: R.string.info_title)) },
+                navigationIcon = {
+                    IconButton(onClick = { if (selected != null) selected = null else onBack() }) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.cd_back))
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        when (val doc = selected) {
+            null -> InfoIndex(padding = padding, onOpen = { selected = it })
+            else -> DocumentContent(doc = doc, padding = padding, onLinkClick = { url -> openUrl(context, url) })
+        }
+    }
+}
+
+@Composable
+private fun InfoIndex(padding: PaddingValues, onOpen: (InfoDoc) -> Unit) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(padding)
+            .verticalScroll(rememberScrollState())
+            .padding(16.dp),
+    ) {
+        InfoDocuments.forEach { doc ->
+            Card(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 6.dp)
+                    .clickable { onOpen(doc) },
+                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
+            ) {
+                Column(modifier = Modifier.padding(16.dp)) {
+                    Text(stringResource(doc.titleRes), style = MaterialTheme.typography.titleMedium)
+                    Text(
+                        stringResource(doc.descRes),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun DocumentContent(doc: InfoDoc, padding: PaddingValues, onLinkClick: (String) -> Unit) {
+    val context = LocalContext.current
+    val state by produceState<DocState>(initialValue = DocState.Loading, doc) {
+        value = withContext(Dispatchers.IO) {
+            runCatching {
+                context.assets.open("docs/${doc.asset}").bufferedReader().use { it.readText() }
+            }.fold(
+                onSuccess = { DocState.Loaded(parseMarkdownBlocks(it)) },
+                onFailure = { DocState.Error },
+            )
+        }
+    }
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(padding)
+            .verticalScroll(rememberScrollState())
+            .padding(16.dp),
+    ) {
+        when (val s = state) {
+            DocState.Loading -> Text(stringResource(R.string.info_loading), style = MaterialTheme.typography.bodyMedium)
+            DocState.Error -> Text(stringResource(R.string.info_load_error), style = MaterialTheme.typography.bodyMedium)
+            is DocState.Loaded -> MarkdownText(blocks = s.blocks, onLinkClick = onLinkClick)
+        }
+    }
+}
+
+private sealed interface DocState {
+    data object Loading : DocState
+    data object Error : DocState
+    data class Loaded(val blocks: List<MdBlock>) : DocState
+}
+
+private data class InfoDoc(
+    @StringRes val titleRes: Int,
+    @StringRes val descRes: Int,
+    val asset: String,
+)
+
+private val InfoDocuments = listOf(
+    InfoDoc(R.string.info_doc_readme, R.string.info_doc_readme_desc, "README.md"),
+    InfoDoc(R.string.info_doc_privacy, R.string.info_doc_privacy_desc, "PRIVACY_POLICY.md"),
+    InfoDoc(R.string.info_doc_permissions, R.string.info_doc_permissions_desc, "PERMISSIONS.md"),
+    InfoDoc(R.string.info_doc_conduct, R.string.info_doc_conduct_desc, "conduct.md"),
+)
+
+/** Opens a URL with the app's standard pattern: an ACTION_VIEW intent, toast on failure. */
+private fun openUrl(context: Context, url: String) {
+    runCatching { context.startActivity(Intent(Intent.ACTION_VIEW, url.toUri())) }
+        .onFailure {
+            Toast.makeText(context, context.getString(R.string.toast_no_app_to_handle), Toast.LENGTH_SHORT).show()
+        }
+}

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/SettingsScreen.kt
@@ -100,7 +100,8 @@ fun SettingsScreen(onBack: () -> Unit, viewModel: MainViewModel) {
             viewModel = viewModel,
             onBack = onBack,
             onOpenProhibited = { currentRoute = SettingsRoute.PROHIBITED },
-            onOpenColorEditor = { currentRoute = SettingsRoute.COLORS }
+            onOpenColorEditor = { currentRoute = SettingsRoute.COLORS },
+            onOpenInfo = { currentRoute = SettingsRoute.INFO }
         )
         SettingsRoute.PROHIBITED -> ProhibitedLogsScreen(
             viewModel = viewModel,
@@ -110,10 +111,13 @@ fun SettingsScreen(onBack: () -> Unit, viewModel: MainViewModel) {
             viewModel = viewModel,
             onBack = { currentRoute = SettingsRoute.MAIN }
         )
+        SettingsRoute.INFO -> InfoScreen(
+            onBack = { currentRoute = SettingsRoute.MAIN }
+        )
     }
 }
 
-private enum class SettingsRoute { MAIN, PROHIBITED, COLORS }
+private enum class SettingsRoute { MAIN, PROHIBITED, COLORS, INFO }
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -122,6 +126,7 @@ private fun SettingsMainScreen(
     onBack: () -> Unit,
     onOpenProhibited: () -> Unit,
     onOpenColorEditor: () -> Unit,
+    onOpenInfo: () -> Unit,
 ) {
     val context = LocalContext.current
     val clipboardManager = LocalClipboardManager.current
@@ -705,6 +710,26 @@ private fun SettingsMainScreen(
             }
 
             PrivacyOptionsSlot()
+
+            SettingsCard(stringResource(R.string.settings_section_about)) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable { onOpenInfo() }
+                        .padding(vertical = 12.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                ) {
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(stringResource(R.string.info_title), style = MaterialTheme.typography.bodyLarge)
+                        Text(
+                            stringResource(R.string.settings_about_desc),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+            }
 
             SettingsFooter(context)
 

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/markdown/MarkdownParser.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/markdown/MarkdownParser.kt
@@ -236,9 +236,22 @@ fun parseInline(input: String): List<MdSpan> {
                     if (end > i) { flush(); spans += MdSpan.Bold(input.substring(i + 2, end)); i = end + 2 }
                     else { plain.append(c); i++ }
                 } else {
-                    // Treat `_` as italic only at a word boundary, so snake_case identifiers survive.
+                    // Treat `_` as italic only when both delimiters sit at word boundaries, so
+                    // snake_case identifiers survive even when emphasized (e.g. `_PACKAGE_USAGE_STATS_`
+                    // italicizes the whole token) and a stray `_` before one doesn't swallow it.
                     val prevOk = i == 0 || !input[i - 1].isLetterOrDigit()
-                    val end = if (prevOk) input.indexOf('_', i + 1) else -1
+                    var end = -1
+                    if (prevOk) {
+                        var searchStart = i + 1
+                        while (searchStart < n) {
+                            val candidate = input.indexOf('_', searchStart)
+                            if (candidate < 0) break
+                            val nextOk = candidate == n - 1 || !input[candidate + 1].isLetterOrDigit()
+                            val prevSpace = input[candidate - 1].isWhitespace()
+                            if (nextOk && !prevSpace) { end = candidate; break }
+                            searchStart = candidate + 1
+                        }
+                    }
                     if (end > i) { flush(); spans += MdSpan.Italic(input.substring(i + 1, end)); i = end + 1 }
                     else { plain.append(c); i++ }
                 }

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/markdown/MarkdownParser.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/markdown/MarkdownParser.kt
@@ -1,0 +1,252 @@
+package com.hereliesaz.logkitty.ui.markdown
+
+/**
+ * A small, dependency-free Markdown parser tailored to the documents LogKitty ships in-app
+ * (README + the docs/ files). It is deliberately *not* a full CommonMark implementation: it
+ * supports the constructs those documents actually use — ATX headings, paragraphs, ordered and
+ * unordered lists, blockquotes, fenced code blocks, GitHub-flavoured pipe tables, thematic breaks,
+ * and inline emphasis / code / links.
+ *
+ * Parsing is split into a pure-Kotlin block/inline model here (unit-testable, no Compose types) and a
+ * thin Compose renderer in `MarkdownText.kt` that turns the model into UI.
+ */
+
+/** A block-level element. */
+sealed interface MdBlock {
+    data class Heading(val level: Int, val spans: List<MdSpan>) : MdBlock
+    data class Paragraph(val spans: List<MdSpan>) : MdBlock
+    data class BulletItem(val indent: Int, val spans: List<MdSpan>) : MdBlock
+    data class NumberedItem(val indent: Int, val number: Int, val spans: List<MdSpan>) : MdBlock
+    data class Quote(val spans: List<MdSpan>) : MdBlock
+    data class CodeBlock(val code: String, val lang: String?) : MdBlock
+    data class Table(val headers: List<List<MdSpan>>, val rows: List<List<List<MdSpan>>>) : MdBlock
+    data object Divider : MdBlock
+}
+
+/** An inline span within a block. */
+sealed interface MdSpan {
+    data class Text(val text: String) : MdSpan
+    data class Bold(val text: String) : MdSpan
+    data class Italic(val text: String) : MdSpan
+    data class BoldItalic(val text: String) : MdSpan
+    data class Code(val text: String) : MdSpan
+    data class Link(val text: String, val url: String) : MdSpan
+}
+
+private val HEADING = Regex("^#{1,6}\\s")
+private val BULLET = Regex("^[-*+]\\s")
+private val NUMBERED = Regex("^\\d+\\.\\s")
+private val HR = Regex("^([-*_])\\1{2,}$")
+private val TABLE_CELL = Regex("^:?-{1,}:?$")
+
+/**
+ * Removes a leading YAML front-matter block (`---` … `---`) if present. The published docs carry
+ * front matter for GitHub Pages permalinks; in-app we don't want to render it.
+ */
+fun stripFrontMatter(raw: String): String {
+    val text = raw.replace("\r\n", "\n")
+    if (!text.startsWith("---\n")) return raw
+    val end = text.indexOf("\n---", 4)
+    if (end < 0) return raw
+    val after = text.indexOf('\n', end + 1)
+    return if (after < 0) "" else text.substring(after + 1)
+}
+
+/** Parses a Markdown document into a flat list of block elements. */
+fun parseMarkdownBlocks(raw: String): List<MdBlock> {
+    val md = stripFrontMatter(raw).replace("\r\n", "\n").replace("\t", "    ")
+    val lines = md.split("\n")
+    val blocks = mutableListOf<MdBlock>()
+    val para = mutableListOf<String>()
+    var i = 0
+
+    fun flushPara() {
+        if (para.isNotEmpty()) {
+            val text = para.joinToString(" ") { it.trim() }.trim()
+            if (text.isNotEmpty()) blocks += MdBlock.Paragraph(parseInline(text))
+            para.clear()
+        }
+    }
+
+    while (i < lines.size) {
+        val line = lines[i]
+        val trimmed = line.trim()
+        when {
+            trimmed.isEmpty() -> { flushPara(); i++ }
+
+            trimmed.startsWith("```") -> {
+                flushPara()
+                val lang = trimmed.removePrefix("```").trim().ifEmpty { null }
+                val code = StringBuilder()
+                i++
+                while (i < lines.size && !lines[i].trim().startsWith("```")) {
+                    code.appendLine(lines[i]); i++
+                }
+                i++ // closing fence
+                blocks += MdBlock.CodeBlock(code.toString().trimEnd('\n'), lang)
+            }
+
+            HEADING.containsMatchIn(trimmed) -> {
+                flushPara()
+                val level = trimmed.takeWhile { it == '#' }.length
+                blocks += MdBlock.Heading(level, parseInline(trimmed.drop(level).trim()))
+                i++
+            }
+
+            trimmed.matches(HR) -> { flushPara(); blocks += MdBlock.Divider; i++ }
+
+            line.contains("|") && i + 1 < lines.size && isTableSeparator(lines[i + 1]) -> {
+                flushPara()
+                val headers = parseTableRow(line)
+                i += 2
+                val rows = mutableListOf<List<List<MdSpan>>>()
+                while (i < lines.size && lines[i].contains("|") && lines[i].trim().isNotEmpty()) {
+                    rows += parseTableRow(lines[i]); i++
+                }
+                blocks += MdBlock.Table(headers, rows)
+            }
+
+            trimmed.startsWith(">") -> {
+                flushPara()
+                val quote = mutableListOf<String>()
+                while (i < lines.size && lines[i].trim().startsWith(">")) {
+                    quote += lines[i].trim().removePrefix(">").trim(); i++
+                }
+                blocks += MdBlock.Quote(parseInline(quote.joinToString(" ").trim()))
+            }
+
+            BULLET.containsMatchIn(trimmed) -> {
+                flushPara()
+                val indent = line.takeWhile { it == ' ' }.length / 2
+                var text = trimmed.replaceFirst(BULLET, "")
+                i++
+                i = consumeContinuation(lines, i) { text += " $it" }
+                blocks += MdBlock.BulletItem(indent, parseInline(text))
+            }
+
+            NUMBERED.containsMatchIn(trimmed) -> {
+                flushPara()
+                val indent = line.takeWhile { it == ' ' }.length / 2
+                val number = trimmed.takeWhile { it.isDigit() }.toIntOrNull() ?: 1
+                var text = trimmed.replaceFirst(NUMBERED, "")
+                i++
+                i = consumeContinuation(lines, i) { text += " $it" }
+                blocks += MdBlock.NumberedItem(indent, number, parseInline(text))
+            }
+
+            else -> { para += line; i++ }
+        }
+    }
+    flushPara()
+    return blocks
+}
+
+/**
+ * Appends soft-wrapped continuation lines of a list item (lines that are neither blank nor the start
+ * of a new block) and returns the index of the first unconsumed line.
+ */
+private inline fun consumeContinuation(lines: List<String>, start: Int, append: (String) -> Unit): Int {
+    var i = start
+    while (i < lines.size) {
+        if (lines[i].trim().isEmpty() || isBlockStart(lines, i)) break
+        append(lines[i].trim())
+        i++
+    }
+    return i
+}
+
+private fun isBlockStart(lines: List<String>, i: Int): Boolean {
+    val line = lines[i]
+    val t = line.trim()
+    if (t.isEmpty()) return false
+    return t.startsWith("```") ||
+        HEADING.containsMatchIn(t) ||
+        t.matches(HR) ||
+        BULLET.containsMatchIn(t) ||
+        NUMBERED.containsMatchIn(t) ||
+        t.startsWith(">") ||
+        (line.contains("|") && i + 1 < lines.size && isTableSeparator(lines[i + 1]))
+}
+
+private fun isTableSeparator(line: String): Boolean {
+    val t = line.trim()
+    if (!t.contains("-") || !t.contains("|")) return false
+    val cells = t.trim('|').split("|")
+    return cells.isNotEmpty() && cells.all { it.trim().matches(TABLE_CELL) }
+}
+
+private fun parseTableRow(line: String): List<List<MdSpan>> =
+    line.trim().trim('|').split("|").map { parseInline(it.trim()) }
+
+/** Parses inline emphasis, code spans and links within a single block of text. */
+fun parseInline(input: String): List<MdSpan> {
+    val spans = mutableListOf<MdSpan>()
+    val plain = StringBuilder()
+    var i = 0
+    val n = input.length
+
+    fun flush() {
+        if (plain.isNotEmpty()) { spans += MdSpan.Text(plain.toString()); plain.clear() }
+    }
+
+    while (i < n) {
+        val c = input[i]
+        when {
+            c == '`' -> {
+                val end = input.indexOf('`', i + 1)
+                if (end > i) { flush(); spans += MdSpan.Code(input.substring(i + 1, end)); i = end + 1 }
+                else { plain.append(c); i++ }
+            }
+
+            c == '[' -> {
+                val close = input.indexOf(']', i + 1)
+                if (close > i && close + 1 < n && input[close + 1] == '(') {
+                    val paren = input.indexOf(')', close + 2)
+                    if (paren > close) {
+                        flush()
+                        spans += MdSpan.Link(input.substring(i + 1, close), input.substring(close + 2, paren))
+                        i = paren + 1
+                    } else { plain.append(c); i++ }
+                } else { plain.append(c); i++ }
+            }
+
+            c == '*' -> {
+                when {
+                    input.startsWith("***", i) -> {
+                        val end = input.indexOf("***", i + 3)
+                        if (end > i) { flush(); spans += MdSpan.BoldItalic(input.substring(i + 3, end)); i = end + 3 }
+                        else { plain.append(c); i++ }
+                    }
+                    input.startsWith("**", i) -> {
+                        val end = input.indexOf("**", i + 2)
+                        if (end > i) { flush(); spans += MdSpan.Bold(input.substring(i + 2, end)); i = end + 2 }
+                        else { plain.append(c); i++ }
+                    }
+                    else -> {
+                        val end = input.indexOf('*', i + 1)
+                        if (end > i) { flush(); spans += MdSpan.Italic(input.substring(i + 1, end)); i = end + 1 }
+                        else { plain.append(c); i++ }
+                    }
+                }
+            }
+
+            c == '_' -> {
+                if (input.startsWith("__", i)) {
+                    val end = input.indexOf("__", i + 2)
+                    if (end > i) { flush(); spans += MdSpan.Bold(input.substring(i + 2, end)); i = end + 2 }
+                    else { plain.append(c); i++ }
+                } else {
+                    // Treat `_` as italic only at a word boundary, so snake_case identifiers survive.
+                    val prevOk = i == 0 || !input[i - 1].isLetterOrDigit()
+                    val end = if (prevOk) input.indexOf('_', i + 1) else -1
+                    if (end > i) { flush(); spans += MdSpan.Italic(input.substring(i + 1, end)); i = end + 1 }
+                    else { plain.append(c); i++ }
+                }
+            }
+
+            else -> { plain.append(c); i++ }
+        }
+    }
+    flush()
+    return spans
+}

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/ui/markdown/MarkdownText.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/ui/markdown/MarkdownText.kt
@@ -1,0 +1,212 @@
+package com.hereliesaz.logkitty.ui.markdown
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.LinkAnnotation
+import androidx.compose.ui.text.TextLinkStyles
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.withLink
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.unit.dp
+
+/**
+ * Renders a parsed Markdown document (see [parseMarkdownBlocks]) as Compose UI. The caller supplies
+ * an [onLinkClick] so link taps route through the app's standard "open URL" path (an ACTION_VIEW
+ * intent with a graceful toast on failure), rather than Compose's default URI handler.
+ */
+@Composable
+fun MarkdownText(
+    blocks: List<MdBlock>,
+    onLinkClick: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier) {
+        blocks.forEach { block ->
+            when (block) {
+                is MdBlock.Heading -> Text(
+                    text = inlineText(block.spans, onLinkClick),
+                    style = headingStyle(block.level),
+                    color = MaterialTheme.colorScheme.onSurface,
+                    modifier = Modifier.padding(top = if (block.level <= 2) 16.dp else 12.dp, bottom = 4.dp),
+                )
+
+                is MdBlock.Paragraph -> Text(
+                    text = inlineText(block.spans, onLinkClick),
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    modifier = Modifier.padding(vertical = 4.dp),
+                )
+
+                is MdBlock.BulletItem -> ListItemRow(
+                    indent = block.indent,
+                    marker = "•",
+                    spans = block.spans,
+                    onLinkClick = onLinkClick,
+                )
+
+                is MdBlock.NumberedItem -> ListItemRow(
+                    indent = block.indent,
+                    marker = "${block.number}.",
+                    spans = block.spans,
+                    onLinkClick = onLinkClick,
+                )
+
+                is MdBlock.Quote -> Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 6.dp)
+                        .clip(RoundedCornerShape(4.dp))
+                        .background(MaterialTheme.colorScheme.surfaceVariant)
+                        .padding(12.dp),
+                ) {
+                    Text(
+                        text = inlineText(block.spans, onLinkClick),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+
+                is MdBlock.CodeBlock -> Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 6.dp)
+                        .clip(RoundedCornerShape(4.dp))
+                        .background(MaterialTheme.colorScheme.surfaceVariant)
+                        .horizontalScroll(rememberScrollState())
+                        .padding(12.dp),
+                ) {
+                    Text(
+                        text = block.code,
+                        style = MaterialTheme.typography.bodySmall,
+                        fontFamily = FontFamily.Monospace,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+
+                is MdBlock.Table -> MarkdownTable(block, onLinkClick)
+
+                MdBlock.Divider -> HorizontalDivider(
+                    modifier = Modifier.padding(vertical = 12.dp),
+                    color = MaterialTheme.colorScheme.outlineVariant,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ListItemRow(indent: Int, marker: String, spans: List<MdSpan>, onLinkClick: (String) -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(start = (indent * 16).dp, top = 2.dp, bottom = 2.dp),
+    ) {
+        Text(
+            text = "$marker ",
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+        Text(
+            text = inlineText(spans, onLinkClick),
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+    }
+}
+
+@Composable
+private fun MarkdownTable(table: MdBlock.Table, onLinkClick: (String) -> Unit) {
+    val border = MaterialTheme.colorScheme.outlineVariant
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 8.dp),
+    ) {
+        Row(modifier = Modifier.fillMaxWidth()) {
+            table.headers.forEach { cell ->
+                Box(modifier = Modifier.weight(1f).padding(6.dp)) {
+                    Text(
+                        text = inlineText(cell, onLinkClick),
+                        style = MaterialTheme.typography.bodySmall,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.onSurface,
+                    )
+                }
+            }
+        }
+        HorizontalDivider(color = border)
+        table.rows.forEach { row ->
+            Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.Top) {
+                val cols = table.headers.size.coerceAtLeast(1)
+                for (c in 0 until cols) {
+                    val cell = row.getOrNull(c) ?: emptyList()
+                    Box(modifier = Modifier.weight(1f).padding(6.dp)) {
+                        Text(
+                            text = inlineText(cell, onLinkClick),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+            }
+            HorizontalDivider(color = border)
+        }
+    }
+}
+
+@Composable
+private fun headingStyle(level: Int) = when (level) {
+    1 -> MaterialTheme.typography.headlineSmall
+    2 -> MaterialTheme.typography.titleLarge
+    3 -> MaterialTheme.typography.titleMedium
+    else -> MaterialTheme.typography.titleSmall
+}
+
+/** Builds a styled [AnnotatedString] from inline spans, wiring links through [onLinkClick]. */
+@Composable
+private fun inlineText(spans: List<MdSpan>, onLinkClick: (String) -> Unit): AnnotatedString {
+    val linkColor = MaterialTheme.colorScheme.primary
+    val codeBg = MaterialTheme.colorScheme.surfaceVariant
+    return buildAnnotatedString {
+        spans.forEach { span ->
+            when (span) {
+                is MdSpan.Text -> append(span.text)
+                is MdSpan.Bold -> withStyle(SpanStyle(fontWeight = FontWeight.Bold)) { append(span.text) }
+                is MdSpan.Italic -> withStyle(SpanStyle(fontStyle = FontStyle.Italic)) { append(span.text) }
+                is MdSpan.BoldItalic ->
+                    withStyle(SpanStyle(fontWeight = FontWeight.Bold, fontStyle = FontStyle.Italic)) { append(span.text) }
+                is MdSpan.Code ->
+                    withStyle(SpanStyle(fontFamily = FontFamily.Monospace, background = codeBg)) { append(span.text) }
+                is MdSpan.Link -> withLink(
+                    LinkAnnotation.Url(
+                        url = span.url,
+                        styles = TextLinkStyles(
+                            SpanStyle(color = linkColor, textDecoration = TextDecoration.Underline),
+                        ),
+                    ) { onLinkClick(span.url) },
+                ) { append(span.text) }
+            }
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -202,6 +202,21 @@
     <string name="settings_ad_privacy">Manage ad consent</string>
     <string name="settings_ad_privacy_desc">Review or change your ad personalization choices.</string>
 
+    <!-- About / Help section + in-app document reader -->
+    <string name="settings_section_about">About &amp; Help</string>
+    <string name="settings_about_desc">Read the project info, privacy policy, and permissions.</string>
+    <string name="info_title">About &amp; Help</string>
+    <string name="info_loading">Loading…</string>
+    <string name="info_load_error">Couldn\'t load this document.</string>
+    <string name="info_doc_readme">About LogKitty</string>
+    <string name="info_doc_readme_desc">What the app is and what it does.</string>
+    <string name="info_doc_privacy">Privacy Policy</string>
+    <string name="info_doc_privacy_desc">What data the app accesses and when anything leaves your device.</string>
+    <string name="info_doc_permissions">Permissions</string>
+    <string name="info_doc_permissions_desc">Every permission the app declares and why.</string>
+    <string name="info_doc_conduct">Code of Conduct</string>
+    <string name="info_doc_conduct_desc">Community standards for the project.</string>
+
     <!-- Permissions section -->
     <string name="settings_section_permissions">Permissions</string>
     <string name="perm_granted">Granted</string>

--- a/app/src/test/kotlin/com/hereliesaz/logkitty/ui/markdown/MarkdownParserTest.kt
+++ b/app/src/test/kotlin/com/hereliesaz/logkitty/ui/markdown/MarkdownParserTest.kt
@@ -65,6 +65,26 @@ class MarkdownParserTest {
     }
 
     @Test
+    fun emphasizedSnakeCaseTokenItalicizesWhole() {
+        // `_PACKAGE_USAGE_STATS_` must italicize the entire token, not just up to the first internal _.
+        val spans = parseInline("_PACKAGE_USAGE_STATS_")
+        assertEquals("PACKAGE_USAGE_STATS", (spans.single() as MdSpan.Italic).text)
+    }
+
+    @Test
+    fun strayUnderscoreDoesNotSwallowFollowingIdentifier() {
+        // An unclosed `_` before a snake_case token must not consume it into an italic span.
+        val spans = parseInline("_unclosed and PACKAGE_USAGE_STATS")
+        assertTrue(spans.none { it is MdSpan.Italic })
+    }
+
+    @Test
+    fun plainUnderscoreEmphasisStillWorks() {
+        val spans = parseInline("an _emphasized_ word")
+        assertTrue(spans.any { it is MdSpan.Italic && it.text == "emphasized" })
+    }
+
+    @Test
     fun parsesBulletList() {
         val blocks = parseMarkdownBlocks("- one\n- two")
         assertEquals(2, blocks.size)

--- a/app/src/test/kotlin/com/hereliesaz/logkitty/ui/markdown/MarkdownParserTest.kt
+++ b/app/src/test/kotlin/com/hereliesaz/logkitty/ui/markdown/MarkdownParserTest.kt
@@ -1,0 +1,73 @@
+package com.hereliesaz.logkitty.ui.markdown
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MarkdownParserTest {
+
+    @Test
+    fun stripsLeadingYamlFrontMatter() {
+        val raw = "---\ntitle: Privacy Policy\npermalink: /privacy/\n---\n\n# Privacy Policy\n"
+        val out = stripFrontMatter(raw)
+        assertTrue("title:" !in out)
+        // The block is gone; the document body (after any leading blank line) starts at the heading.
+        assertTrue(out.trimStart().startsWith("# Privacy Policy"))
+        // And it parses cleanly to a single heading block.
+        val heading = parseMarkdownBlocks(raw).single() as MdBlock.Heading
+        assertEquals("Privacy Policy", (heading.spans.single() as MdSpan.Text).text)
+    }
+
+    @Test
+    fun leavesContentWithoutFrontMatterUntouched() {
+        val raw = "# Heading\n\nBody."
+        assertEquals(raw, stripFrontMatter(raw))
+    }
+
+    @Test
+    fun parsesHeadingLevelAndText() {
+        val blocks = parseMarkdownBlocks("## Permissions")
+        val heading = blocks.single() as MdBlock.Heading
+        assertEquals(2, heading.level)
+        assertEquals("Permissions", (heading.spans.single() as MdSpan.Text).text)
+    }
+
+    @Test
+    fun parsesGfmTable() {
+        val md = """
+            | Permission | Purpose |
+            | --- | --- |
+            | `READ_LOGS` | Read the system log. |
+        """.trimIndent()
+        val table = parseMarkdownBlocks(md).single() as MdBlock.Table
+        assertEquals(2, table.headers.size)
+        assertEquals(1, table.rows.size)
+        // First cell of the row is an inline code span.
+        assertEquals("READ_LOGS", (table.rows[0][0].single() as MdSpan.Code).text)
+    }
+
+    @Test
+    fun parsesInlineLinkBoldAndCode() {
+        val spans = parseInline("See **bold**, `code`, and [the site](https://example.com).")
+        assertTrue(spans.any { it is MdSpan.Bold && it.text == "bold" })
+        assertTrue(spans.any { it is MdSpan.Code && it.text == "code" })
+        val link = spans.filterIsInstance<MdSpan.Link>().single()
+        assertEquals("the site", link.text)
+        assertEquals("https://example.com", link.url)
+    }
+
+    @Test
+    fun underscoresInIdentifiersAreNotItalic() {
+        // PACKAGE_USAGE_STATS must survive as literal text, not be split into an italic run.
+        val spans = parseInline("PACKAGE_USAGE_STATS detail")
+        assertTrue(spans.none { it is MdSpan.Italic })
+        assertEquals("PACKAGE_USAGE_STATS detail", (spans.single() as MdSpan.Text).text)
+    }
+
+    @Test
+    fun parsesBulletList() {
+        val blocks = parseMarkdownBlocks("- one\n- two")
+        assertEquals(2, blocks.size)
+        assertTrue(blocks.all { it is MdBlock.BulletItem })
+    }
+}

--- a/version.properties
+++ b/version.properties
@@ -1,5 +1,5 @@
-#Mon Jun 08 15:17:19 CDT 2026
-build=11
+#Wed Jun 24 06:20:31 UTC 2026
+build=14
 major=0
 minor=7
 patch=0


### PR DESCRIPTION
## Summary
Adds a **Settings → "About & Help"** entry that opens an in-app reader for the project's own documentation — **README, Privacy Policy, Permissions, Code of Conduct** — rendered natively from Markdown. This is the in-app companion to the GitHub Pages hosting in #175.

## How it works
- **Single source of truth, no committed copies.** A generated-source task (`copyInAppDocs`) bundles the canonical `README.md` + selected `docs/*.md` into assets at build time. It's wired through the AGP Variant API (`addGeneratedSourceDirectory`) so the task dependency reaches every consumer (asset-merge *and* lint) — AGP 9 rejects the legacy `srcDir(Provider)` form.
- **Dependency-free Markdown.** `MarkdownParser.kt` parses the constructs these docs actually use (ATX headings, ordered/unordered lists, blockquotes, fenced code, GFM pipe tables, thematic breaks, inline emphasis/code/links) and strips the GitHub Pages YAML front matter. No third-party library added.
- **Native rendering.** `MarkdownText.kt` turns the parsed model into Compose UI with Material3 theming. Link taps route through the app's standard `ACTION_VIEW` + toast-on-failure pattern (matching `SettingsScreen`).
- **`InfoScreen.kt`** shows a doc index; selecting one loads it off the main thread from assets and renders it. System back returns to the index first.
- **Nav wiring**: adds `INFO` to the existing `SettingsRoute` enum hub and an "About & Help" card in the settings list.

## Tests
`MarkdownParserTest` (pure JVM, no Compose) covers front-matter stripping, heading levels, GFM tables, inline bold/code/link, bullet lists, and — importantly — that snake_case identifiers like `PACKAGE_USAGE_STATS` survive as literal text rather than being split into italics.

## Verification
- `./gradlew :app:assembleDebug :app:testDebugUnitTest :app:lintDebug` ✅ (lint: no new issues).
- Confirmed the APK contains `assets/docs/{README,PRIVACY_POLICY,PERMISSIONS,conduct}.md`.
- No emulator in this environment, so on-device rendering wasn't exercised; the parser is covered by unit tests and the renderer is a thin, conventional Compose mapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MsdbtsxKQbhDJDb6p61Mgj)_