### PR TITLE
Strip AD_ID in feature modules and gate Play uploads on a clean bundle

### DIFF
--- a/.github/workflows/play-publish.yml
+++ b/.github/workflows/play-publish.yml
@@ -128,6 +128,53 @@ jobs:
           path: app/build/outputs/bundle/release/*.aab
           if-no-files-found: error
 
+      # Gate the upload on the bundle actually being free of AD_ID. Play rejects the whole edit with
+      # "This release includes the com.google.android.gms.permission.AD_ID permission but your
+      # declaration on Play Console says your app doesn't use advertising ID" when *any* module in
+      # the bundle declares it — and that same message is also returned when the permission comes
+      # from an older version code still active on the target track, which is a Play Console
+      # problem, not a build problem. Proving the artifact clean here is what tells the two apart:
+      # if this step passes and Play still rejects the commit, the offending permission is in a
+      # previously published release, not in this one.
+      # Runs on dry runs too (no `if:`), so a regression is caught before anyone opts into publish.
+      - name: Verify bundle declares no AD_ID permission
+        run: |
+          set -euo pipefail
+          BT_VERSION=1.17.2
+          curl -fsSL -o bundletool.jar \
+            "https://github.com/google/bundletool/releases/download/${BT_VERSION}/bundletool-all-${BT_VERSION}.jar"
+
+          AAB=$(find app/build/outputs/bundle -name "*.aab" | head -n 1)
+          if [ -z "$AAB" ]; then echo "::error::no .aab produced!"; exit 1; fi
+          echo "Bundle: $AAB"
+
+          # Every top-level directory holding manifest/AndroidManifest.xml is a bundle module
+          # (base, feature:stats, feature:github, ...). Check all of them, not just base.
+          MODULES=$(unzip -Z1 "$AAB" | sed -n 's#^\([^/]*\)/manifest/AndroidManifest\.xml$#\1#p' | sort -u)
+          if [ -z "$MODULES" ]; then echo "::error::no module manifests found in $AAB"; exit 1; fi
+          echo "Modules: $(echo "$MODULES" | tr '\n' ' ')"
+
+          DIRTY=0
+          for M in $MODULES; do
+            # bundletool decodes the proto-encoded manifest back to XML, so this reads the exact
+            # permission set Play will see for that module.
+            MANIFEST=$(java -jar bundletool.jar dump manifest --bundle="$AAB" --module="$M")
+            if echo "$MANIFEST" | grep -q "com.google.android.gms.permission.AD_ID"; then
+              echo "::error::module '$M' declares com.google.android.gms.permission.AD_ID"
+              echo "$MANIFEST" | grep -n "uses-permission" || true
+              DIRTY=1
+            else
+              echo "module '$M': clean"
+            fi
+          done
+
+          if [ "$DIRTY" -ne 0 ]; then
+            echo "::error::Bundle carries AD_ID. Either remove the dependency that merges it in, or"
+            echo "::error::change the Play Console advertising-ID declaration to \"Yes\"."
+            exit 1
+          fi
+          echo "No module declares AD_ID — the advertising-ID declaration may stay \"No\"."
+
       # Publish only when the operator opts in. Service-account JSON + Play API access required
       # (see docs/RELEASING.md). packageName must match the app's applicationId.
       - name: Publish to Google Play
@@ -154,9 +201,12 @@ jobs:
           KEY_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
         run: |
           set -e
+          # Already fetched by the AD_ID verification step; re-fetch only if that changed.
           BT_VERSION=1.17.2
-          curl -fsSL -o bundletool.jar \
-            "https://github.com/google/bundletool/releases/download/${BT_VERSION}/bundletool-all-${BT_VERSION}.jar"
+          if [ ! -f bundletool.jar ]; then
+            curl -fsSL -o bundletool.jar \
+              "https://github.com/google/bundletool/releases/download/${BT_VERSION}/bundletool-all-${BT_VERSION}.jar"
+          fi
 
           AAB=$(find app/build/outputs/bundle -name "*.aab" | head -n 1)
           if [ -z "$AAB" ]; then echo "Error: no .aab produced!"; exit 1; fi

--- a/docs/PERMISSIONS.md
+++ b/docs/PERMISSIONS.md
@@ -111,20 +111,36 @@ reduced source-classification accuracy.)*
 ## Other Play data declarations to remember
 
 - **Advertising ID (`AD_ID`):** LogKitty **does not use** the advertising ID.
-  Ads and the Google Mobile Ads SDK were removed, and the base manifest
-  explicitly strips the permission with `tools:node="remove"` so no transitive
-  dependency can merge it back in. Play still requires an answer:
+  Ads and the Google Mobile Ads SDK were removed, and every module manifest —
+  the base plus each dynamic feature — strips the permission with
+  `tools:node="remove"` so no transitive dependency can merge it back in. Each
+  dynamic feature runs its own manifest merge, so the base module's removal does
+  not cover them; the declaration has to be repeated per module. Play still
+  requires an answer:
   - **App content → Advertising ID** → answer **"No, my app does not use
     advertising ID"**. Leaving this unanswered is what produces the
     *"Incomplete advertising ID declaration"* blocker.
   - **Data safety** → do not list advertising ID under collected/shared data.
   - Play cross-checks the answer against the uploaded bundle: answering "No"
     while the bundle still contains `com.google.android.gms.permission.AD_ID`
-    is rejected. Verify with
-    `bundletool dump manifest --bundle=app-release.aab | grep AD_ID`
-    (or check the merged manifest in `app/build/intermediates/merged_manifests/`)
-    before submitting.
+    is rejected. The *Publish to Google Play* workflow gates the upload on this,
+    running `bundletool dump manifest` per bundle module before it touches Play.
+    To check by hand, do the same thing — the plain
+    `bundletool dump manifest --bundle=app-release.aab` only reads the **base**
+    module, so pass `--module=<name>` for each feature too.
+
+  **If Play rejects the edit but the bundle verifies clean.** The API returns the
+  same *"This release includes the com.google.android.gms.permission.AD_ID
+  permission…"* message when the permission comes from an older version code
+  that is still **active on the target track**, not from the bundle being
+  uploaded. Nothing in this repository can fix that. In the Play Console:
+  1. **App bundle explorer** → check **Permissions** per active version code to
+     find which ones carry `AD_ID`. Anything built before commit `0b71c7b`
+     (which removed the `:feature:ads` module) is suspect.
+  2. Either deactivate those releases on every track, **or** flip the
+     declaration to "Yes", roll a verified-clean build out to every track
+     including production, then flip it back to "No".
 - **Usage access (`PACKAGE_USAGE_STATS`):** a special app access the user grants
   in system settings; surfaced and explained in-app under Settings → Permissions.
 
-_Last updated: 2026-06-08._
+_Last updated: 2026-07-25._

--- a/feature/github/src/main/AndroidManifest.xml
+++ b/feature/github/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:dist="http://schemas.android.com/apk/distribution">
+    xmlns:dist="http://schemas.android.com/apk/distribution"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <dist:module
         dist:instant="false"
@@ -14,4 +15,12 @@
     </dist:module>
 
     <!-- INTERNET is declared in the base module; GitHub REST calls need no extra permission. -->
+
+    <!-- Each dynamic feature runs its own manifest merge, so the base module's AD_ID removal does
+         not reach this module. Repeat it here: Play validates the permission across every module
+         in the bundle, and a single feature-level dependency reintroducing it would fail the
+         "Advertising ID = No" declaration for the whole release. -->
+    <uses-permission
+        android:name="com.google.android.gms.permission.AD_ID"
+        tools:node="remove" />
 </manifest>

--- a/feature/stats/src/main/AndroidManifest.xml
+++ b/feature/stats/src/main/AndroidManifest.xml
@@ -15,4 +15,12 @@
     </dist:module>
 
     <!-- PACKAGE_USAGE_STATS is declared in the base module (used by Context Mode too). -->
+
+    <!-- Each dynamic feature runs its own manifest merge, so the base module's AD_ID removal does
+         not reach this module. Repeat it here: Play validates the permission across every module
+         in the bundle, and a single feature-level dependency reintroducing it would fail the
+         "Advertising ID = No" declaration for the whole release. -->
+    <uses-permission
+        android:name="com.google.android.gms.permission.AD_ID"
+        tools:node="remove" />
 </manifest>


### PR DESCRIPTION
## Context

The `internal`-track publish failed at edit commit:

```
Error: This release includes the com.google.android.gms.permission.AD_ID permission
but your declaration on Play Console says your app doesn't use advertising ID.
```

Investigating turned up one real gap in the build and one thing the repository cannot fix.

## What was actually wrong in the build

The base manifest strips `com.google.android.gms.permission.AD_ID` with `tools:node="remove"`, but **each dynamic feature runs its own manifest merge** — that removal never reached `:feature:stats` or `:feature:github`. Play validates the permission across every module in the bundle, so one feature-level dependency merging it back in would fail the "Advertising ID = No" declaration for the whole release. Both feature manifests now repeat the removal.

To be clear about the current state: nothing on today's release classpath declares `AD_ID`. Checking the manifest of every resolved AAR — including `billing:9.1.0` and its `play-services-location:19.0.0` / `play-services-base` / `datatransport` transitives, plus `app-update` and `feature-delivery` — turns up no declaration of it anywhere. The feature-module fix is regression-proofing, not a live bug.

## The verification gate

New `Verify bundle declares no AD_ID permission` step, between the build and the Play upload. It enumerates every module in the `.aab` and runs `bundletool dump manifest --module=<name>` on each, failing the job if any declares `AD_ID`. The per-module loop matters: a plain `bundletool dump manifest` reads only the **base** module, which is exactly the check that would have missed a feature-module regression.

No `if: inputs.publish` guard, so dry runs verify too. The universal-APK step reuses the bundletool jar this step downloads instead of fetching its own.

## Why this makes the failure diagnosable

Play returns that same error message in two different situations: the uploaded bundle carries the permission, **or** an older version code still active on the target track does. Proving the artifact clean before upload tells them apart — if the gate passes and Play still rejects the commit, the offending permission is in a previously published release, not in this build.

That second case is where things currently stand, and it needs Play Console work that no code change can do:

1. **App bundle explorer** → check **Permissions** per active version code. Anything built before `0b71c7b` (which removed the `:feature:ads` module) is suspect.
2. Either deactivate those releases on every track, or flip the declaration to "Yes", roll a verified-clean build out to every track including production, then flip back to "No".

`docs/PERMISSIONS.md` now documents this, corrects the base-module-only `bundletool` recipe it previously suggested, and notes that the removal has to be repeated per module.

## Testing

No Android SDK in this environment, so the bundle could not be built locally. Verified instead:

- YAML parses; step ordering is `Build signed App Bundle` → `Upload .aab artifact` → `Verify bundle declares no AD_ID permission` → `Publish to Google Play`.
- All three changed manifests are well-formed XML.
- Permission audit across resolved AARs, as described above.

The gate itself gets its first real exercise on the next workflow run — a dry run (`publish: false`) will exercise it without touching Play.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bnb2beFmH6EnRfSLVNDgnx)_

## Summary by Sourcery

Ensure Play Store uploads are gated on app bundles being free of the AD_ID permission and document the workflow and Play Console implications.

Bug Fixes:
- Prevent dynamic feature modules from reintroducing the AD_ID permission by explicitly stripping it in their manifests.

Enhancements:
- Add a CI step that inspects every bundle module manifest with bundletool and fails if any declares the AD_ID permission.
- Reuse the downloaded bundletool binary between verification and universal APK generation steps to avoid redundant downloads.

Documentation:
- Expand permissions documentation to cover per-module AD_ID removal, the new verification gate, and how to resolve Play Console rejections related to legacy releases.