### PR TITLE
Fix NoClassDefFoundError for internal Kotlin classes

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -46,3 +46,4 @@
 # stripped Billing's proto-lite classes above.
 -keep class com.google.android.play.core.** { *; }
 -dontwarn com.google.android.play.core.**
+-keep class kotlin.jvm.internal.** { *; }


### PR DESCRIPTION
The release build was crashing with a `java.lang.NoClassDefFoundError` related to `pz1`, which through the Proguard mapping (or lack thereof for this class) and codebase search was identified as `kotlin.jvm.internal.Ref$IntRef`. This was being aggressively minified/stripped by R8. Adding a keep rule for `kotlin.jvm.internal.**` fixes this issue.

---
*PR created automatically by Jules for task [11604874990638154076](https://jules.google.com/task/11604874990638154076) started by @HereLiesAz*

## Summary by Sourcery

Build:
- Add R8/ProGuard keep rule for kotlin.jvm.internal classes to avoid NoClassDefFoundError in release builds.