### PR TITLE
Play compliance: advertising ID declaration + edge-to-edge insets

### DIFF
--- a/app-ads.txt
+++ b/app-ads.txt
@@ -1,1 +1,0 @@
-google.com, pub-7304740804770627, DIRECT, f08c47fec0942fa0

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -261,8 +261,8 @@ configurations.all {
                     useVersion("0.9.6")
                     because("Security fix: DoS via compressed JWE content")
                 }
-                // play-services-basement (via play-services-ads) drags in an old Fragment (1.x),
-                // which makes the InvalidFragmentVersionForActivityResult lint fatal for our
+                // Some Play/GMS transitives still drag in an old Fragment (1.x), which makes the
+                // InvalidFragmentVersionForActivityResult lint fatal for our
                 // registerForActivityResult calls. Force a version >= 1.3.0.
                 g == "androidx.fragment" && n == "fragment" -> {
                     useVersion("1.6.2")

--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -69,17 +69,6 @@
 
     <issue
         id="GradleDependency"
-        message="A newer version of com.google.android.gms:play-services-ads than 25.3.0 is available: 25.4.0"
-        errorLine1="playServicesAds = &quot;25.3.0&quot;"
-        errorLine2="                  ~~~~~~~~">
-        <location
-            file="../gradle/libs.versions.toml"
-            line="5"
-            column="19"/>
-    </issue>
-
-    <issue
-        id="GradleDependency"
         message="A newer version of androidx.lifecycle:lifecycle-runtime-ktx than 2.10.0 is available: 2.11.0"
         errorLine1="lifecycleRuntimeKtx = &quot;2.10.0&quot;"
         errorLine2="                      ~~~~~~~~">

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,6 +13,16 @@
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
     <uses-permission android:name="android.permission.READ_LOGS" tools:ignore="ProtectedPermissions" />
     <uses-permission android:name="com.android.vending.BILLING" />
+
+    <!-- LogKitty does not use the advertising ID. The ads feature module and the Google Mobile Ads
+         SDK were removed, so nothing declares AD_ID today; this explicit removal keeps it that way
+         if a future dependency tries to merge the permission back in. Play's "Advertising ID"
+         declaration (App content → Advertising ID) must stay answered "No" — Play rejects a "No"
+         answer if the shipped bundle contains this permission. -->
+    <uses-permission
+        android:name="com.google.android.gms.permission.AD_ID"
+        tools:node="remove" />
+
     <queries>
         <intent>
             <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/kotlin/com/hereliesaz/logkitty/MainActivity.kt
+++ b/app/src/main/kotlin/com/hereliesaz/logkitty/MainActivity.kt
@@ -12,6 +12,7 @@ import android.os.Bundle
 import android.provider.Settings
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
@@ -108,6 +109,15 @@ class MainActivity : ComponentActivity() {
     ) { }
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        // Draw behind the system bars. From Android 15 (targetSdk 35+) the platform forces this on
+        // regardless, and the `windowOptOutEdgeToEdgeEnforcement` escape hatch is ignored from
+        // targetSdk 36 — so the only question is whether we opt in deliberately or get it done to
+        // us. Calling it here also back-ports the same layout to API 30-34, so there is one inset
+        // behaviour to reason about instead of two. Must run before setContent so the first frame
+        // is already edge-to-edge. Every screen below is responsible for its own safe-area padding:
+        // the Scaffold-based screens get it from Scaffold/TopAppBar defaults, and MainScreenContent
+        // applies WindowInsets.safeDrawing itself.
+        enableEdgeToEdge()
         super.onCreate(savedInstanceState)
 
         // Register receiver for service death
@@ -372,7 +382,15 @@ fun MainScreenContent(
     // Read Logs OR Root is required for functionality.
     val canStart = isOverlayGranted && (isReadLogsGranted || isRootEnabled)
 
-    Box(modifier = Modifier.fillMaxSize()) {
+    // Unlike the other screens this one has no Scaffold, so nothing applies the safe area for it.
+    // Under edge-to-edge the logo would slide under the status bar and the bottom buttons under the
+    // navigation bar / gesture handle, so inset the scroll viewport here. safeDrawing (rather than
+    // systemBars) also covers display cutouts and the IME.
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .windowInsetsPadding(WindowInsets.safeDrawing)
+    ) {
         Column(
             modifier = Modifier.fillMaxSize().padding(24.dp).verticalScroll(scrollState),
             verticalArrangement = Arrangement.Center,

--- a/app/src/main/res/raw/keep.xml
+++ b/app/src/main/res/raw/keep.xml
@@ -5,4 +5,4 @@
   see the cross-module reference. Keep them explicitly.
 -->
 <resources xmlns:tools="http://schemas.android.com/tools"
-    tools:keep="@string/feature_stats_title,@string/feature_ads_title,@string/feature_github_title" />
+    tools:keep="@string/feature_stats_title,@string/feature_github_title" />

--- a/docs/PERMISSIONS.md
+++ b/docs/PERMISSIONS.md
@@ -28,8 +28,7 @@ locally and are never uploaded by the app. See [PRIVACY_POLICY.md](PRIVACY_POLIC
 | `POST_NOTIFICATIONS` | runtime (Android 13+) | Show the persistent, silent notification that lets you start/stop capture and confirms the service is running. | None. |
 | `PACKAGE_USAGE_STATS` | special app access | Let Context Mode detect the foreground app (where available) to auto-filter the log to it. | Foreground package name, processed on-device only. |
 | `QUERY_ALL_PACKAGES` | sensitive (Play declaration) | Let the user pick **any** installed app to monitor, and classify each log line by its source app/category. | Installed-app list used on-device only; never transmitted. |
-| `INTERNET` | normal | Download the chosen code fonts, show the Settings banner ad, and (in some builds) upload crash reports. | LogKitty never uploads your logs. Fonts/ads handled by Google SDKs; crash reports = stack trace + device metadata only. |
- Advertising ID handled by Google's ad SDK; user can opt out in device Google ad settings. |
+| `INTERNET` | normal | Download the chosen code fonts, talk to Google Play for billing/updates, and (in some builds) upload crash reports. | LogKitty never uploads your logs. Fonts handled by Google SDKs; crash reports = stack trace + device metadata only. No advertising ID is read or transmitted. |
 | `BIND_ACCESSIBILITY_SERVICE` | declared on the service (system-bound) | Powers **Context Mode**: detects the foreground app and Home/Recents transitions to auto-filter the log and collapse the overlay. **Not** an assistive tool. | Foreground package name + window-state events only. `canRetrieveWindowContent=false` — no screen content, text, or input is read. Nothing leaves the device. |
 
 ---
@@ -111,8 +110,20 @@ reduced source-classification accuracy.)*
 
 ## Other Play data declarations to remember
 
-- **Advertising ID (`AD_ID`):** declare advertising-ID collection/usage in the
-  **Data safety** form (used for ads via the Google Mobile Ads SDK).
+- **Advertising ID (`AD_ID`):** LogKitty **does not use** the advertising ID.
+  Ads and the Google Mobile Ads SDK were removed, and the base manifest
+  explicitly strips the permission with `tools:node="remove"` so no transitive
+  dependency can merge it back in. Play still requires an answer:
+  - **App content → Advertising ID** → answer **"No, my app does not use
+    advertising ID"**. Leaving this unanswered is what produces the
+    *"Incomplete advertising ID declaration"* blocker.
+  - **Data safety** → do not list advertising ID under collected/shared data.
+  - Play cross-checks the answer against the uploaded bundle: answering "No"
+    while the bundle still contains `com.google.android.gms.permission.AD_ID`
+    is rejected. Verify with
+    `bundletool dump manifest --bundle=app-release.aab | grep AD_ID`
+    (or check the merged manifest in `app/build/intermediates/merged_manifests/`)
+    before submitting.
 - **Usage access (`PACKAGE_USAGE_STATS`):** a special app access the user grants
   in system settings; surfaced and explained in-app under Settings → Permissions.
 

--- a/docs/PRE_RELEASE_CHECKLIST.md
+++ b/docs/PRE_RELEASE_CHECKLIST.md
@@ -27,8 +27,21 @@ build/signing/publish mechanics; this is the human checklist around them.
 Install a release build — ideally from a **Play internal-testing** track, or a
 `bundletool build-apks --local-testing` install — and verify:
 - [ ] **Resource shrinking** didn't strip anything needed: the on-demand install dialogs show their
-      titles (Developer Stats, Ads), and no screen is missing text/icons. (`isShrinkResources` is on;
-      cross-module title strings are protected by `res/raw/keep.xml`.)
+      titles (Developer Stats, GitHub), and no screen is missing text/icons. (`isShrinkResources` is
+      on; cross-module title strings are protected by `res/raw/keep.xml`.)
+- [ ] **Edge-to-edge safe areas** (enforced from Android 15; we opt in explicitly via
+      `enableEdgeToEdge()` so API 30+ behaves the same). On a device with **gesture navigation** and
+      again with **3-button navigation**, check that nothing is hidden or unreachable behind the
+      bars:
+  - [ ] Dashboard / permission wizard: the logo clears the status bar and the bottom
+        "Settings" / "Open GitHub" buttons clear the navigation bar and gesture handle.
+  - [ ] Scaffold screens (Settings, GitHub, Info, Color scheme editor, Prohibited logs): the top app
+        bar sits below the status bar and the last list row scrolls clear of the navigation bar.
+  - [ ] Dashboard FAB ("Start/Stop") is fully tappable, not clipped by the gesture handle.
+  - [ ] Rotate to **landscape** and re-check — the display cutout moves to a side edge.
+  - [ ] Settings text fields: the IME doesn't cover the focused field.
+  - [ ] The overlay window is a separate `TYPE_APPLICATION_OVERLAY` window that measures the nav-bar
+        inset itself, so confirm it is unchanged (peek strip still sits above the bar).
 - [ ] **On-demand modules install and load**: open the Stats tab (downloads `:feature:stats`); the
 - [ ] **Context Mode** works: foreground-app auto-filtering after granting Usage Access (non-root),
       and via `dumpsys` on a rooted device (no grant needed).

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,8 +2,6 @@
 agp = "9.3.0"
 aetherTransportFile = "2.0.14"
 aznavrail = "11.0"
-playServicesAds = "25.3.0"
-userMessagingPlatform = "4.0.0"
 coreKtx = "1.19.0"
 kotlinxCoroutinesCore = "1.11.0"
 junit = "4.13.2"
@@ -46,8 +44,6 @@ androidx-navigation-compose = { module = "androidx.navigation:navigation-compose
 # is the Compose-Multiplatform Android target and it is MISSING AzNavHostKt. `aznavrail` is the
 # normal Android library and resolves cleanly (androidJvm module metadata; brings coil-compose).
 aznavrail = { group = "com.github.HereLiesAz.AzNavRail", name = "aznavrail", version.ref = "aznavrail" }
-play-services-ads = { module = "com.google.android.gms:play-services-ads", version.ref = "playServicesAds" }
-user-messaging-platform = { module = "com.google.android.ump:user-messaging-platform", version.ref = "userMessagingPlatform" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }


### PR DESCRIPTION
Clears two Play Console blockers. Both are compliance items rather than feature work.

---

## 1. Incomplete advertising ID declaration

The warning comes from an unanswered form under **App content → Advertising ID**, not from the build — the ads removal was already complete. The code side makes the correct answer ("No") permanently safe to give.

- **`app/src/main/AndroidManifest.xml`** — strip `com.google.android.gms.permission.AD_ID` with `tools:node="remove"`. Nothing declares it today; this stops a future transitive dependency from merging it back in and silently contradicting the declaration. Play rejects a "No" answer if the uploaded bundle still contains the permission.
- **`gradle/libs.versions.toml`** — drop the unreferenced `play-services-ads` and `user-messaging-platform` entries and their version refs.
- **`app/lint-baseline.xml`** — drop the stale `GradleDependency` entry for `play-services-ads`.
- **`app/src/main/res/raw/keep.xml`** — drop `@string/feature_ads_title`; the string no longer exists.
- **`app/build.gradle.kts`** — the `androidx.fragment` resolution strategy comment blamed `play-services-basement (via play-services-ads)`. The force is still needed for other Play/GMS transitives; only the attribution changed.
- **`app-ads.txt`** — deleted. The AdMob account is no longer active, and the file sat at the repo root while the Jekyll workflow publishes from `./docs`, so it was never actually served.
- **`docs/PERMISSIONS.md`** — the `INTERNET` row still described a "Settings banner ad" and left a dangling half-row about the advertising ID. The Play-declarations section instructed the reader to *declare advertising-ID usage*, now exactly the wrong answer; rewritten to "No", with the bundle cross-check and a `bundletool` verification command.

### Why the warning can persist after answering "No"

Play evaluates the declaration against the bundles on your **active tracks**, not just the next upload. The now-deleted `feature/ads/src/main/AndroidManifest.xml` declared:

```xml
<uses-permission android:name="com.google.android.gms.permission.AD_ID" />
```

under `<dist:fusing dist:include="true" />` — so the permission was fused into the universal/standalone APK, and **every bundle built before the ads module was deleted contains it**. It was also briefly in the base manifest between aa13de7 and 0ae52c3. Any release still sitting on an active track (including a forgotten internal- or closed-testing release) will keep the answer inconsistent until it is superseded or the track is halted.

---

## 2. Edge-to-edge / window insets

The app targets SDK 37, so Android already draws it edge-to-edge, and the `windowOptOutEdgeToEdgeEnforcement` escape hatch is ignored from targetSdk 36. But the app had **no inset handling at all** — no `enableEdgeToEdge()`, no `WindowCompat`, and no `WindowInsets` usage outside the overlay service.

- **`MainActivity.onCreate`** — call `enableEdgeToEdge()` before `setContent`. Beyond satisfying the check, this back-ports the same layout to API 30–34, so there is one inset behaviour to reason about rather than one per OS version.
- **`MainScreenContent`** — pad with `WindowInsets.safeDrawing`. This is the one screen with no `Scaffold`, so nothing applied a safe area: the logo rendered under the status bar and the bottom "Settings" / "Open GitHub" buttons under the navigation bar and gesture handle. `safeDrawing` also covers display cutouts and the IME.

Audited and deliberately unchanged:

| Surface | Why no change |
| --- | --- |
| The six `Scaffold` screens | All consume `innerPadding`; correct insets come from `Scaffold`/`TopAppBar` defaults |
| `AppPickerDialog`, `ColorPickerDialog` | Default platform sizing — centered and inset |
| `DiagnosisScreen` | Renders inside `LogBottomSheet` in the overlay's `TYPE_APPLICATION_OVERLAY` window, which measures the nav-bar inset itself |
| `FileSaverActivity` | No UI; launches a document-picker intent |

**`docs/PRE_RELEASE_CHECKLIST.md`** gains edge-to-edge verification steps (gesture vs 3-button nav, landscape cutout, IME, FAB reachability), and a stale "Ads" on-demand module reference is corrected to "GitHub".

---

## Verification

- `:app:compileDebugKotlin` succeeds against the real `compileSdk = 37`.
- Merged manifest confirmed free of `AD_ID`, with the `tools:node="remove"` merging cleanly:

```
android.permission.ACCESS_NETWORK_STATE      android.permission.READ_LOGS
android.permission.FOREGROUND_SERVICE        android.permission.RECEIVE_BOOT_COMPLETED
android.permission.FOREGROUND_SERVICE_SPECIAL_USE   android.permission.SYSTEM_ALERT_WINDOW
android.permission.INTERNET                  android.permission.WAKE_LOCK
android.permission.PACKAGE_USAGE_STATS       com.android.vending.BILLING
android.permission.POST_NOTIFICATIONS        com.hereliesaz.logkitty.DYNAMIC_RECEIVER_NOT_EXPORTED_PERMISSION
```

The edge-to-edge change is layout behaviour and still wants the on-device pass now written into the checklist — I could not run it here.

Note: the `invoke / invoke` check is failing with a Gemini API 429 ("exhausted your daily quota", free-tier limit 20/day). That is the sunset Gemini Code Assist bot failing on itself, unrelated to this diff.

## Not addressed

`AdsState` / `isAdFree` / `isAdFreePermanently` in `billing/` are now dead state still written by `BillingManager`. Removing them is a billing refactor, out of scope here.

## Required manual step

The code cannot clear the Play warning on its own:

1. **App content → Advertising ID** → *"No, my app does not use advertising ID"*.
2. **Data safety** → ensure advertising ID is not listed as collected or shared.
3. Roll out a build from this branch to every active track, so no active release still carries the fused `AD_ID`.