### PR TITLE
Enable optimized resource shrinking

### DIFF
--- a/docs/PRE_RELEASE_CHECKLIST.md
+++ b/docs/PRE_RELEASE_CHECKLIST.md
@@ -28,7 +28,12 @@ Install a release build — ideally from a **Play internal-testing** track, or a
 `bundletool build-apks --local-testing` install — and verify:
 - [ ] **Resource shrinking** didn't strip anything needed: the on-demand install dialogs show their
       titles (Developer Stats, GitHub), and no screen is missing text/icons. (`isShrinkResources` is
-      on; cross-module title strings are protected by `res/raw/keep.xml`.)
+      on; cross-module title strings are protected by `res/raw/keep.xml`.) Note this now runs in
+      **optimized** mode (`android.r8.optimizedResourceShrinking=true` in `gradle.properties`),
+      which additionally collapses duplicate resources and strips resource *names* from
+      `resources.arsc` — so anything resolved by name at runtime via `Resources.getIdentifier`
+      would fail here rather than at compile time. Worth a pass over the dynamic-feature install
+      dialogs specifically, since those titles cross a module boundary.
 - [ ] **Edge-to-edge safe areas** (enforced from Android 15; we opt in explicitly via
       `enableEdgeToEdge()` so API 30+ behaves the same). On a device with **gesture navigation** and
       again with **3-button navigation**, check that nothing is hidden or unreachable behind the

--- a/gradle.properties
+++ b/gradle.properties
@@ -30,4 +30,11 @@ android.usesSdkInManifest.disallowed=false
 android.uniquePackageNames=false
 android.dependency.useConstraints=true
 android.r8.strictFullModeForKeepRules=false
-android.r8.optimizedResourceShrinking=false
+# Optimized resource shrinking. R8 shrinks resources in the same pass as code, so it can also
+# collapse identical resources and strip the resource *names* from resources.arsc, on top of the
+# reachability-based removal `isShrinkResources` already does. Play Console's app-optimization
+# report flags the build when this is off. Anything looked up by name at runtime
+# (Resources.getIdentifier) must be protected by res/raw/keep.xml — we already keep the
+# cross-module dynamic-feature title strings there, and the only getIdentifier call in the app
+# resolves a *platform* resource (android:dimen/navigation_bar_height), which this never touches.
+android.r8.optimizedResourceShrinking=true


### PR DESCRIPTION
Addresses the **"Optimized resource shrinking isn't enabled"** item in Play Console's app-optimization report.

## Change

It was not merely unset — `gradle.properties` explicitly pinned it off:

```properties
android.r8.optimizedResourceShrinking=false
```

Flipped to `true`. R8 now shrinks resources in the same pass as code, so on top of the reachability-based removal `isShrinkResources` already did, it can collapse duplicate resources and strip resource *names* from `resources.arsc`.

## Measured

Real signed `bundleRelease` at this commit, built both ways:

| `optimizedResourceShrinking` | AAB size |
| --- | --- |
| `false` | 6,156,753 bytes |
| `true` | 6,110,838 bytes |

~45 KB. Modest, but it also clears the Play report.

## Risk

Resources resolved by name at runtime via `Resources.getIdentifier` can no longer be found — this fails at runtime, not compile time. Audited:

- The only `getIdentifier` call in the app (`LogKittyOverlayService`) resolves a **platform** resource, `android:dimen/navigation_bar_height`, which this never touches.
- The cross-module dynamic-feature title strings are already protected by `res/raw/keep.xml`.

`docs/PRE_RELEASE_CHECKLIST.md` is updated so the on-demand install dialogs get an explicit on-device look, since those titles cross a module boundary.

## On the other two Play items

**Bitmap image optimization (`q35.E1`) — no code change warranted.** No app code downloads or decodes images; every network call in the repo is a JSON API (GitHub REST, crash reporter). The only decode site is `AppPickerDialog`, which renders app icons from `PackageManager`, not the network.

The flagged class is **Coil 2.7.0**, pulled in transitively by `aznavrail`. `coil.fetch.HttpUriFetcher` and `coil.decode.BitmapFactoryDecoder` both survive into the shipped DEX; R8 class-merging is why a single obfuscated class appears to both download and decode. Play flagged the image-loading library it recommends adopting.

Coil is also not removable — excluding `io.coil-kt` fails the R8 pass:

```
Missing class coil.compose.AsyncImagePainter (referenced from: void
  com.hereliesaz.aznavrail.AzNavRailButtonKt.ItemContentRenderer-iJQMabo(...))
```

so AzNavRail genuinely uses it to render nav-rail item icons.

**The `AD_ID` upload failure is not this bundle.** Play rejected run #17, which built merge commit `bb94e04`. I built `bundleRelease` locally at that same commit and unpacked the AAB — all three module manifests are clean:

```
base/manifest/AndroidManifest.xml     0 occurrences of AD_ID
github/manifest/AndroidManifest.xml   0
stats/manifest/AndroidManifest.xml    0
```

Verified against a positive control (`READ_LOGS`, `SYSTEM_ALERT_WINDOW`, `BILLING`, `POST_NOTIFICATIONS` all found by the same grep), so that is a true negative, not a broken check. The full base permission list contains no advertising ID.

The conflict is therefore with **older releases still active on the tracks**, which carry the `AD_ID` fused in from the deleted `:feature:ads` module. See the notes on PR #186.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bnb2beFmH6EnRfSLVNDgnx)_

## Summary by Sourcery

Enable optimized R8 resource shrinking and update the pre-release checklist to cover additional runtime verification for cross-module resource lookups.

Enhancements:
- Turn on R8 optimized resource shrinking in gradle.properties to reduce bundle size and satisfy Play Console app-optimization requirements.

Documentation:
- Expand the pre-release checklist with guidance for validating optimized resource shrinking, especially dynamic-feature install dialogs that rely on cross-module resources.