### PR TITLE
Keep Play Core's obfuscated classes alive under R8 too

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -37,3 +37,12 @@
 # warning R8 would otherwise raise for this exact gap, so it only surfaces at runtime.)
 -keep class com.google.android.gms.internal.play_billing.** { *; }
 -keep class com.android.billingclient.api.** { *; }
+
+# Same failure mode, different library: com.google.android.play:app-update ships NO consumer
+# proguard rules at all (its AAR has no proguard.txt), yet AppUpdateManager's IPC with the Play
+# Store app (checkForAppUpdate(), called on every launch from MainActivity.onCreate) relies on
+# obfuscated com.google.android.play.core.** classes only reachable through the library's own
+# reflection/Binder callback plumbing. Without an explicit keep, R8 strips them the same way it
+# stripped Billing's proto-lite classes above.
+-keep class com.google.android.play.core.** { *; }
+-dontwarn com.google.android.play.core.**


### PR DESCRIPTION
## Summary
- Follow-up to #189, which fixed one instance of this crash (Play Billing's proto-lite classes stripped by R8) but not the whole thing: the user rebuilt with that fix (confirmed — release `v0.8.54.456`, built from the exact merge commit of #189) and the app **still** force-closes ~5s after launch, with the identical crash signature, just pointing at a different obfuscated class:
  ```
  FATAL EXCEPTION: pool-6-thread-1
  java.lang.NoClassDefFoundError: Failed resolution of: Lpz1;
      at sv1.<clinit>
      at ov1.b
      at qv1.run
  Caused by: java.lang.ClassNotFoundException: pz1
  ```
- Same shape as before (a class only reachable via a library's internal reflection, torn out from a `<clinit>` invoked on a background `ThreadPoolExecutor`), so I looked for another library with the same gap. I couldn't retrace the exact class (the release workflow doesn't upload `mapping.txt` as a build artifact, and R8's synthetic renaming isn't reproducible byte-for-byte outside CI's exact environment, so a local rebuild produces a different mapping even from identical source).
- Instead I re-validated that the #189 fix is doing its job: rebuilding at the exact commit Play was built from and inspecting R8's `seeds.txt`/`usage.txt` confirms all `com.android.billingclient.**` / `com.google.android.gms.internal.play_billing.**` classes are fully retained now — so Billing is very unlikely to still be the source.
- `MainActivity.checkForAppUpdate()` also runs unconditionally on every launch and drives `com.google.android.play:app-update`'s `AppUpdateManager`, which talks to the Play Store app over a background executor the same way Billing does. I pulled that AAR directly from Google's Maven repo — **it has no `proguard.txt` at all**, unlike Billing (which at least has a partial one). That's a stronger gap than the one #189 fixed.
- Fix: `-keep class com.google.android.play.core.** { *; }` (+ `-dontwarn`), mirroring the Billing fix. Verified via `:app:minifyReleaseWithR8` that R8's `seeds.txt` now retains ~1,956 `com.google.android.play.core.**` classes/members that were previously subject to tree-shaking, with `usage.txt` showing only unrelated resource-index classes (`R`/`R$style` for feature-delivery/corecommon submodules this app doesn't use) and trivial no-op `<clinit>` inlining left — the same safe pattern validated on #189.

## Test plan
- [x] Reproduced that #189's fix alone is insufficient via a fresh device logcat from the user, on a release build confirmed built from #189's merge commit
- [x] Verified `com.android.billingclient`/`play_billing` classes are fully retained post-#189 (ruling that library back out) via `seeds.txt`/`usage.txt` inspection
- [x] Confirmed `com.google.android.play:app-update`'s AAR ships no consumer proguard rules, and that this rule addition makes R8 retain its classes (`seeds.txt`/`usage.txt` inspection)
- [ ] Verify the app no longer force-closes ~5s after launch on the reporting user's device with a build including this change
- [ ] Confirm in-app update prompts (`AppUpdateManager`) still work end-to-end on a signed release build

---
_Generated by [Claude Code](https://claude.ai/code/session_01JdG9Tjb6e9xx1DUFHuxxAM)_

## Summary by Sourcery

Bug Fixes:
- Prevent force-close on app launch caused by R8 stripping obfuscated com.google.android.play.core classes used by AppUpdateManager IPC.