### PR TITLE
Fix NoClassDefFoundError in release builds

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -46,3 +46,6 @@
 # stripped Billing's proto-lite classes above.
 -keep class com.google.android.play.core.** { *; }
 -dontwarn com.google.android.play.core.**
+-keep class kotlin.jvm.internal.** { *; }
+-keep class androidx.work.** { *; }
+-keep class androidx.core.** { *; }


### PR DESCRIPTION
Add Proguard rules to keep internal Kotlin JVM classes, androidx.work, and androidx.core classes to prevent R8 from stripping or heavily obfuscating them. This resolves crashes with `java.lang.NoClassDefFoundError: pz1` related to `kotlin.jvm.internal.Ref$IntRef`, `u42` related to `androidx.work.impl.RescheduleMigration`, and `k32` related to `androidx.core.provider.RequestExecutor$ReplyRunnable`.

## Summary by Sourcery

Build:
- Update Proguard configuration to keep kotlin.jvm.internal, androidx.work, and androidx.core classes to avoid NoClassDefFoundError crashes in release builds.