### PR TITLE
Fix NoClassDefFoundError in release builds

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -46,3 +46,5 @@
 # stripped Billing's proto-lite classes above.
 -keep class com.google.android.play.core.** { *; }
 -dontwarn com.google.android.play.core.**
+-keep class kotlin.jvm.internal.** { *; }
+-keep class androidx.work.** { *; }


### PR DESCRIPTION
Add Proguard rules to keep internal Kotlin JVM classes and androidx.work classes to prevent R8 from stripping or heavily obfuscating them, resolving crashes with `java.lang.NoClassDefFoundError: pz1` related to `kotlin.jvm.internal.Ref$IntRef` and `u42` related to `androidx.work.impl.RescheduleMigration`.

## Summary by Sourcery

Update Proguard configuration to prevent R8 from stripping or over-obfuscating essential Kotlin and WorkManager runtime classes, avoiding NoClassDefFoundError crashes in release builds.

Build:
- Add Proguard keep rules for kotlin.jvm.internal classes to ensure they remain available at runtime in release builds.
- Add Proguard keep rules for androidx.work classes to prevent removal or excessive obfuscation that leads to runtime class loading failures.