### PR TITLE
Fix force-close by keeping Play Billing's proto-lite classes in R8

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -26,3 +26,14 @@
 -keep class com.hereliesaz.logkitty.feature.stats.StatsFeatureImpl { <init>(); }
 
 -keep class com.hereliesaz.logkitty.feature.github.GitHubFeatureImpl { <init>(); }
+
+# The Play Billing Library's bundled consumer rules only keep the *fields* of its generated
+# proto-lite message classes (`-keepclassmembers class * extends ...zzgp { <fields>; }`), not the
+# classes themselves. Under R8 full mode those message classes are otherwise only reachable via the
+# proto runtime's own reflection, so tree-shaking removes them entirely — BillingManager's
+# background connection callback (com.android.billingclient.api.BillingClientStateListener) then
+# crashes a few seconds after launch with NoClassDefFoundError the first time it touches one.
+# (android.r8.strictFullModeForKeepRules=false in gradle.properties suppresses the build-time
+# warning R8 would otherwise raise for this exact gap, so it only surfaces at runtime.)
+-keep class com.google.android.gms.internal.play_billing.** { *; }
+-keep class com.android.billingclient.api.** { *; }


### PR DESCRIPTION
## Summary
- The user reported the app force-closing ~5 seconds after every launch, with no auto-filed crash issue on GitHub (meaning `CrashReporter`'s upload never fired for their build). A logcat pull from their device gave the real trace:
  ```
  FATAL EXCEPTION: pool-6-thread-1
  java.lang.NoClassDefFoundError: Failed resolution of: Lfz1;
      at fv1.<clinit>
      at bv1.b
      at dv1.run
  Caused by: java.lang.ClassNotFoundException: fz1
  ```
- `BillingManager` starts a Play Billing connection on every app launch (`init { startConnection() }`), and the crash fires from a background thread pool a few seconds later — matching Billing's async setup/query callbacks.
- I pulled the actual `com.android.billingclient:billing:9.1.0` AAR from Google's Maven repo and inspected its bundled `proguard.txt`: it only does `-keepclassmembers class * extends ...zzgp { <fields>; }` for its generated proto-lite message classes — that protects *fields*, not the classes themselves. Under R8 full-mode shrinking, those message classes are otherwise unreachable through normal call-graph analysis (only touched via the proto runtime's own reflection), so R8 strips them entirely.
- `gradle.properties` sets `android.r8.strictFullModeForKeepRules=false`, which suppresses the build-time warning R8 would otherwise raise for this exact kind of incomplete keep chain — so the break only ever surfaced as a runtime crash, never at build time.
- Fix: add explicit `-keep` rules in `app/proguard-rules.pro` for `com.google.android.gms.internal.play_billing.**` and `com.android.billingclient.api.**` so R8 keeps the classes (not just members).

## Test plan
- [x] Reproduced root cause via real device logcat + inspection of the actual Billing Library AAR's consumer proguard rules
- [ ] Verify `./gradlew :app:assembleRelease` succeeds and the app no longer force-closes ~5s after launch on the reporting user's device
- [ ] Confirm the ad-free purchase flow (`BillingManager`) still works end-to-end on a signed release build

---
_Generated by [Claude Code](https://claude.ai/code/session_01JdG9Tjb6e9xx1DUFHuxxAM)_

## Summary by Sourcery

Bug Fixes:
- Prevent NoClassDefFoundError crashes on app launch by keeping Play Billing's internal classes from being stripped by R8.